### PR TITLE
Add headers to fetch options to bypass Cloudflare's bot detection

### DIFF
--- a/packages/ui/src/lib/graphql/server.ts
+++ b/packages/ui/src/lib/graphql/server.ts
@@ -14,7 +14,12 @@ export const getServerApolloClient = (url: string) => {
 
         // you can disable result caching here if you want to
         // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
-        fetchOptions: { cache: "no-store",  },
+        fetchOptions: { 
+          cache: "no-store",
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept': 'application/json',
+          },
       }),
     });
   });


### PR DESCRIPTION
Configure the Apollo Client to send browser-like headers User-Agent to bypass Cloudflare's bot detection.