### PR TITLE
Refactor user authentication logic and application settings updates

### DIFF
--- a/apps/middleman/src/lib/utils/actions.ts
+++ b/apps/middleman/src/lib/utils/actions.ts
@@ -1,12 +1,17 @@
 import 'server-only';
 import {auth} from "@/auth";
 
-export async function getCurrentUserIdentity() {
+export async function getCurrentUser() {
   const session = await auth();
 
   if (!session) {
     throw new Error("Not logged in");
   }
 
-  return session.user.identity;
+  return session.user;
+}
+
+export async function getCurrentUserIdentity() {
+  const user = await getCurrentUser();
+  return user.identity;
 }

--- a/apps/provider/src/actions/ApplicationSettings.ts
+++ b/apps/provider/src/actions/ApplicationSettings.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import {ApplicationSettings, ChainId} from "@/db/schema";
+import {ApplicationSettings, ChainId, UserRole} from "@/db/schema";
 import {
   getApplicationSettings as fetchApplicationSettings,
   insertApplicationSettings,
@@ -8,7 +8,7 @@ import {
 } from "@/lib/dal/applicationSettings";
 import { redirect } from "next/navigation";
 import { z } from "zod";
-import {getCurrentUserIdentity} from "@/lib/utils/actions";
+import {getCurrentUser} from "@/lib/utils/actions";
 import urlJoin from "url-join";
 import { getServerApolloClient } from '@igniter/ui/graphql/server'
 import { indexerStatusDocument } from '@igniter/graphql'
@@ -53,8 +53,16 @@ export async function UpsertApplicationSettings(
   values: Partial<ApplicationSettings>,
   isUpdate: boolean
 ) {
-  const userIdentity = await getCurrentUserIdentity();
+  const user = await getCurrentUser();
+  const userIdentity= user.identity;
+
+  if (user.role !== UserRole.Owner) {
+    // TODO: Allow for more granular changes when actual `Admin` users are allowed.
+    throw new Error("Unauthorized");
+  }
+
   const validatedFields = ValidateWithSchema(isUpdate ? UpdateSettingsSchema : CreateSettingsSchema, values);
+
   if (isUpdate) {
     await updateApplicationSettings({
       ...validatedFields.data,
@@ -70,7 +78,7 @@ export async function UpsertApplicationSettings(
 }
 
 export async function completeSetup() {
-  await updateApplicationSettings({ isBootstrapped: true });
+  await UpsertApplicationSettings({ isBootstrapped: true }, true);
   return redirect("/admin");
 }
 

--- a/apps/provider/src/lib/utils/actions.ts
+++ b/apps/provider/src/lib/utils/actions.ts
@@ -1,12 +1,17 @@
 import 'server-only';
 import {auth} from "@/auth";
 
-export async function getCurrentUserIdentity() {
+export async function getCurrentUser() {
   const session = await auth();
 
   if (!session) {
     throw new Error("Not logged in");
   }
 
-  return session.user.identity;
+  return session.user;
+}
+
+export async function getCurrentUserIdentity() {
+  const user = await getCurrentUser();
+  return user.identity;
 }


### PR DESCRIPTION
- Unified `getCurrentUser` helper across `provider` and `middleman` apps, replacing `getCurrentUserIdentity` for better reusability.
- Introduced role-based authorization, restricting non-Owners from modifying application settings.
- Updated `UpsertApplicationSettings` usage in setup flow for consistency.