### PR TITLE
Sync Providers and Delegators from CDN

### DIFF
--- a/apps/middleman/src/actions/Providers.ts
+++ b/apps/middleman/src/actions/Providers.ts
@@ -54,78 +54,90 @@ export async function UpdateProvidersFromSource() {
     };
 
     const providersFromCdn = (await response.json()) as CdnProvider[];
-    console.log(`[Providers] Fetched ${providersFromCdn.length} providers from CDN`);
+    console.log(
+      `[Providers] Fetched ${providersFromCdn.length} providers from CDN`,
+    );
 
     const currentProviders = await list(true);
-
     const currentProvidersMap = new Map(
       currentProviders.map((p) => [p.identity, p]),
     );
 
     const allCdnIdentities = new Set<string>();
-
-    let inserted = 0;
-    let updated = 0;
-    let disabled = 0;
-
     for (const p of providersFromCdn) {
       allCdnIdentities.add(p.identity);
       p.identityHistory.forEach((h) => allCdnIdentities.add(h));
     }
 
-    for (const cdnProvider of providersFromCdn) {
-      const possibleIds = [cdnProvider.identity, ...cdnProvider.identityHistory];
+    const { inserted, updated, disabled } = await db.transaction(
+      async (tx) => {
+        let inserted = 0;
+        let updated = 0;
+        let disabled = 0;
 
-      const matchingCurrent =
-        possibleIds.map((id) => currentProvidersMap.get(id)).find(Boolean) ??
-        null;
+        for (const cdnProvider of providersFromCdn) {
+          const possibleIds = [
+            cdnProvider.identity,
+            ...cdnProvider.identityHistory,
+          ];
 
-      if (matchingCurrent) {
-        const shouldUpdateIdentity =
-          matchingCurrent.identity !== cdnProvider.identity;
-        const shouldUpdateName = matchingCurrent.name !== cdnProvider.name;
-        const shouldUpdateUrl = matchingCurrent.url !== cdnProvider.url;
+          const matchingCurrent =
+            possibleIds.map((id) => currentProvidersMap.get(id)).find(Boolean) ??
+            null;
 
-        if (shouldUpdateIdentity || shouldUpdateName || shouldUpdateUrl) {
-          await db
-            .update(providersTable)
-            .set({
-              identity: cdnProvider.identity,
+          if (matchingCurrent) {
+            const shouldUpdateIdentity =
+              matchingCurrent.identity !== cdnProvider.identity;
+            const shouldUpdateName = matchingCurrent.name !== cdnProvider.name;
+            const shouldUpdateUrl = matchingCurrent.url !== cdnProvider.url;
+
+            if (shouldUpdateIdentity || shouldUpdateName || shouldUpdateUrl) {
+              await tx
+                .update(providersTable)
+                .set({
+                  identity: cdnProvider.identity,
+                  name: cdnProvider.name,
+                  url: cdnProvider.url,
+                  updatedBy: userIdentity,
+                })
+                .where(eq(providersTable.id, matchingCurrent.id));
+              updated += 1;
+            }
+          } else {
+            await tx.insert(providersTable).values({
               name: cdnProvider.name,
+              identity: cdnProvider.identity,
               url: cdnProvider.url,
+              enabled: false,
+              visible: false,
+              createdBy: userIdentity,
               updatedBy: userIdentity,
-            })
-            .where(eq(providersTable.id, matchingCurrent.id));
-          updated += 1;
+            });
+            inserted += 1;
+          }
         }
-      } else {
-        await db.insert(providersTable).values({
-          name: cdnProvider.name,
-          identity: cdnProvider.identity,
-          url: cdnProvider.url,
-          enabled: false,
-          visible: false,
-          createdBy: userIdentity,
-          updatedBy: userIdentity,
-        });
-        inserted += 1;
-      }
-    }
 
-    for (const provider of currentProviders) {
-      if (!allCdnIdentities.has(provider.identity) && (provider.enabled || provider.visible)) {
-        await db
-          .update(providersTable)
-          .set({
-            enabled: false,
-            visible: false,
-            updatedAt: new Date(),
-            updatedBy: userIdentity,
-          })
-          .where(eq(providersTable.identity, provider.identity));
-        disabled += 1;
-      }
-    }
+        for (const provider of currentProviders) {
+          if (
+            !allCdnIdentities.has(provider.identity) &&
+            (provider.enabled || provider.visible)
+          ) {
+            await tx
+              .update(providersTable)
+              .set({
+                enabled: false,
+                visible: false,
+                updatedAt: new Date(),
+                updatedBy: userIdentity,
+              })
+              .where(eq(providersTable.identity, provider.identity));
+            disabled += 1;
+          }
+        }
+
+        return { inserted, updated, disabled };
+      },
+    );
 
     console.log(
       `[Providers] Done. Inserted: ${inserted}, Updated: ${updated}, Disabled: ${disabled}`,

--- a/apps/middleman/src/actions/Providers.ts
+++ b/apps/middleman/src/actions/Providers.ts
@@ -5,6 +5,9 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import {getCurrentUserIdentity} from "@/lib/utils/actions";
 import { getApplicationSettings } from '@/actions/ApplicationSettings'
+import {providersTable} from "@/db/schema";
+import {db} from "@/db";
+import {eq} from "drizzle-orm";
 
 export interface Provider {
   id: number;
@@ -19,26 +22,108 @@ const updateProvidersSchema = z.object({
   }),
 });
 
-export async function UpdateProvidersFromSource(): Promise<Provider[]> {
-  const applicationSettings = await getApplicationSettings();
+export async function UpdateProvidersFromSource() {
+  const [userIdentity, appSettings] = await Promise.all([
+    getCurrentUserIdentity(),
+    getApplicationSettings(),
+  ]);
 
-  const url = process.env.PROVIDERS_CDN_URL!.replace('{chainId}', applicationSettings.chainId);
+  const providersCdnUrl = process.env.PROVIDERS_CDN_URL!.replace(
+    "{chainId}",
+    appSettings.chainId,
+  );
 
-  if (!url) {
-    throw new Error("PROVIDERS_CDN_URL is not defined");
+  if (!providersCdnUrl) {
+    throw new Error("PROVIDERS_CDN_URL environment variable is not defined");
   }
 
   try {
-    const response = await fetch(url);
+    const response = await fetch(providersCdnUrl);
+
     if (!response.ok) {
-      throw new Error(
-        `Failed to fetch providers from CDN: ${response.statusText}`
-      );
+      throw new Error(`Failed to fetch providers: ${response.statusText}`);
     }
-    return await response.json();
+
+    type CdnProvider = {
+      name: string;
+      identity: string;
+      identityHistory: string[];
+      url: string;
+    };
+
+    const providersFromCdn = (await response.json()) as CdnProvider[];
+
+    const currentProviders = await list(true);
+
+    const currentProvidersMap = new Map(
+      currentProviders.map((p) => [p.identity, p]),
+    );
+
+    const allCdnIdentities = new Set<string>();
+
+    for (const p of providersFromCdn) {
+      allCdnIdentities.add(p.identity);
+      p.identityHistory.forEach((h) => allCdnIdentities.add(h));
+    }
+
+    for (const cdnProvider of providersFromCdn) {
+      const possibleIds = [cdnProvider.identity, ...cdnProvider.identityHistory];
+
+      const matchingCurrent =
+        possibleIds.map((id) => currentProvidersMap.get(id)).find(Boolean) ??
+        null;
+
+      if (matchingCurrent) {
+        const shouldUpdateIdentity =
+          matchingCurrent.identity !== cdnProvider.identity;
+        const shouldUpdateName = matchingCurrent.name !== cdnProvider.name;
+        const shouldUpdateUrl = matchingCurrent.url !== cdnProvider.url;
+
+        if (shouldUpdateIdentity || shouldUpdateName || shouldUpdateUrl) {
+          await db
+            .update(providersTable)
+            .set({
+              identity: cdnProvider.identity,
+              name: cdnProvider.name,
+              url: cdnProvider.url,
+              updatedBy: userIdentity,
+            })
+            .where(eq(providersTable.id, matchingCurrent.id));
+        }
+      } else {
+        await db.insert(providersTable).values({
+          name: cdnProvider.name,
+          identity: cdnProvider.identity,
+          url: cdnProvider.url,
+          enabled: false,
+          visible: false,
+          createdBy: userIdentity,
+          updatedBy: userIdentity,
+        });
+      }
+    }
+
+    for (const provider of currentProviders) {
+      if (!allCdnIdentities.has(provider.identity) && (provider.enabled || provider.visible)) {
+        await db
+          .update(providersTable)
+          .set({
+            enabled: false,
+            visible: false,
+            updatedAt: new Date(),
+            updatedBy: userIdentity,
+          })
+          .where(eq(providersTable.identity, provider.identity));
+      }
+    }
+
+    return { success: true };
   } catch (error) {
-    console.error("Error loading providers from CDN:", error);
-    return [];
+    console.error("Error updating providers:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error occurred",
+    };
   }
 }
 

--- a/apps/provider/src/lib/services/suppliers.ts
+++ b/apps/provider/src/lib/services/suppliers.ts
@@ -153,10 +153,13 @@ export async function getSupplierStakeConfigurations(
                 }
                 const ownerPct =
                     100 - revShare.reduce((sum, r) => sum + r.revSharePercentage, 0);
-                revShare.push({
-                    address: stakeDistribution.ownerAddress,
-                    revSharePercentage: ownerPct,
-                });
+
+                if (ownerPct > 0) {
+                    revShare.push({
+                        address: stakeDistribution.ownerAddress,
+                        revSharePercentage: ownerPct,
+                    });
+                }
 
                 return {
                     serviceId: cfg.serviceId,


### PR DESCRIPTION
Purpose
- Sync Providers and Delegators from the CDN source.
- Improve identity tracking

Main changes
- Add UpdateProvidersFromSource and UpdateDelegatorsFromSource entry points.
- Use identityHistory to match identities that have changed so records are not duplicated.
- Only write changed fields (name, identity, visibility) to avoid needless updates.
- Mark missing records as disabled instead of deleting them to preserve history.
- Add detailed start and summary logging to increase sync observability.

Why
- The CDN is authoritative for provider/delegator data.
- identityHistory prevents duplicate records when an entity's identity changes.
- Disabling missing records preserves historical data and provides downstream consumers the choice to ignore or resurrect entries.