### PR TITLE
[Chore] Improve Temporal and provider setup: dynamic ports, namespace checks, and cleanup

### DIFF
--- a/docker-compose/apps/provider/.env.sample
+++ b/docker-compose/apps/provider/.env.sample
@@ -14,10 +14,10 @@ TEMPORAL_WORKFLOW_RETENTION="604800"
 # Postgresql
 PGHOST="postgresql"
 PGUSER="igniter"
-# CHANGE THIS (this should be the same of POSTGRES_PASSWORD at dependencies/.env)
-PGPASSWORD="igniter"
-DATABASE_URL="postgres://igniter:igniter@postgresql:5432/provider?sslmode=disable"
+# Must match POSTGRES_PASSWORD in dependencies/.env
+PGPASSWORD=""
 DB_NAME="provider"
+DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:5432/${DB_NAME}?sslmode=disable"
 
 # Used on worker/workflows to deliver txs
 # Set the proper one for the right network. You can use your own or one of the public ones:

--- a/docker-compose/apps/provider/docker-compose.yaml
+++ b/docker-compose/apps/provider/docker-compose.yaml
@@ -1,8 +1,8 @@
 services:
   provider-migration:
-    image: "ghcr.io/stake-igniter/provider:0.2.4-rc.0"
+    image: "ghcr.io/stake-igniter/provider:latest"
     container_name: provider-migration
-    restart: on-failure
+    restart: "no"
     command: [ "pnpm", "provider:migration:migrate" ]
     networks:
       - igniter
@@ -10,7 +10,7 @@ services:
       - .env
 
   provider-web:
-    image: "ghcr.io/stake-igniter/provider:0.2.4-rc.0"
+    image: "ghcr.io/stake-igniter/provider:latest"
     container_name: provider-web
     networks:
       - igniter
@@ -23,7 +23,7 @@ services:
       - "127.0.0.1:3001:3001"
 
   provider-workflows:
-    image: "ghcr.io/stake-igniter/provider-workflows:0.2.4-rc.0"
+    image: "ghcr.io/stake-igniter/provider-workflows:latest"
     container_name: provider-workflows
     networks:
       - igniter

--- a/docker-compose/dependencies/docker-compose.yaml
+++ b/docker-compose/dependencies/docker-compose.yaml
@@ -69,6 +69,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+      - TEMPORAL_UI_PORT=8080
     networks:
       - igniter
     ports:
@@ -77,7 +78,7 @@ services:
   wf-setup:
     image: temporalio/admin-tools:${TEMPORAL_TOOLS_VERSION}
     container_name: wf-setup
-    restart: on-failure
+    restart: "no"
     entrypoint: [ "/home/temporal/initialize.sh" ]
     networks:
       - igniter

--- a/docker-compose/dependencies/temporal/initialize.sh
+++ b/docker-compose/dependencies/temporal/initialize.sh
@@ -1,5 +1,74 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-temporal operator namespace create provider
+# ---------------------------------------------
+# Config (override via env)
+# ---------------------------------------------
+NAMESPACES="${NAMESPACES:-provider middleman}"   # space-separated list
+ADDRESS="${TEMPORAL_ADDRESS:-temporal:7233}"     # Temporal server (docker compose service)
 
-temporal operator namespace create middleman
+# ---------------------------------------------
+# Helpers
+# ---------------------------------------------
+temporal_cli() {
+  temporal --address "$ADDRESS" "$@"
+}
+
+wait_for_temporal() {
+  echo "Waiting for Temporal at $ADDRESS ..."
+  local tries=0
+  until temporal_cli cluster health >/dev/null 2>&1 || temporal_cli operator namespace list >/dev/null 2>&1; do
+    tries=$((tries+1))
+    if (( tries > 60 )); then
+      echo "Timed out waiting for Temporal at $ADDRESS" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+  echo "Temporal is reachable."
+}
+
+ns_exists() {
+  local ns="$1"
+  if temporal_cli operator namespace describe -n "$ns" >/dev/null 2>&1; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+create_ns() {
+  local ns="$1"
+  if ns_exists "$ns"; then
+    echo "Namespace '$ns' already exists — skipping create."
+    return 0
+  fi
+
+  echo "Creating namespace '$ns' ..."
+  temporal_cli operator namespace create -n "$ns"
+
+  # Verify creation
+  temporal_cli operator namespace describe -n "$ns" >/dev/null
+  echo "Namespace '$ns' created."
+}
+
+# ---------------------------------------------
+# Main
+# ---------------------------------------------
+wait_for_temporal
+
+for ns in $NAMESPACES; do
+  # Backoff + retry creation in case the cluster just came up
+  tries=0
+  until create_ns "$ns"; do
+    tries=$((tries+1))
+    if (( tries > 5 )); then
+      echo "Failed to create namespace '$ns' after retries." >&2
+      exit 1
+    fi
+    sleep $((tries * 2))
+  done
+done
+
+echo "✅ All namespaces ensured: $NAMESPACES"
+echo "✅ All setup tasks completed successfully — exiting script."


### PR DESCRIPTION
### Summary
This PR refines several Temporal and provider-related setup components for a cleaner, more predictable workflow.

### Changes
- Added logic to verify namespaces before creation and skip if already exists.
- Added a completion message to indicate successful script exit.
- Added `TEMPORAL_UI_PORT` to allow changing the UI’s internal port when `8080` is in use.
- Updated provider image to use the `latest` working tag.
- Set restart policy to "no" for `wf-setup and `provider-migration` containers since they perform a one-time job and exit.

### Impact
These updates improve setup consistency, reduce unnecessary restarts, make configuration more flexible, and production ready .