### PR TITLE
Disable providers based on their address groups configurations

### DIFF
--- a/apps/middleman/src/actions/Stake.ts
+++ b/apps/middleman/src/actions/Stake.ts
@@ -68,7 +68,7 @@ export async function CalculateStakeDistribution(stakeAmount: number, ownerAddre
 
     if (
         !provider.allowPublicStaking &&
-        !provider.allowedStakers?.map((addr: string) => addr.toLowerCase()).includes(ownerAddress.toLowerCase())
+        !provider.allowedStakers?.some((address: string) => address.toLowerCase() === ownerAddress.toLowerCase())
     ) {
       distribution = []
     }

--- a/apps/middleman/src/actions/Stake.ts
+++ b/apps/middleman/src/actions/Stake.ts
@@ -45,7 +45,15 @@ export async function CalculateStakeDistribution(stakeAmount: number, ownerAddre
   return providers.map(provider => {
     let distribution: StakeDistributionItem[] = []
 
-    if (provider.enabled && provider.operationalFunds && provider.minimumStake) {
+    const ownerCanStakeWithProvider =
+        provider.allowPublicStaking ||
+        provider.allowedStakers?.some((address: string) => address.toLowerCase() === ownerAddress.toLowerCase());
+
+    if (!ownerCanStakeWithProvider) {
+      distribution = [];
+    }
+
+    if (provider.enabled && provider.operationalFunds && provider.minimumStake && ownerCanStakeWithProvider) {
 
       const allowedSizes = availableNodeSizes.filter(amount => amount >= provider.minimumStake)
 
@@ -64,13 +72,6 @@ export async function CalculateStakeDistribution(stakeAmount: number, ownerAddre
       if (remaining !== 0) {
         distribution = []
       }
-    }
-
-    if (
-        !provider.allowPublicStaking &&
-        !provider.allowedStakers?.some((address: string) => address.toLowerCase() === ownerAddress.toLowerCase())
-    ) {
-      distribution = []
     }
 
     return {

--- a/apps/middleman/src/actions/Stake.ts
+++ b/apps/middleman/src/actions/Stake.ts
@@ -36,7 +36,7 @@ export interface CreateSignedMemoRequest {
   settings: ApplicationSettings;
 }
 
-export async function CalculateStakeDistribution(stakeAmount: number): Promise<StakeDistributionOffer[]> {
+export async function CalculateStakeDistribution(stakeAmount: number, ownerAddress: string): Promise<StakeDistributionOffer[]> {
   const applicationSettings = await getApplicationSettings()
   const providers = await ListProviders()
 
@@ -46,6 +46,7 @@ export async function CalculateStakeDistribution(stakeAmount: number): Promise<S
     let distribution: StakeDistributionItem[] = []
 
     if (provider.enabled && provider.operationalFunds && provider.minimumStake) {
+
       const allowedSizes = availableNodeSizes.filter(amount => amount >= provider.minimumStake)
 
       let remaining = stakeAmount
@@ -63,6 +64,10 @@ export async function CalculateStakeDistribution(stakeAmount: number): Promise<S
       if (remaining !== 0) {
         distribution = []
       }
+    }
+
+    if (!provider.allowPublicStaking && !provider.allowedStakers?.includes(ownerAddress)) {
+      distribution = []
     }
 
     return {

--- a/apps/middleman/src/actions/Stake.ts
+++ b/apps/middleman/src/actions/Stake.ts
@@ -66,7 +66,10 @@ export async function CalculateStakeDistribution(stakeAmount: number, ownerAddre
       }
     }
 
-    if (!provider.allowPublicStaking && !provider.allowedStakers?.includes(ownerAddress)) {
+    if (
+        !provider.allowPublicStaking &&
+        !provider.allowedStakers?.map((addr: string) => addr.toLowerCase()).includes(ownerAddress.toLowerCase())
+    ) {
       distribution = []
     }
 

--- a/apps/middleman/src/app/app/stake/components/PickOfferStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/PickOfferStep/index.tsx
@@ -12,13 +12,14 @@ import {ActivityContentLoading} from "@/app/app/stake/components/ActivityContent
 
 export interface PickOfferStepProps {
     amount: number;
+    ownerAddress: string;
     defaultOffer?: StakeDistributionOffer;
     onOfferSelected: (offer: StakeDistributionOffer) => void;
     onBack: () => void;
     onClose: () => void;
 }
 
-export function PickOfferStep({onOfferSelected, amount, onBack, defaultOffer, onClose}: Readonly<PickOfferStepProps>) {
+export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, defaultOffer, onClose}: Readonly<PickOfferStepProps>) {
     const [selectedOffer, setSelectedOffer] = useState<StakeDistributionOffer | undefined>(defaultOffer);
     const [isShowingUnavailable, setIsShowingUnavailable] = useState<boolean>(false);
     const [offers, setOffers] = useState<StakeDistributionOffer[]>([]);
@@ -53,7 +54,7 @@ export function PickOfferStep({onOfferSelected, amount, onBack, defaultOffer, on
         (async () => {
             setIsLoadingOffers(true);
             try {
-                const calculatedOffers = await CalculateStakeDistribution(amount);
+                const calculatedOffers = await CalculateStakeDistribution(amount, ownerAddress);
                 setOffers(calculatedOffers);
                 if (selectedOffer) {
                     const updatedSelectedOffer = calculatedOffers.find((offer) => offer.id === selectedOffer.id && offer.stakeDistribution.length > 0);;

--- a/apps/middleman/src/app/app/stake/page.tsx
+++ b/apps/middleman/src/app/app/stake/page.tsx
@@ -144,6 +144,7 @@ export default function StakePage() {
                 {step === StakeActivitySteps.PickOffer && (
                     <PickOfferStep
                         amount={stakeAmount}
+                        ownerAddress={ownerAddress}
                         defaultOffer={selectedOffer}
                         onOfferSelected={(offer) => {
                             setSelectedOffer(offer);

--- a/apps/provider/src/app/api/status/route.ts
+++ b/apps/provider/src/app/api/status/route.ts
@@ -57,7 +57,7 @@ export async function POST(request: Request) {
       allowedStakers,
       minimumStake: minimumStake,
       allowPublicStaking: addressGroups.some(group => !group.private),
-      fee: Math.max(...fees),
+      fee: fees.length > 0 ? Math.max(...fees) : 0,
       feeType: Array.from(new Set(fees)).length === 1 ? ProviderFee.Fixed : ProviderFee.UpTo,
       domains: getUniqueDomains(addressGroups),
       healthy: true,

--- a/apps/provider/src/app/api/status/route.ts
+++ b/apps/provider/src/app/api/status/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
 
     const regions = await getUniqueRegions();
 
-    const allowedStakers = addressGroups.flatMap(group => group.linkedAddresses);
+    const allowedStakers = Array.from(new Set(addressGroups.flatMap(group => group.linkedAddresses)));
     
     const response: StatusResponse = {
       regions,

--- a/apps/provider/src/app/api/status/route.ts
+++ b/apps/provider/src/app/api/status/route.ts
@@ -49,10 +49,14 @@ export async function POST(request: Request) {
     }, [] as number[]);
 
     const regions = await getUniqueRegions();
+
+    const allowedStakers = addressGroups.flatMap(group => group.linkedAddresses);
     
     const response: StatusResponse = {
       regions,
+      allowedStakers,
       minimumStake: minimumStake,
+      allowPublicStaking: addressGroups.some(group => !group.private),
       fee: Math.max(...fees),
       feeType: Array.from(new Set(fees)).length === 1 ? ProviderFee.Fixed : ProviderFee.UpTo,
       domains: getUniqueDomains(addressGroups),

--- a/apps/provider/src/app/api/status/route.ts
+++ b/apps/provider/src/app/api/status/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: Request) {
       regions,
       allowedStakers,
       minimumStake: minimumStake,
-      allowPublicStaking: addressGroups.some(group => !group.private),
+      allowPublicStaking: addressGroups && Array.isArray(addressGroups) && addressGroups.some(group => !group.private),
       fee: fees.length > 0 ? Math.max(...fees) : 0,
       feeType: Array.from(new Set(fees)).length === 1 ? ProviderFee.Fixed : ProviderFee.UpTo,
       domains: getUniqueDomains(addressGroups),

--- a/apps/provider/src/lib/models/status.ts
+++ b/apps/provider/src/lib/models/status.ts
@@ -7,6 +7,8 @@ export interface StatusResponse {
   minimumStake: number;
   fee: number;
   feeType: ProviderFee;
+  allowPublicStaking: boolean;
+  allowedStakers: string[];
   domains: string[];
   regions: string[];
   healthy: boolean;

--- a/packages/db/src/middleman/schema/provider.ts
+++ b/packages/db/src/middleman/schema/provider.ts
@@ -28,6 +28,8 @@ export const providersTable = pgTable('providers', {
   feeType: providerFeeEnum(),
   domains: text().array().default([]),
   regions: text().array().default([]),
+  allowPublicStaking: boolean().default(false),
+  allowedStakers: varchar().array().default([]),
   status: providerStatusEnum().notNull().default(ProviderStatus.Unknown),
   minimumStake: integer().notNull().default(0),
   operationalFunds: integer().notNull().default(5),


### PR DESCRIPTION
- Start collecting two new values during provider status check:
  * allowPublicStaking: Whether this provider has address groups that are not private.
  * allowedStakers: The flat list of linked addresses on the provider's address groups
  
 - Updates the "middleman" tool to consider the new "allowPublicStaking" and "allowedStakers" attributes. When gathering the list of available providers for a given ownerAddress, if the provider doesn't support public staking, and the ownerAddress is not part of the "allowedStakers" list, the provider appears as disabled.