### PR TITLE
[#148] Refactor node table columns to add dynamic renderers and include height and owner address

### DIFF
--- a/apps/middleman-workflows/package.json
+++ b/apps/middleman-workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniter/middleman-workflows",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "license": "UNLICENSED",
   "private": true,
   "scripts": {

--- a/apps/middleman/package.json
+++ b/apps/middleman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniter/middleman",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "type": "module",
   "private": true,
   "scripts": {

--- a/apps/provider-workflows/package.json
+++ b/apps/provider-workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniter/provider-workflows",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "license": "UNLICENSED",
   "private": true,
   "main": "./dist/src/worker.js",

--- a/apps/provider/package.json
+++ b/apps/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@igniter/provider",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
- Introduced `createAddressCellRenderer` for reusable address and owner address rendering logic.
- Added `height` column with dynamic calculation from transaction data
- Changed sorting to use the height, adjusted the label
- Included `createdAt` column with formatted date rendering for better node tracking.
- Improved clipboard handling with success confirmation