### PR TITLE
[BUG] 187 188 - Fixes rpc type validations and mappings

### DIFF
--- a/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
+++ b/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
@@ -41,7 +41,7 @@ interface ServiceOnChain {
   computeUnits: number;
 }
 
-const PROTOCOL_DEFAULT_TYPE = PROTOCOL_DEFAULT_RPC_TYPE.toString()
+const PROTOCOL_DEFAULT_TYPE = PROTOCOL_DEFAULT_RPC_TYPE.toString();
 
 const DEFAULT_ENDPOINTS = [{ url: "", rpcType: PROTOCOL_DEFAULT_TYPE }]
 

--- a/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
+++ b/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
@@ -70,7 +70,7 @@ const preprocessEndpoints = (v: unknown) => {
   return v.map((endpoint) => ({
     ...endpoint,
     rpcType: preprocessRpcType(endpoint.rpcType),
-  }))
+  }));
 }
 
 const endpointSchema = z.object({

--- a/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
+++ b/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
@@ -31,6 +31,8 @@ import type {ApplicationSettings, Service} from "@igniter/db/provider/schema";
 import {GetApplicationSettings} from "@/actions/ApplicationSettings";
 import {Region} from "@/lib/models/commons";
 import { labelByRpcType, validRpcTypes as validRpcTypesEnums } from '@/lib/constants'
+import {RPCTypeMap} from '@igniter/pocket/constants';
+import type {ValidRPCTypes} from '@igniter/pocket';
 
 interface ServiceOnChain {
   serviceId: string;
@@ -39,7 +41,9 @@ interface ServiceOnChain {
   computeUnits: number;
 }
 
-const PROTOCOL_DEFAULT_TYPE = PROTOCOL_DEFAULT_RPC_TYPE.toString();
+const PROTOCOL_DEFAULT_TYPE = PROTOCOL_DEFAULT_RPC_TYPE.toString()
+
+const DEFAULT_ENDPOINTS = [{ url: "", rpcType: PROTOCOL_DEFAULT_TYPE }]
 
 const validRpcTypes = [
   validRpcTypesEnums[0].toString(),
@@ -48,9 +52,30 @@ const validRpcTypes = [
   validRpcTypesEnums[3].toString(),
 ] as const;
 
+const RPCTypeSchema = z.enum(validRpcTypes).default(PROTOCOL_DEFAULT_TYPE).transform(v => Number(v));
+
+const preprocessRpcType = (v: unknown) => {
+  if (!v || !RPCTypeMap[v as ValidRPCTypes]) {
+    return PROTOCOL_DEFAULT_TYPE;
+  }
+
+  return  RPCTypeMap[v as ValidRPCTypes]?.toString() ?? PROTOCOL_DEFAULT_TYPE;
+}
+
+const preprocessEndpoints = (v: unknown) => {
+  if (!v || !Array.isArray(v)) {
+    return DEFAULT_ENDPOINTS
+  }
+
+  return v.map((endpoint) => ({
+    ...endpoint,
+    rpcType: preprocessRpcType(endpoint.rpcType),
+  }))
+}
+
 const endpointSchema = z.object({
   url: z.string(),
-  rpcType: z.enum(validRpcTypes).default(PROTOCOL_DEFAULT_TYPE).transform(v => Number(v)),
+  rpcType: z.preprocess(preprocessRpcType, RPCTypeSchema),
 }).transform((data) => ({
   ...data,
   url: data.url || getDefaultUrlWithSchemeByRpcType(data.rpcType)
@@ -81,9 +106,7 @@ export function AddOrUpdateServiceDialog({
                                              onClose,
                                              service,
                                            }: Readonly<AddServiceDialogProps>) {
-  const [endpoints, setEndpoints] = useState<{ url: string; rpcType: number }[]>(
-    service?.endpoints ?? [{ url: "", rpcType: PROTOCOL_DEFAULT_TYPE }]
-  );
+  const [endpoints, setEndpoints] = useState<{ url: string; rpcType: number }[]>(preprocessEndpoints(service?.endpoints));
 
   const [serviceOnChain, setServiceOnChain] = useState<ServiceOnChain>();
   const [isLoadingService, setIsLoadingService] = useState(false);
@@ -168,7 +191,7 @@ export function AddOrUpdateServiceDialog({
     defaultValues: {
       serviceId: service?.serviceId || "",
       revSharePercentage: service?.revSharePercentage || null,
-      endpoints: service?.endpoints ?? [{ url: "", rpcType: PROTOCOL_DEFAULT_TYPE }],
+      endpoints: preprocessEndpoints(service?.endpoints),
     },
   });
 

--- a/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.test.ts
+++ b/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.test.ts
@@ -49,6 +49,7 @@ describe('BuildSupplierServiceConfigHandler', () => {
                 serviceId: 'svc-1',
                 endpoints: [
                     { url: 'https://dummy', rpcType: 'REST' },
+                    { url: 'https://dummy-grpc', rpcType: 1 },
                 ],
             },
         ] as any,
@@ -80,12 +81,18 @@ describe('BuildSupplierServiceConfigHandler', () => {
         const cfg: SupplierServiceConfig = result[0];
 
         expect(cfg.serviceId).toBe('svc-1');
-        expect(cfg.endpoints).toHaveLength(1);
+        expect(cfg.endpoints).toHaveLength(2);
         expect(cfg.endpoints[0]).toMatchObject({
             url: 'https://interpolated',
-            rpcType: 'REST',
+            rpcType: 4,
             configs: [],
         });
+
+      expect(cfg.endpoints[1]).toMatchObject({
+        url: 'https://interpolated',
+        rpcType: 1,
+        configs: [],
+      });
 
         expect(cfg.revShare).toEqual(
             expect.arrayContaining([

--- a/packages/pocket/package.json
+++ b/packages/pocket/package.json
@@ -11,6 +11,12 @@
       "default": "./dist/cjs/src/index.js",
       "import": "./dist/cjs/src/index.js"
     },
+    "./constants": {
+      "types": "./dist/types/src/constants.d.ts",
+      "require": "./dist/cjs/src/constants.js",
+      "default": "./dist/cjs/src/constants.js",
+      "import": "./dist/cjs/src/constants.js"
+    },
     "./proto/*": {
       "types": "./dist/types/src/proto/generated/*.d.ts",
       "require": "./dist/cjs/src/proto/generated/*.js",

--- a/packages/pocket/src/constants.ts
+++ b/packages/pocket/src/constants.ts
@@ -1,0 +1,33 @@
+import {RPCType} from "./proto/generated/pocket/shared/service";
+import {ValidRPCTypes} from "./types";
+
+/**
+ * Represents a mapping of RPC types to their corresponding integer values.
+ *
+ * This object is used to define and identify various types of Remote Procedure Call (RPC) protocols
+ * by assigning each type a unique integer representation.
+ *
+ * @constant {Object} RPCTypeMap
+ * @property {number} UNKNOWN_RPC - Represents an unknown or unspecified RPC type, default value of 0.
+ * @property {number} GRPC - Represents the gRPC protocol, assigned with a value of 1.
+ * @property {number} WEBSOCKET - Represents WebSocket-based RPC, assigned with a value of 2.
+ * @property {number} JSON_RPC - Represents JSON-RPC protocol, assigned with a value of 3.
+ * @property {number} REST - Represents REST-based RPC, assigned with a value of 4.
+ * @property {number} COMET_BFT - Represents the CometBFT protocol, assigned with a value of 5.
+ * @property {number} UNRECOGNIZED - Represents an unrecognized or unsupported RPC type, assigned with a value of -1.
+ */
+export const RPCTypeMap: Record<ValidRPCTypes, RPCType> = {
+  "UNKNOWN_RPC": 0,
+  "GRPC": 1,
+  "WEBSOCKET": 2,
+  "JSON_RPC": 3,
+  "REST": 4,
+  "COMET_BFT": 5,
+  "UNRECOGNIZED": -1,
+  "0": 0,
+  "1": 1,
+  "2": 2,
+  "3": 3,
+  "4": 4,
+  "5": 5,
+}

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -35,6 +35,7 @@ import {isValidPrivateKey} from "@pocket/utils";
 import {getLogger, Logger} from '@igniter/logger'
 
 export * from './types'
+export * from './constants';
 
 /**
  * Creates a Protobuf-based RPC client for querying a blockchain using a QueryClient.

--- a/packages/pocket/src/types.ts
+++ b/packages/pocket/src/types.ts
@@ -84,27 +84,5 @@ export type StakeSupplierParams = {
   signerPrivateKey: string;
 } & MsgStakeSupplier;
 
-/**
- * Represents a mapping of RPC types to their corresponding integer values.
- *
- * This object is used to define and identify various types of Remote Procedure Call (RPC) protocols
- * by assigning each type a unique integer representation.
- *
- * @constant {Object} RPCTypeMap
- * @property {number} UNKNOWN_RPC - Represents an unknown or unspecified RPC type, default value of 0.
- * @property {number} GRPC - Represents the gRPC protocol, assigned with a value of 1.
- * @property {number} WEBSOCKET - Represents WebSocket-based RPC, assigned with a value of 2.
- * @property {number} JSON_RPC - Represents JSON-RPC protocol, assigned with a value of 3.
- * @property {number} REST - Represents REST-based RPC, assigned with a value of 4.
- * @property {number} COMET_BFT - Represents the CometBFT protocol, assigned with a value of 5.
- * @property {number} UNRECOGNIZED - Represents an unrecognized or unsupported RPC type, assigned with a value of -1.
- */
-export const RPCTypeMap: Record<keyof typeof RPCType, RPCType> = {
-  "UNKNOWN_RPC": 0,
-  "GRPC": 1,
-  "WEBSOCKET": 2,
-  "JSON_RPC": 3,
-  "REST": 4,
-  "COMET_BFT": 5,
-  "UNRECOGNIZED": -1,
-}
+
+export type ValidRPCTypes = keyof typeof RPCType | "0" | "1" | "2" | "3" | "4" | "5";


### PR DESCRIPTION
- Pre-process service endpoint entries coming from the database or going into the database after user input so that they are consistently mapped. Allowing for both legacy text based RPC Types and new number based RPC Types.