### PR TITLE
Add Public Address Groups and Improve Staking UI

### DIFF
--- a/apps/middleman/drizzle/0004_new_master_chief.sql
+++ b/apps/middleman/drizzle/0004_new_master_chief.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "providers" ADD COLUMN "address_groups" jsonb DEFAULT '[]'::jsonb;

--- a/apps/middleman/drizzle/0005_lying_owl.sql
+++ b/apps/middleman/drizzle/0005_lying_owl.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "providers" ADD COLUMN "rewardAddresses" varchar[];

--- a/apps/middleman/drizzle/0006_brown_titania.sql
+++ b/apps/middleman/drizzle/0006_brown_titania.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."chain_ids" ADD VALUE 'pocket-lego-testnet';

--- a/apps/middleman/drizzle/meta/0004_snapshot.json
+++ b/apps/middleman/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,898 @@
+{
+  "id": "0e086ead-40ec-464a-a9ab-8be2ccfd3a0d",
+  "prevId": "8c505bb9-410a-4e4a-badd-7a254286e120",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appIdentity": {
+          "name": "appIdentity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supportEmail": {
+          "name": "supportEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerEmail": {
+          "name": "ownerEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerIdentity": {
+          "name": "ownerIdentity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isBootstrapped": {
+          "name": "isBootstrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "chain_ids",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpcUrl": {
+          "name": "rpcUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexerApiUrl": {
+          "name": "indexerApiUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAtHeight": {
+          "name": "updatedAtHeight",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacyPolicy": {
+          "name": "privacyPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_settings_createdBy_users_identity_fk": {
+          "name": "application_settings_createdBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "application_settings_updatedBy_users_identity_fk": {
+          "name": "application_settings_updatedBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "nodes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stakeAmount": {
+          "name": "stakeAmount",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUpdatedHeight": {
+          "name": "lastUpdatedHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nodes_providerId_providers_identity_fk": {
+          "name": "nodes_providerId_providers_identity_fk",
+          "tableFrom": "nodes",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "nodes_createdBy_users_identity_fk": {
+          "name": "nodes_createdBy_users_identity_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions_to_nodes": {
+      "name": "transactions_to_nodes",
+      "schema": "",
+      "columns": {
+        "transactionId": {
+          "name": "transactionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_to_nodes_transactionId_transactions_id_fk": {
+          "name": "transactions_to_nodes_transactionId_transactions_id_fk",
+          "tableFrom": "transactions_to_nodes",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transactionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_to_nodes_nodeId_nodes_id_fk": {
+          "name": "transactions_to_nodes_nodeId_nodes_id_fk",
+          "tableFrom": "transactions_to_nodes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transactions_to_nodes_transactionId_nodeId_pk": {
+          "name": "transactions_to_nodes_transactionId_nodeId_pk",
+          "columns": [
+            "transactionId",
+            "nodeId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "providers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "provider_fee",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "regions": {
+          "name": "regions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "allowPublicStaking": {
+          "name": "allowPublicStaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowedStakers": {
+          "name": "allowedStakers",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "operationalFunds": {
+          "name": "operationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "address_groups": {
+          "name": "address_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "providers_createdBy_users_identity_fk": {
+          "name": "providers_createdBy_users_identity_fk",
+          "tableFrom": "providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "providers_updatedBy_users_identity_fk": {
+          "name": "providers_updatedBy_users_identity_fk",
+          "tableFrom": "providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_identity_unique": {
+          "name": "providers_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "transactions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "tx_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tx_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionHeight": {
+          "name": "executionHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionTimestamp": {
+          "name": "executionTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationHeight": {
+          "name": "verificationHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationTimestamp": {
+          "name": "verificationTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signedPayload": {
+          "name": "signedPayload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromAddress": {
+          "name": "fromAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsignedPayload": {
+          "name": "unsignedPayload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimatedFee": {
+          "name": "estimatedFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedFee": {
+          "name": "consumedFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerFee": {
+          "name": "providerFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "typeProviderFee": {
+          "name": "typeProviderFee",
+          "type": "provider_fee",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_dependsOn_transactions_id_fk": {
+          "name": "transactions_dependsOn_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "dependsOn"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_providerId_providers_identity_fk": {
+          "name": "transactions_providerId_providers_identity_fk",
+          "tableFrom": "transactions",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_createdBy_users_identity_fk": {
+          "name": "transactions_createdBy_users_identity_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_unique": {
+          "name": "users_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chain_ids": {
+      "name": "chain_ids",
+      "schema": "public",
+      "values": [
+        "pocket",
+        "pocket-beta",
+        "pocket-alpha"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "staked",
+        "unstaked",
+        "unstaking"
+      ]
+    },
+    "public.provider_fee": {
+      "name": "provider_fee",
+      "schema": "public",
+      "values": [
+        "up_to",
+        "fixed"
+      ]
+    },
+    "public.provider_status": {
+      "name": "provider_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy",
+        "unknown",
+        "unreachable"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "owner"
+      ]
+    },
+    "public.tx_status": {
+      "name": "tx_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failure",
+        "not_executed"
+      ]
+    },
+    "public.tx_type": {
+      "name": "tx_type",
+      "schema": "public",
+      "values": [
+        "Stake",
+        "Unstake",
+        "Upstake",
+        "Operational Funds"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/middleman/drizzle/meta/0005_snapshot.json
+++ b/apps/middleman/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,904 @@
+{
+  "id": "8dbc8841-0256-40a3-8382-ddaf94f0579c",
+  "prevId": "0e086ead-40ec-464a-a9ab-8be2ccfd3a0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appIdentity": {
+          "name": "appIdentity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supportEmail": {
+          "name": "supportEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerEmail": {
+          "name": "ownerEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerIdentity": {
+          "name": "ownerIdentity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isBootstrapped": {
+          "name": "isBootstrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "chain_ids",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpcUrl": {
+          "name": "rpcUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexerApiUrl": {
+          "name": "indexerApiUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAtHeight": {
+          "name": "updatedAtHeight",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacyPolicy": {
+          "name": "privacyPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_settings_createdBy_users_identity_fk": {
+          "name": "application_settings_createdBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "application_settings_updatedBy_users_identity_fk": {
+          "name": "application_settings_updatedBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "nodes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stakeAmount": {
+          "name": "stakeAmount",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUpdatedHeight": {
+          "name": "lastUpdatedHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nodes_providerId_providers_identity_fk": {
+          "name": "nodes_providerId_providers_identity_fk",
+          "tableFrom": "nodes",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "nodes_createdBy_users_identity_fk": {
+          "name": "nodes_createdBy_users_identity_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions_to_nodes": {
+      "name": "transactions_to_nodes",
+      "schema": "",
+      "columns": {
+        "transactionId": {
+          "name": "transactionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_to_nodes_transactionId_transactions_id_fk": {
+          "name": "transactions_to_nodes_transactionId_transactions_id_fk",
+          "tableFrom": "transactions_to_nodes",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transactionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_to_nodes_nodeId_nodes_id_fk": {
+          "name": "transactions_to_nodes_nodeId_nodes_id_fk",
+          "tableFrom": "transactions_to_nodes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transactions_to_nodes_transactionId_nodeId_pk": {
+          "name": "transactions_to_nodes_transactionId_nodeId_pk",
+          "columns": [
+            "transactionId",
+            "nodeId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "providers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "provider_fee",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "regions": {
+          "name": "regions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "allowPublicStaking": {
+          "name": "allowPublicStaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowedStakers": {
+          "name": "allowedStakers",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "operationalFunds": {
+          "name": "operationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "address_groups": {
+          "name": "address_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "rewardAddresses": {
+          "name": "rewardAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "providers_createdBy_users_identity_fk": {
+          "name": "providers_createdBy_users_identity_fk",
+          "tableFrom": "providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "providers_updatedBy_users_identity_fk": {
+          "name": "providers_updatedBy_users_identity_fk",
+          "tableFrom": "providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_identity_unique": {
+          "name": "providers_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "transactions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "tx_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tx_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionHeight": {
+          "name": "executionHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionTimestamp": {
+          "name": "executionTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationHeight": {
+          "name": "verificationHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationTimestamp": {
+          "name": "verificationTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signedPayload": {
+          "name": "signedPayload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromAddress": {
+          "name": "fromAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsignedPayload": {
+          "name": "unsignedPayload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimatedFee": {
+          "name": "estimatedFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedFee": {
+          "name": "consumedFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerFee": {
+          "name": "providerFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "typeProviderFee": {
+          "name": "typeProviderFee",
+          "type": "provider_fee",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_dependsOn_transactions_id_fk": {
+          "name": "transactions_dependsOn_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "dependsOn"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_providerId_providers_identity_fk": {
+          "name": "transactions_providerId_providers_identity_fk",
+          "tableFrom": "transactions",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_createdBy_users_identity_fk": {
+          "name": "transactions_createdBy_users_identity_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_unique": {
+          "name": "users_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chain_ids": {
+      "name": "chain_ids",
+      "schema": "public",
+      "values": [
+        "pocket",
+        "pocket-beta",
+        "pocket-alpha"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "staked",
+        "unstaked",
+        "unstaking"
+      ]
+    },
+    "public.provider_fee": {
+      "name": "provider_fee",
+      "schema": "public",
+      "values": [
+        "up_to",
+        "fixed"
+      ]
+    },
+    "public.provider_status": {
+      "name": "provider_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy",
+        "unknown",
+        "unreachable"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "owner"
+      ]
+    },
+    "public.tx_status": {
+      "name": "tx_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failure",
+        "not_executed"
+      ]
+    },
+    "public.tx_type": {
+      "name": "tx_type",
+      "schema": "public",
+      "values": [
+        "Stake",
+        "Unstake",
+        "Upstake",
+        "Operational Funds"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/middleman/drizzle/meta/0006_snapshot.json
+++ b/apps/middleman/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,905 @@
+{
+  "id": "401b2006-d2fc-4359-a30f-e71145a2b9a3",
+  "prevId": "8dbc8841-0256-40a3-8382-ddaf94f0579c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appIdentity": {
+          "name": "appIdentity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supportEmail": {
+          "name": "supportEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerEmail": {
+          "name": "ownerEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerIdentity": {
+          "name": "ownerIdentity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isBootstrapped": {
+          "name": "isBootstrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "chain_ids",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rpcUrl": {
+          "name": "rpcUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexerApiUrl": {
+          "name": "indexerApiUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAtHeight": {
+          "name": "updatedAtHeight",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacyPolicy": {
+          "name": "privacyPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_settings_createdBy_users_identity_fk": {
+          "name": "application_settings_createdBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "application_settings_updatedBy_users_identity_fk": {
+          "name": "application_settings_updatedBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nodes": {
+      "name": "nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "nodes_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "node_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stakeAmount": {
+          "name": "stakeAmount",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUpdatedHeight": {
+          "name": "lastUpdatedHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nodes_providerId_providers_identity_fk": {
+          "name": "nodes_providerId_providers_identity_fk",
+          "tableFrom": "nodes",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "nodes_createdBy_users_identity_fk": {
+          "name": "nodes_createdBy_users_identity_fk",
+          "tableFrom": "nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions_to_nodes": {
+      "name": "transactions_to_nodes",
+      "schema": "",
+      "columns": {
+        "transactionId": {
+          "name": "transactionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_to_nodes_transactionId_transactions_id_fk": {
+          "name": "transactions_to_nodes_transactionId_transactions_id_fk",
+          "tableFrom": "transactions_to_nodes",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transactionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_to_nodes_nodeId_nodes_id_fk": {
+          "name": "transactions_to_nodes_nodeId_nodes_id_fk",
+          "tableFrom": "transactions_to_nodes",
+          "tableTo": "nodes",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transactions_to_nodes_transactionId_nodeId_pk": {
+          "name": "transactions_to_nodes_transactionId_nodeId_pk",
+          "columns": [
+            "transactionId",
+            "nodeId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.providers": {
+      "name": "providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "providers_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visible": {
+          "name": "visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeType": {
+          "name": "feeType",
+          "type": "provider_fee",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "regions": {
+          "name": "regions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "allowPublicStaking": {
+          "name": "allowPublicStaking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowedStakers": {
+          "name": "allowedStakers",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "operationalFunds": {
+          "name": "operationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "address_groups": {
+          "name": "address_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "rewardAddresses": {
+          "name": "rewardAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "providers_createdBy_users_identity_fk": {
+          "name": "providers_createdBy_users_identity_fk",
+          "tableFrom": "providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "providers_updatedBy_users_identity_fk": {
+          "name": "providers_updatedBy_users_identity_fk",
+          "tableFrom": "providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "providers_identity_unique": {
+          "name": "providers_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "transactions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "tx_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tx_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log": {
+          "name": "log",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionHeight": {
+          "name": "executionHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionTimestamp": {
+          "name": "executionTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationHeight": {
+          "name": "verificationHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationTimestamp": {
+          "name": "verificationTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signedPayload": {
+          "name": "signedPayload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fromAddress": {
+          "name": "fromAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unsignedPayload": {
+          "name": "unsignedPayload",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estimatedFee": {
+          "name": "estimatedFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedFee": {
+          "name": "consumedFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerFee": {
+          "name": "providerFee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "typeProviderFee": {
+          "name": "typeProviderFee",
+          "type": "provider_fee",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_dependsOn_transactions_id_fk": {
+          "name": "transactions_dependsOn_transactions_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "dependsOn"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_providerId_providers_identity_fk": {
+          "name": "transactions_providerId_providers_identity_fk",
+          "tableFrom": "transactions",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "providerId"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_createdBy_users_identity_fk": {
+          "name": "transactions_createdBy_users_identity_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_unique": {
+          "name": "users_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chain_ids": {
+      "name": "chain_ids",
+      "schema": "public",
+      "values": [
+        "pocket",
+        "pocket-beta",
+        "pocket-alpha",
+        "pocket-lego-testnet"
+      ]
+    },
+    "public.node_status": {
+      "name": "node_status",
+      "schema": "public",
+      "values": [
+        "staked",
+        "unstaked",
+        "unstaking"
+      ]
+    },
+    "public.provider_fee": {
+      "name": "provider_fee",
+      "schema": "public",
+      "values": [
+        "up_to",
+        "fixed"
+      ]
+    },
+    "public.provider_status": {
+      "name": "provider_status",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy",
+        "unknown",
+        "unreachable"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "owner"
+      ]
+    },
+    "public.tx_status": {
+      "name": "tx_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failure",
+        "not_executed"
+      ]
+    },
+    "public.tx_type": {
+      "name": "tx_type",
+      "schema": "public",
+      "values": [
+        "Stake",
+        "Unstake",
+        "Upstake",
+        "Operational Funds"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/middleman/drizzle/meta/_journal.json
+++ b/apps/middleman/drizzle/meta/_journal.json
@@ -29,6 +29,27 @@
       "when": 1766006762249,
       "tag": "0003_sharp_starjammers",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1769199829869,
+      "tag": "0004_new_master_chief",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1769524079843,
+      "tag": "0005_lying_owl",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1769785593729,
+      "tag": "0006_brown_titania",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/middleman/src/app/app/(lists)/layout.tsx
+++ b/apps/middleman/src/app/app/(lists)/layout.tsx
@@ -5,7 +5,7 @@ export default function ListLayout({
 }>) {
   return (
     <div className="flex flex-col gap-10">
-      <div className="mx-30 pt-10">{children}</div>
+      <div>{children}</div>
     </div>
   );
 }

--- a/apps/middleman/src/app/app/(lists)/nodes/page.tsx
+++ b/apps/middleman/src/app/app/(lists)/nodes/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import React from 'react'
 import NodesTable from '@/app/app/(lists)/nodes/table'
 import { GetAppName } from '@/actions/ApplicationSettings'
+import Link from 'next/link'
+import { Button } from '@igniter/ui/components/button'
 
 export const dynamic = "force-dynamic";
 
@@ -16,8 +18,25 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Page() {
   return (
     <>
-      <h1>Nodes</h1>
-      <NodesTable />
+      <div className={"border-b-1"}>
+        <div className="px-5 sm:px-3 md:px-6 lg:px-6 xl:px-10 py-10">
+          <div className="flex flex-row justify-between items-center">
+            <div className="flex flex-col">
+              <h1>Suppliers</h1>
+            </div>
+            <div className="flex flex-col">
+              <div className="flex flex-row gap-3">
+                <Link href="/app/stake">
+                  <Button>New Stake</Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mx-10 pt-10">
+        <NodesTable />
+      </div>
     </>
   );
 }

--- a/apps/middleman/src/app/app/(lists)/transactions/page.tsx
+++ b/apps/middleman/src/app/app/(lists)/transactions/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import TransactionsTable from '@/app/app/(lists)/transactions/table'
 import { GetAppName } from '@/actions/ApplicationSettings'
+import React from 'react'
 
 export const dynamic = "force-dynamic";
 
@@ -15,8 +16,18 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Page() {
   return (
     <>
-      <h1>Transactions</h1>
-      <TransactionsTable />
+      <div className={"border-b-1"}>
+        <div className="px-5 sm:px-3 md:px-6 lg:px-6 xl:px-10 py-10">
+          <div className="flex flex-row justify-between items-center">
+            <div className="flex flex-col">
+              <h1>Transactions</h1>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mx-10 pt-10">
+        <TransactionsTable />
+      </div>
     </>
   );
 }

--- a/apps/middleman/src/app/app/overview/page.tsx
+++ b/apps/middleman/src/app/app/overview/page.tsx
@@ -36,7 +36,7 @@ export default async function Page() {
             <div className="flex flex-col">
               <div className="flex flex-row gap-3">
                 <Link href="/app/stake">
-                  <Button>Stake</Button>
+                  <Button>New Stake</Button>
                 </Link>
               </div>
             </div>

--- a/apps/middleman/src/app/app/providers/clientPage.tsx
+++ b/apps/middleman/src/app/app/providers/clientPage.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { Button } from '@igniter/ui/components/button';
+import { getShortAddress } from '@igniter/ui/lib/utils';
+import { CaretIcon, InfoIcon } from '@igniter/ui/assets';
+import { ProviderStatus } from '@igniter/db/middleman/enums';
+import AvatarByString from '@igniter/ui/components/AvatarByString';
+import { useWalletConnection } from '@igniter/ui/context/WalletConnection/index';
+import { Popover, PopoverContent, PopoverTrigger } from '@igniter/ui/components/popover';
+import { ListProvidersWithPublicPlans, ProviderWithPublicPlans } from '@/actions/Providers';
+import { ServicesPopover } from '@/app/app/stake/components/ServicesPopover';
+import { getApplicationSettings } from '@/actions/ApplicationSettings';
+import ProviderIcon from '@/app/assets/icons/dark/providers.svg';
+import { calculateShares } from '@/lib/utils/shareCalculations';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@igniter/ui/components/tooltip'
+
+export default function ClientProvidersPage() {
+  const router = useRouter();
+  const { isConnected, connectedIdentities } = useWalletConnection();
+  const [expandedProviders, setExpandedProviders] = useState<Set<number>>(new Set());
+  const [hasInitializedExpanded, setHasInitializedExpanded] = useState(false);
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['providers', connectedIdentities],
+    queryFn: async () => {
+      const [providersData, appSettings] = await Promise.all([
+        ListProvidersWithPublicPlans(connectedIdentities || []),
+        getApplicationSettings(),
+      ]);
+      return {
+        providers: providersData,
+        delegatorFee: appSettings.fee ? Number(appSettings.fee) : 0,
+      };
+    },
+    enabled: isConnected,
+    refetchInterval: 30000,
+  });
+
+  const providers = data?.providers || [];
+  const delegatorFee = data?.delegatorFee || 0;
+
+  useEffect(() => {
+    if (!hasInitializedExpanded && providers.length > 0) {
+      const autoExpand = new Set<number>();
+      providers.forEach(p => {
+        if (p.addressGroups.length === 1) {
+          autoExpand.add(p.id);
+        }
+      });
+      setExpandedProviders(autoExpand);
+      setHasInitializedExpanded(true);
+    }
+  }, [providers, hasInitializedExpanded]);
+
+  const toggleExpanded = (providerId: number) => {
+    setExpandedProviders(prev => {
+      const next = new Set(prev);
+      if (next.has(providerId)) {
+        next.delete(providerId);
+      } else {
+        next.add(providerId);
+      }
+      return next;
+    });
+  };
+
+  const handleStakeClick = (providerId: number, addressGroupId: number, linkedAccount?: string | null) => {
+    const params = new URLSearchParams({
+      providerId: providerId.toString(),
+      addressGroupId: addressGroupId.toString(),
+    });
+    if (linkedAccount) {
+      params.set('linkedAccount', linkedAccount);
+    }
+    router.push(`/app/stake?${params.toString()}`);
+  };
+
+  return (
+    <>
+      <div className="border-b-1">
+        <div className="px-5 sm:px-3 md:px-6 lg:px-6 xl:px-10 py-10">
+          <div className="flex flex-row justify-between items-center">
+            <div className="flex flex-col">
+              <h1>Providers</h1>
+              <p className="text-muted-foreground">
+                Browse available node runners and their staking plans.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col p-4 w-full gap-4 md:gap-6 sm:px-3 md:px-6 lg:px-6 xl:px-10">
+        {isLoading || (!data && !isError) && (
+          <div className="animate-pulse grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(600px, 1fr))' }}>
+            {[1, 2, 3, 4, 5, 6].map(i => (
+              <div key={i} className="h-24 bg-[var(--color-slate-2)] rounded-lg" />
+            ))}
+          </div>
+        )}
+
+        {isError && (
+          <div className="flex flex-col items-center justify-center py-12 gap-4">
+            <span className="text-[14px] text-[var(--color-white-3)]">
+              Failed to load providers. Please try again.
+            </span>
+            <Button variant="outline" onClick={() => refetch()}>
+              Reload
+            </Button>
+          </div>
+        )}
+
+        {!isLoading && !isError && !!data && providers.length === 0 && (
+          <div className="flex items-center justify-center py-12">
+            <span className="text-[14px] text-[var(--color-white-3)]">
+              No providers available at this time.
+            </span>
+          </div>
+        )}
+
+        {!isLoading && !isError && providers.length > 0 && (
+          <div className="grid gap-6" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(600px, 1fr))' }}>
+            {providers.map(provider => (
+              <ProviderCard
+                key={provider.id}
+                provider={provider}
+                isExpanded={expandedProviders.has(provider.id)}
+                onToggleExpand={() => toggleExpanded(provider.id)}
+                onStakeClick={handleStakeClick}
+                delegatorFee={delegatorFee}
+                connectedAccounts={connectedIdentities || []}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+interface ProviderCardProps {
+  provider: ProviderWithPublicPlans;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onStakeClick: (providerId: number, addressGroupId: number, linkedAccount?: string | null) => void;
+  delegatorFee: number;
+  connectedAccounts: string[];
+}
+
+function ProviderCard({
+  provider,
+  isExpanded,
+  onToggleExpand,
+  onStakeClick,
+  delegatorFee,
+  connectedAccounts,
+}: ProviderCardProps) {
+  const normalizedConnectedAccounts = connectedAccounts.map(addr => addr.toLowerCase());
+
+  const getLinkedAccount = (linkedAddresses: string[] | undefined): string | null => {
+    if (!linkedAddresses || linkedAddresses.length === 0) return null;
+    const linkedAccount = linkedAddresses.find(
+      (addr: string) => normalizedConnectedAccounts.includes(addr.toLowerCase())
+    );
+    if (linkedAccount) {
+      // Return the original (non-lowercased) connected account
+      return connectedAccounts.find(
+        (acc) => acc.toLowerCase() === linkedAccount.toLowerCase()
+      ) || linkedAccount;
+    }
+    return null;
+  };
+
+  const sortedAddressGroups = [...provider.addressGroups].sort((a, b) => {
+    const aLinkedAccount = getLinkedAccount(a.linkedAddresses);
+    const bLinkedAccount = getLinkedAccount(b.linkedAddresses);
+
+    if (aLinkedAccount && !bLinkedAccount) return -1;
+    if (!aLinkedAccount && bLinkedAccount) return 1;
+    return 0;
+  });
+
+  return (
+    <div className="flex flex-col rounded-[8px] border-[2px] border-[--black-dividers]">
+      <div className="flex flex-col bg-[var(--background)] rounded-[8px]">
+        <div
+          className="flex flex-row items-center justify-between p-[20px_25px] cursor-pointer hover:opacity-80"
+          onClick={onToggleExpand}
+        >
+          <span className="flex flex-row items-center gap-5">
+            <span>
+              <ProviderIcon />
+            </span>
+            <span className="flex flex-col gap-2">
+              <span className="flex flex-row items-center gap-2">
+                <span>{provider.name}</span>
+                <Popover>
+                  <PopoverTrigger asChild onClick={(e) => e.stopPropagation()}>
+                    <InfoIcon />
+                  </PopoverTrigger>
+                  <PopoverContent className="flex flex-col w-[360px] bg-[var(--color-slate-2)] p-0 max-h-[500px] overflow-y-auto">
+                    <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px] sticky top-0 bg-[var(--color-slate-2)] border-b border-[var(--slate-dividers)]">
+                      About Client Share
+                    </span>
+                    <div className="flex flex-col gap-4 p-[12px_16px]">
+                      <div className="flex flex-col gap-1">
+                        <span className="font-medium text-[var(--color-white-1)]">Client Share</span>
+                        <span className="text-[13px] text-[var(--color-white-3)]">
+                          The share of the rewards you will receive from this plan.
+                        </span>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </span>
+              <span className="flex flex-row items-center gap-4 text-[14px]">
+                <span>Performance: N/A</span>
+                <span>Plans: {provider.addressGroups.length}</span>
+                {provider.status !== ProviderStatus.Healthy && (
+                  <span className={`px-2 py-0.5 text-[11px] font-medium rounded ${
+                    provider.status === ProviderStatus.Unhealthy ? 'bg-red-500/20 text-red-300' :
+                      provider.status === ProviderStatus.Unreachable ? 'bg-orange-500/20 text-orange-300' :
+                        'bg-yellow-500/20 text-yellow-300'
+                  }`}>
+                    {provider.status === ProviderStatus.Unhealthy ? 'Unhealthy' :
+                      provider.status === ProviderStatus.Unreachable ? 'Unreachable' :
+                        'Unknown'}
+                  </span>
+                )}
+              </span>
+            </span>
+          </span>
+          <span className={`transition-transform ${isExpanded ? 'rotate-90' : ''}`}>
+            <CaretIcon />
+          </span>
+        </div>
+
+        {isExpanded && (
+          <div className="flex flex-col border-t border-[var(--black-dividers)]">
+            {sortedAddressGroups.map((addressGroup, index) => {
+              const shares = calculateShares(addressGroup, delegatorFee);
+              const servicesCount = addressGroup.addressGroupServices?.length || 0;
+              const linkedAccount = getLinkedAccount(addressGroup.linkedAddresses);
+
+              return (
+                <div
+                  key={addressGroup.id}
+                  className={`flex flex-col p-[16px_25px] ${
+                    index !== sortedAddressGroups.length - 1
+                      ? 'border-b border-[var(--black-dividers)]'
+                      : ''
+                  }`}
+                >
+                  <div className="flex flex-row items-center justify-between">
+                    <span className="flex flex-row items-center gap-2">
+                      <span className="font-medium">{addressGroup.name}</span>
+                      {linkedAccount && (
+                        <span className="flex flex-row items-center gap-1.5">
+                          <Tooltip>
+                            <TooltipTrigger asChild onClick={(e) => e.stopPropagation()}>
+                              <span className="flex flex-row items-center h-6 gap-1.5 pr-2 pl-1 py-0.5 text-[11px] font-medium bg-purple-500/20 text-purple-300 rounded">
+                                <AvatarByString string={linkedAccount} size={18} />
+                                <span className="font-mono">{getShortAddress(linkedAccount, 5)}</span>
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent className="flex flex-col w-[280px] bg-[var(--color-slate-2)] p-0 border-2 border-[var(--black-dividers)]">
+                              <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px]">
+                                Personal Plan
+                              </span>
+                              <div className="h-[1px] bg-[var(--slate-dividers)]"></div>
+                              <span className="text-[13px] text-[var(--color-white-3)] p-[12px_16px]">
+                                This plan is exclusively available to you based on your wallet address
+                                <span className="font-mono text-[var(--color-white-1)] inline-flex items-center gap-2 mt-1">
+                                  <AvatarByString string={linkedAccount} size={15} />
+                                  <span>{getShortAddress(linkedAccount, 5)}</span>
+                                </span>.
+                              </span>
+                            </TooltipContent>
+                          </Tooltip>
+                        </span>
+                      )}
+                      <span className="text-[var(--color-white-3)] -ml-2">:</span>
+                      <span className="flex flex-row items-center gap-1.5 text-[14px] mt-0.5">
+                        <span className="text-[var(--color-white-3)]">Client Share:</span>
+                        <span className="font-mono mt-0.5">{shares.clientShare.toFixed(1)}%</span>
+                      </span>
+                    </span>
+                    <div className="flex flex-row items-center gap-3">
+                      <ServicesPopover
+                        addressGroupName={addressGroup.name}
+                        services={addressGroup.addressGroupServices || []}
+                        servicesCount={servicesCount}
+                        triggerClassName="text-[14px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer"
+                        delegatorFee={delegatorFee}
+                      />
+                      <Button
+                        size="sm"
+                        disabled={provider.status !== ProviderStatus.Healthy}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onStakeClick(provider.id, addressGroup.id, linkedAccount);
+                        }}
+                      >
+                        Stake
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/middleman/src/app/app/providers/page.tsx
+++ b/apps/middleman/src/app/app/providers/page.tsx
@@ -1,6 +1,6 @@
-import ClientStakePage from '@/app/app/stake/clientPage'
 import type { Metadata } from 'next'
 import { GetAppName } from '@/actions/ApplicationSettings'
+import ClientProvidersPage from '@/app/app/providers/clientPage'
 
 export const dynamic = "force-dynamic";
 
@@ -8,11 +8,12 @@ export async function generateMetadata(): Promise<Metadata> {
   const appName = await GetAppName()
 
   return {
-    title: `Stake - ${appName}`,
+    title: `Providers - ${appName}`,
   }
 }
-export default function StakePage() {
+
+export default function ProvidersPage() {
   return (
-    <ClientStakePage />
+    <ClientProvidersPage />
   )
 }

--- a/apps/middleman/src/app/app/stake/clientPage.tsx
+++ b/apps/middleman/src/app/app/stake/clientPage.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import {useCallback, useEffect, useState} from 'react'
+import {PickStakeAmountStep} from "@/app/app/stake/components/PickStakeAmountStep";
+import {PickOfferStep} from "@/app/app/stake/components/PickOfferStep";
+import {ReviewStep} from "@/app/app/stake/components/ReviewStep";
+import {StakeDistributionOffer} from "@/lib/models/StakeDistributionOffer";
+import {StakeSuccessStep} from "@/app/app/stake/components/StakeSuccessStep";
+import {useRouter, useSearchParams} from "next/navigation";
+import {AbortConfirmationDialog} from '@igniter/ui/components/AbortConfirmationDialog'
+import { Transaction } from '@igniter/db/middleman/schema'
+import {allStagesSucceeded, getFailedStage} from "@/app/app/stake/utils";
+import {StakingProcessStatus} from "@/app/app/stake/components/ReviewStep/StakingProcess";
+import { useWalletConnection } from '@igniter/ui/context/WalletConnection/index'
+import OwnerAddressStep from '@/app/app/stake/components/OwnerAddressStep'
+import Loading from '@/app/app/stake/components/Loading'
+import {SupplierStake} from "@/lib/models/Transactions";
+import {releaseSuppliers} from "@/lib/services/provider";
+import {useNotifications} from "@igniter/ui/context/Notifications/index";
+import OverrideSidebar from '@igniter/ui/components/OverrideSidebar'
+
+
+enum StakeActivitySteps {
+  OwnerAddress = 'OwnerAddress',
+  PickStakeAmount = 'PickStakeAmount',
+  PickOffer = 'PickOffer',
+  Review = 'Review',
+  Success = 'Success'
+}
+
+export default function ClientStakePage() {
+  const {connectedIdentity, connectedIdentities, isConnected} = useWalletConnection()
+  const searchParams = useSearchParams();
+
+  // Read preselection params from URL
+  const preselectedProviderId = searchParams.get('providerId') ? Number(searchParams.get('providerId')) : undefined;
+  const preselectedAddressGroupId = searchParams.get('addressGroupId') ? Number(searchParams.get('addressGroupId')) : undefined;
+  const preselectedLinkedAccount = searchParams.get('linkedAccount') || undefined;
+
+  // Check if the linked account is one of the connected accounts
+  const isLinkedAccountConnected = preselectedLinkedAccount &&
+    connectedIdentities?.some(addr => addr.toLowerCase() === preselectedLinkedAccount.toLowerCase());
+
+  // Get the actual connected account (with proper casing)
+  const resolvedLinkedAccount = isLinkedAccountConnected
+    ? connectedIdentities?.find(addr => addr.toLowerCase() === preselectedLinkedAccount?.toLowerCase())
+    : undefined;
+
+  const [step, setStep] = useState<StakeActivitySteps>(
+    connectedIdentities && connectedIdentities.length > 1 ?
+      StakeActivitySteps.OwnerAddress :
+      StakeActivitySteps.PickStakeAmount
+  );
+
+  const [stakeAmount, setStakeAmount] = useState<number>(0);
+  const [selectedOffer, setSelectedOffer] = useState<StakeDistributionOffer | undefined>();
+  const [selectedAddressGroupId, setSelectedAddressGroupId] = useState<number | undefined>();
+  const [transaction, setTransaction] = useState<Transaction | undefined>(undefined);
+  const [isAbortDialogOpen, setAbortDialogOpen] = useState(false);
+  const [isAborting, setIsAborting] = useState(false);
+  const [ownerAddress, setOwnerAddress] = useState<string>(
+    resolvedLinkedAccount ? resolvedLinkedAccount :
+      (connectedIdentities!.length > 1 ? '' : connectedIdentity!)
+  );
+  const [stakingErrorMessage, setStakingErrorMessage] = useState<string | undefined>(undefined);
+  const [supplierProspects, setSupplierProspects] = useState<Array<SupplierStake>>([]);
+  const { addNotification } = useNotifications();
+  const router = useRouter();
+
+  const errorsMap: Record<keyof StakingProcessStatus, string> = {
+    requestSuppliersStatus: 'The staking process failed while requesting suppliers. Please try again later or contact support if the issue persists.',
+    transactionSignatureStatus: 'Transaction signature failed. If you rejected the signature request, please note that your signature is required to complete the staking process. Otherwise, check your wallet connection and try again.',
+    schedulingTransactionStatus: 'The transaction was signed but could not be scheduled. Please try again or contact support if the issue persists.'
+  };
+
+  useEffect(() => {
+    if (isConnected) {
+      // Check for preselected linked account
+      const linkedAccount = preselectedLinkedAccount
+        ? connectedIdentities?.find(addr => addr.toLowerCase() === preselectedLinkedAccount.toLowerCase())
+        : undefined;
+
+      setOwnerAddress(
+        linkedAccount ? linkedAccount :
+          (connectedIdentities!.length > 1 ? '' : connectedIdentity!)
+      )
+      setStep(
+        connectedIdentities!.length > 1 ?
+          StakeActivitySteps.OwnerAddress :
+          StakeActivitySteps.PickStakeAmount
+      );
+    }
+  }, [isConnected])
+
+  const handleOwnerAddressChange = (address: string) => {
+    setOwnerAddress(address);
+    setStep(StakeActivitySteps.PickStakeAmount);
+  }
+
+  const handleStakeAmountChange = (amount: number) => {
+    setStakeAmount(amount);
+    setStep(StakeActivitySteps.PickOffer);
+  };
+
+  const onAbort = useCallback(async (abort: boolean) => {
+    if (abort) {
+      setIsAborting(true);
+      try {
+        if (supplierProspects.length > 0) {
+          const addresses = supplierProspects.map((s) => s.operatorAddress);
+          await releaseSuppliers(selectedOffer!, addresses);
+        }
+        setIsAborting(false);
+        await router.push('/app');
+      } catch (error) {
+        console.error(error);
+        addNotification({
+          id: `abort-stake-error`,
+          type: 'error',
+          showTypeIcon: true,
+          content: 'An error occurred while aborting the staking process. Please try again or contact support if the issue persists.',
+        });
+        setIsAborting(false);
+      } finally {
+        setAbortDialogOpen(false);
+      }
+    } else {
+      setAbortDialogOpen(false);
+    }
+  }, [supplierProspects]);
+
+  if (!isConnected) {
+    return (
+      <div className="flex flex-row justify-center w-full">
+        <Loading />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <OverrideSidebar>
+        <div className="flex flex-row justify-center overflow-auto pb-16">
+          {step === StakeActivitySteps.OwnerAddress && (
+            <OwnerAddressStep
+              onClose={() => setAbortDialogOpen(true)}
+              onOwnerAddressSelected={handleOwnerAddressChange}
+              selectedOwnerAddress={ownerAddress}
+              preselectedForPersonalPlan={resolvedLinkedAccount}
+            />
+          )}
+
+          {step === StakeActivitySteps.PickStakeAmount && (
+            <PickStakeAmountStep
+              ownerAddress={ownerAddress}
+              defaultAmount={stakeAmount}
+              onAmountSelected={handleStakeAmountChange}
+              onClose={() => setAbortDialogOpen(true)}
+              onBack={
+                connectedIdentities!.length > 1 ?
+                  () => setStep(StakeActivitySteps.OwnerAddress) :
+                  undefined
+              }
+            />
+          )}
+
+          {step === StakeActivitySteps.PickOffer && (
+            <PickOfferStep
+              amount={stakeAmount}
+              ownerAddress={ownerAddress}
+              defaultOffer={selectedOffer}
+              defaultAddressGroupId={selectedAddressGroupId}
+              preselectedProviderId={preselectedProviderId}
+              preselectedAddressGroupId={preselectedAddressGroupId}
+              onOfferSelected={(offer, addressGroupId) => {
+                setSelectedOffer(offer);
+                setSelectedAddressGroupId(addressGroupId);
+                setStep(StakeActivitySteps.Review);
+              }}
+              onBack={() => {
+                setStep(StakeActivitySteps.PickStakeAmount);
+              }}
+              onClose={() => setAbortDialogOpen(true)}
+            />
+          )}
+
+          {step === StakeActivitySteps.Review && (
+            <ReviewStep
+              amount={stakeAmount}
+              errorMessage={stakingErrorMessage}
+              selectedOffer={selectedOffer!}
+              selectedAddressGroupId={selectedAddressGroupId!}
+              ownerAddress={ownerAddress}
+              onSuppliersReceived={setSupplierProspects}
+              onStakeCompleted={(result, transaction) => {
+                if (allStagesSucceeded(result)) {
+                  setStep(StakeActivitySteps.Success);
+                  setTransaction(transaction)
+                } else {
+                  const failedStage = getFailedStage(result);
+                  if (failedStage) {
+                    setStakingErrorMessage(errorsMap[failedStage]);
+                  }
+                }
+              }}
+              onBack={() => {
+                setStep(StakeActivitySteps.PickOffer);
+              }}
+              onClose={() => setAbortDialogOpen(true)}
+            />
+          )}
+
+          {step === StakeActivitySteps.Success && (
+            <StakeSuccessStep
+              transaction={transaction!}
+              amount={stakeAmount}
+              selectedOffer={selectedOffer!}
+              selectedAddressGroupId={selectedAddressGroupId!}
+              onClose={() => {
+                router.push('/app');
+              }}
+            />
+          )}
+        </div>
+      </OverrideSidebar>
+      <AbortConfirmationDialog
+        isOpen={isAbortDialogOpen}
+        isLoading={isAborting}
+        onResponse={(abort) => { onAbort(abort) }}
+      />
+    </>
+  );
+}

--- a/apps/middleman/src/app/app/stake/clientPage.tsx
+++ b/apps/middleman/src/app/app/stake/clientPage.tsx
@@ -47,7 +47,7 @@ export default function ClientStakePage() {
     : undefined;
 
   const [step, setStep] = useState<StakeActivitySteps>(
-    connectedIdentities && connectedIdentities.length > 1 ?
+    connectedIdentities && connectedIdentities.length > 1 && !isLinkedAccountConnected ?
       StakeActivitySteps.OwnerAddress :
       StakeActivitySteps.PickStakeAmount
   );
@@ -85,7 +85,7 @@ export default function ClientStakePage() {
           (connectedIdentities!.length > 1 ? '' : connectedIdentity!)
       )
       setStep(
-        connectedIdentities!.length > 1 ?
+        connectedIdentities!.length > 1 && !linkedAccount ?
           StakeActivitySteps.OwnerAddress :
           StakeActivitySteps.PickStakeAmount
       );
@@ -191,6 +191,7 @@ export default function ClientStakePage() {
               selectedOffer={selectedOffer!}
               selectedAddressGroupId={selectedAddressGroupId!}
               ownerAddress={ownerAddress}
+              ownerWasPreselected={ownerAddress === resolvedLinkedAccount}
               onSuppliersReceived={setSupplierProspects}
               onStakeCompleted={(result, transaction) => {
                 if (allStagesSucceeded(result)) {

--- a/apps/middleman/src/app/app/stake/components/OwnerAddressStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/OwnerAddressStep/index.tsx
@@ -11,9 +11,10 @@ interface OwnerAddressStepProps {
   onClose: () => void;
   selectedOwnerAddress?: string;
   onOwnerAddressSelected: (address: string) => void;
+  preselectedForPersonalPlan?: string;
 }
 
-export default function OwnerAddressStep({onClose, onOwnerAddressSelected, selectedOwnerAddress: selectedOwnerAddressFromProps}: OwnerAddressStepProps) {
+export default function OwnerAddressStep({onClose, onOwnerAddressSelected, selectedOwnerAddress: selectedOwnerAddressFromProps, preselectedForPersonalPlan}: OwnerAddressStepProps) {
   const {connectedIdentity, connectedIdentities, getBalance} = useWalletConnection();
   const [{data: balancesByAddress, error, loading}, setBalancesState] = useState<{
     data: Record<string, number> | null
@@ -60,9 +61,21 @@ export default function OwnerAddressStep({onClose, onOwnerAddressSelected, selec
     fetchBalances()
   }, [connectedIdentities])
 
+  // Determine the highlighted account: preselected linked account if exists, otherwise signed-in account
+  const highlightedAccount = preselectedForPersonalPlan
+    ? connectedIdentities?.find(addr => addr.toLowerCase() === preselectedForPersonalPlan.toLowerCase()) || connectedIdentity!
+    : connectedIdentity!;
+
+  const isHighlightedPreselected = preselectedForPersonalPlan?.toLowerCase() === highlightedAccount.toLowerCase();
+
+  // Other accounts are all connected accounts except the highlighted one
+  const otherAccounts = connectedIdentities!.filter(
+    a => a.toLowerCase() !== highlightedAccount.toLowerCase()
+  );
+
   return (
     <div
-      className="flex relative flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
+      className="flex relative flex-col w-[580px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
       <ActivityHeader
         title="Stake"
         subtitle="Select the owner address of your nodes."
@@ -70,19 +83,22 @@ export default function OwnerAddressStep({onClose, onOwnerAddressSelected, selec
       />
 
       <div className={'flex flex-col gap-4 h-full overflow-y-auto'}>
+        {/* Highlighted account at top */}
         <div
-          className="w-full h-11 cursor-pointer select-none flex flex-row items-center gap-2 py-3 pl-3 pr-4 bg-(--input-bg) border border-amber-100 rounded-lg"
-          onClick={() => setSelectedOwnerAddress(connectedIdentity!)}
+          className={`w-full h-11 cursor-pointer select-none flex flex-row items-center gap-2 py-3 pl-3 pr-4 bg-(--input-bg) border rounded-lg ${
+            isHighlightedPreselected ? 'border-purple-500/50' : 'border-amber-100'
+          }`}
+          onClick={() => setSelectedOwnerAddress(highlightedAccount)}
         >
-          <AvatarByString string={connectedIdentity!} />
+          <AvatarByString string={highlightedAccount} />
           <div className="flex flex-col w-full gap-0">
             <p className="font-mono text-sm">
-              {getShortAddress(connectedIdentity!, 5)}
+              {getShortAddress(highlightedAccount, 5)}
             </p>
           </div>
-          {balancesByAddress && typeof balancesByAddress[connectedIdentity!] === 'number' ? (
+          {balancesByAddress && typeof balancesByAddress[highlightedAccount] === 'number' ? (
             <p className={'whitespace-nowrap !text-xs mr-2 mb-1'}>
-              <Amount value={balancesByAddress[connectedIdentity!] || 0} />
+              <Amount value={balancesByAddress[highlightedAccount] || 0} />
             </p>
           ) : loading ? (
             <p>
@@ -94,46 +110,58 @@ export default function OwnerAddressStep({onClose, onOwnerAddressSelected, selec
             </p>
           )}
           <Checkbox
-            checked={selectedOwnerAddress === connectedIdentity}
+            checked={selectedOwnerAddress === highlightedAccount}
           />
         </div>
-        <p className={'!text-[10px] mb-2.5 mt-[-12px] ml-1'}>
-          You're signed in with this account.
+        <p className={`!text-[10px] mb-2.5 mt-[-12px] ml-1 ${isHighlightedPreselected ? 'text-purple-300' : ''}`}>
+          {isHighlightedPreselected
+            ? 'Preselected because the plan you chose is linked to this wallet.'
+            : "You're signed in with this account."}
         </p>
 
         <div className="absolute left-[24px] top-[246px] w-[432px] h-[1px] bg-[var(--slate-dividers)]"/>
 
-        {connectedIdentities!.filter(a => a !== connectedIdentity).map((address) => (
-          <div
-            key={address}
-            className="w-full h-11 cursor-pointer select-none flex flex-row items-center gap-2 py-3 pl-3 pr-4 bg-(--input-bg) border rounded-lg"
-            onClick={() => setSelectedOwnerAddress(address)}
-          >
-            <AvatarByString string={address} />
-            <div className="flex flex-col w-full gap-0">
-              <p className="font-mono text-sm">
-                {getShortAddress(address, 5)}
-              </p>
-            </div>
-            {balancesByAddress && typeof balancesByAddress[address] === 'number' ? (
-              <p className={'whitespace-nowrap !text-xs mr-2 mb-1'}>
-                <Amount value={balancesByAddress[address]} />
-              </p>
-            ) : loading ? (
-              <p>
-                Loading
-              </p>
-            ): (
-              <p>
-                Error
-              </p>
-            )}
+        {/* Other accounts */}
+        {otherAccounts.map((address) => {
+          const isSignedInAccount = address.toLowerCase() === connectedIdentity?.toLowerCase();
+          return (
+            <div key={address} className="flex flex-col">
+              <div
+                className="w-full h-11 cursor-pointer select-none flex flex-row items-center gap-2 py-3 pl-3 pr-4 bg-(--input-bg) border rounded-lg"
+                onClick={() => setSelectedOwnerAddress(address)}
+              >
+                <AvatarByString string={address} />
+                <div className="flex flex-col w-full gap-0">
+                  <p className="font-mono text-sm">
+                    {getShortAddress(address, 5)}
+                  </p>
+                </div>
+                {balancesByAddress && typeof balancesByAddress[address] === 'number' ? (
+                  <p className={'whitespace-nowrap !text-xs mr-2 mb-1'}>
+                    <Amount value={balancesByAddress[address]} />
+                  </p>
+                ) : loading ? (
+                  <p>
+                    Loading
+                  </p>
+                ): (
+                  <p>
+                    Error
+                  </p>
+                )}
 
-            <Checkbox
-              checked={selectedOwnerAddress === address}
-            />
-          </div>
-        ))}
+                <Checkbox
+                  checked={selectedOwnerAddress === address}
+                />
+              </div>
+              {isSignedInAccount && isHighlightedPreselected && (
+                <p className={'!text-[10px] mt-1 ml-1'}>
+                  You're signed in with this account.
+                </p>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       <Button

--- a/apps/middleman/src/app/app/stake/components/PickOfferStep/ProviderOfferItem.tsx
+++ b/apps/middleman/src/app/app/stake/components/PickOfferStep/ProviderOfferItem.tsx
@@ -1,130 +1,156 @@
-import ProviderIcon from '@/app/assets/icons/dark/providers.svg';
-import {StakeDistributionOffer} from '@/lib/models/StakeDistributionOffer';
-import {
-    CheckIcon,
-    FeeIcon,
-    FeeDisabledIcon,
-    InfoIcon,
-    RewardsIcon,
-    RewardsDisabledIcon
-} from '@igniter/ui/assets';
-import {
-    Popover,
-    PopoverContent,
-    PopoverTrigger,
-} from '@igniter/ui/components/popover';
-import {toCurrencyFormat} from "@igniter/ui/lib/utils";
+import ProviderIcon from '@/app/assets/icons/dark/providers.svg'
+import { StakeDistributionOffer } from '@/lib/models/StakeDistributionOffer'
+import { CheckIcon, InfoIcon, CaretIcon } from '@igniter/ui/assets'
+import { Popover, PopoverContent, PopoverTrigger } from '@igniter/ui/components/popover'
+import { useState } from 'react'
+import { calculateShares } from '@/lib/utils/shareCalculations'
+import { ServicesPopover } from '@/app/app/stake/components/ServicesPopover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@igniter/ui/components/tooltip'
 
 export interface ProviderOfferItemProps {
     offer: StakeDistributionOffer;
-    isSelected?: boolean;
-    onSelect?: (offer: StakeDistributionOffer) => void;
+    selectedAddressGroupId?: number;
+    onSelectAddressGroup?: (offer: StakeDistributionOffer, addressGroupId: number) => void;
     disabled?: boolean;
+    delegatorFee: number;
+    userIdentity: string;
 }
 
-export function ProviderOfferItem({ isSelected, offer, onSelect, disabled }: Readonly<ProviderOfferItemProps>) {
-    const className =
-        isSelected
-            ? 'relative flex h-[88px] gradient-border-purple'
-            : 'relative flex h-[88px] rounded-[8px] border-[2px] border-[--black-dividers]';
+export function ProviderOfferItem({ selectedAddressGroupId, offer, onSelectAddressGroup, disabled, delegatorFee, userIdentity }: Readonly<ProviderOfferItemProps>) {
+    const [isExpanded, setIsExpanded] = useState(offer.addressGroups.length === 1)
+
+    // Sort address groups: linked/personal ones first
+    const sortedAddressGroups = [...offer.addressGroups].sort((a, b) => {
+        const aIsLinked = a.linkedAddresses && a.linkedAddresses.length > 0 && a.linkedAddresses.some((addr: string) => addr.toLowerCase() === userIdentity.toLowerCase())
+        const bIsLinked = b.linkedAddresses && b.linkedAddresses.length > 0 && b.linkedAddresses.some((addr: string) => addr.toLowerCase() === userIdentity.toLowerCase())
+
+        if (aIsLinked && !bIsLinked) return -1
+        if (!aIsLinked && bIsLinked) return 1
+        return 0
+    })
+
+    const hasSelection = offer.addressGroups.some(ag => ag.id === selectedAddressGroupId)
+
+    const className = hasSelection
+        ? 'relative flex flex-col gradient-border-purple'
+        : 'relative flex flex-col rounded-[8px] border-[2px] border-[--black-dividers]'
 
     return (
-        <div className={className} onClick={() => onSelect?.(offer)}>
-            <div className={`absolute inset-0 flex flex-row items-center m-[0.5px] bg-[var(--background)] rounded-[8px] p-[20px_25px] ${isSelected ? 'justify-between' : 'flex-start'}`}>
-                <span className="flex flex-row items-center gap-5">
-                    <span>
-                        <ProviderIcon />
-                    </span>
-                    <span className="flex flex-col gap-2">
-                        <span className="flex flex-row items-center gap-2">
-                            <span className={`${disabled ? 'text-[var(--color-white-3)]' : ''}`}>{offer.name}</span>
-                            <Popover>
-                                <PopoverTrigger asChild>
-                                    <InfoIcon />
-                                </PopoverTrigger>
-                                <PopoverContent className="flex flex-col w-[260px] bg-[var(--color-slate-2)] p-0">
-                                    <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px]">
-                                        About {offer.name}
-                                    </span>
-                                    <div className="h-[1px] bg-[var(--slate-dividers)]"></div>
-                                    <span className="flex flex-col gap-2.5 p-[12px_16px]">
-                                        <span className="flex flex-row items-center justify-between">
-                                            <span className="flex flex-row items-center gap-2">
-                                                <FeeIcon />
-                                                <span>Fee</span>
-                                            </span>
-                                            <span className="font-mono">
-                                                {offer.fee}%
-                                            </span>
-                                        </span>
-                                        <span className="text-[14px] text-[var(--color-white-3)]">
-                                            Share of rewards providers charge for node running services.
-                                        </span>
-                                    </span>
-                                    <div className="h-[1px] bg-[var(--slate-dividers)]"></div>
-                                    <span className="flex flex-col gap-2.5 p-[12px_16px]">
-                                        <span className="flex flex-row items-center justify-between">
-                                            <span className="flex flex-row items-center gap-2">
-                                                <RewardsIcon />
-                                                <span>Rewards</span>
-                                            </span>
-                                            <span className="font-mono">
-                                                {toCurrencyFormat(Number(offer.rewards), 2)}
-                                            </span>
-                                        </span>
-                                        <span className="text-[14px] text-[var(--color-white-3)]">
-                                            Net $POKT rewards for the last 7 days per 15,000 $POKT staked.
-                                        </span>
-                                    </span>
-                                </PopoverContent>
-                            </Popover>
-                        </span>
+        <div className={className}>
+            <div className={`flex flex-col m-[0.5px] bg-[var(--background)] rounded-[8px]`}>
+                {/* Provider Header */}
+                <div
+                    className="flex flex-row items-center justify-between p-[20px_25px] cursor-pointer hover:opacity-80"
+                    onClick={() => setIsExpanded(!isExpanded)}
+                >
+                    <span className="flex flex-row items-center gap-5">
                         <span>
-                            {!disabled && !isSelected && (
-                                <span className="flex flex-row items-center gap-4">
-                                    <span className="flex flex-row items-center gap-2">
-                                        <FeeIcon />
-                                        <span className="font-mono leading-[1.6] relative top-[0.05em] text-[14px]">{`${offer.fee}%`}</span>
-                                    </span>
-                                    <span className="flex flex-row items-center gap-2">
-                                        <RewardsIcon />
-                                        <span className="font-mono leading-[1.6] relative top-[0.05em] text-[14px]">{offer.rewards}</span>
-                                    </span>
+                            <ProviderIcon />
+                        </span>
+                        <span className="flex flex-col gap-2">
+                            <span className="flex flex-row items-center gap-2">
+                                <span className={`${disabled ? 'text-[var(--color-white-3)]' : ''}`}>{offer.name}</span>
+                                <Popover>
+                                    <PopoverTrigger asChild onClick={(e) => e.stopPropagation()}>
+                                        <InfoIcon />
+                                    </PopoverTrigger>
+                                    <PopoverContent className="flex flex-col w-[360px] bg-[var(--color-slate-2)] p-0 max-h-[500px] overflow-y-auto">
+                                        <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px] sticky top-0 bg-[var(--color-slate-2)] border-b border-[var(--slate-dividers)]">
+                                            About Client Share
+                                        </span>
+                                        <div className="flex flex-col gap-4 p-[12px_16px]">
+                                            <div className="flex flex-col gap-1">
+                                                <span className="font-medium text-[var(--color-white-1)]">Client Share</span>
+                                                <span className="text-[13px] text-[var(--color-white-3)]">
+                                                    The share of the rewards you will receive from this plan.
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </PopoverContent>
+                                </Popover>
+                            </span>
+                            <span className="flex flex-row items-center gap-4 text-[14px]">
+                                <span className={`${disabled ? 'text-[var(--color-white-3)]' : ''}`}>
+                                    Performance: {offer.rewards}
                                 </span>
-                            )}
-                            {!disabled && isSelected && (
-                                <span className="flex flex-row items-center gap-4 text-[var(--color-white-2)]">
-                                    <span className="flex flex-row items-center gap-2">
-                                        <FeeIcon />
-                                        <span className="font-mono leading-[1.6] relative top-[0.05em] text-[14px]">{`${offer.fee}%`}</span>
-                                    </span>
-                                    <span className="flex flex-row items-center gap-2">
-                                        <RewardsIcon />
-                                        <span className="font-mono leading-[1.6] relative top-[0.05em] text-[14px]">{offer.rewards}</span>
-                                    </span>
+                                <span className={`${disabled ? 'text-[var(--color-white-3)]' : ''}`}>
+                                    Plans: {offer.addressGroups.length}
                                 </span>
-                            )}
-                            {disabled && (
-                                <span className="flex flex-row items-center gap-4 text-[var(--color-white-3)]">
-                                    <span className="flex flex-row items-center gap-2">
-                                        <FeeDisabledIcon />
-                                        <span className="font-mono leading-[1.6] relative top-[0.05em] text-[14px]">{`${offer.fee}%`}</span>
-                                    </span>
-                                    <span className="flex flex-row items-center gap-2">
-                                        <RewardsDisabledIcon />
-                                        <span className="font-mono leading-[1.6] relative top-[0.05em] text-[14px]">{offer.rewards}</span>
-                                    </span>
-                                </span>
-                            )}
+                            </span>
                         </span>
                     </span>
-                </span>
-                {isSelected && (
-                    <span>
-                        <CheckIcon />
+                    <span className={`transition-transform ${isExpanded ? 'rotate-90' : ''}`}>
+                        <CaretIcon />
                     </span>
+                </div>
+
+                {/* Address Groups (Plans) */}
+                {isExpanded && (
+                    <div className="flex flex-col border-t border-[var(--black-dividers)]">
+                        {sortedAddressGroups.map((addressGroup, index) => {
+                            const shares = calculateShares(addressGroup, delegatorFee)
+                            const isSelected = addressGroup.id === selectedAddressGroupId
+                            const servicesCount = addressGroup.addressGroupServices?.length || 0
+
+                            return (
+                                <div
+                                    key={addressGroup.id}
+                                    className={`flex flex-col p-[16px_25px] overflow-visible ${index !== sortedAddressGroups.length - 1 ? 'border-b border-[var(--black-dividers)]' : ''} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--color-slate-2)]'} ${isSelected ? 'bg-[var(--color-slate-2)]' : ''}`}
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        if (!disabled && onSelectAddressGroup) {
+                                            onSelectAddressGroup(offer, addressGroup.id)
+                                        }
+                                    }}
+                                >
+                                    <div className="flex flex-row items-center justify-between overflow-visible">
+                                        <span className="flex flex-row items-center gap-2 overflow-visible">
+                                            <span className="font-medium">{addressGroup.name}</span>
+                                            {addressGroup.linkedAddresses && addressGroup.linkedAddresses.length > 0 && addressGroup.linkedAddresses.some((addr: string) => addr.toLowerCase() === userIdentity.toLowerCase()) && (
+                                                <span className="flex flex-row items-center gap-1.5">
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild onClick={(e) => e.stopPropagation()}>
+                                                            <span className="px-2 py-0.5 text-[11px] font-medium bg-purple-500/20 text-purple-300 rounded">
+                                                                Personal
+                                                            </span>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent className="flex flex-col w-[260px] bg-[var(--color-slate-2)] p-0 border-2 border-[var(--black-dividers)] shadow-[0_8px_16px_rgba(0,0,0,0.4)]">
+                                                            <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px]">
+                                                                Personal Plan
+                                                            </span>
+                                                            <div className="h-[1px] bg-[var(--slate-dividers)]"></div>
+                                                            <span className="text-[13px] text-[var(--color-white-3)] p-[12px_16px]">
+                                                                This plan is exclusively available to you based on your selected owner address being linked to this provider's plan. Other users cannot stake to this plan.
+                                                            </span>
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                </span>
+                                            )}
+                                            <span className="text-[var(--color-white-3)] -ml-2">:</span>
+                                            <span className="flex flex-row items-center gap-1.5 text-[14px] mt-0.5">
+                                                <span className="text-[var(--color-white-3)]">Client Share:</span>
+                                                <span className="font-mono">{shares.clientShare.toFixed(1)}%</span>
+                                            </span>
+                                        </span>
+                                        <div className="flex flex-row items-center gap-3">
+                                            <ServicesPopover
+                                                addressGroupName={addressGroup.name}
+                                                services={addressGroup.addressGroupServices}
+                                                servicesCount={servicesCount}
+                                                triggerClassName="text-[14px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer"
+                                                delegatorFee={delegatorFee}
+                                            />
+                                            <span className="w-5 h-5 flex items-center justify-center">
+                                                {isSelected && <CheckIcon />}
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            )
+                        })}
+                    </div>
                 )}
             </div>
         </div>
-    );
+    )
 }

--- a/apps/middleman/src/app/app/stake/components/PickOfferStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/PickOfferStep/index.tsx
@@ -9,31 +9,39 @@ import {ProviderOfferItem} from "@/app/app/stake/components/PickOfferStep/Provid
 import {CaretIcon} from "@igniter/ui/assets";
 import {CalculateStakeDistribution} from "@/actions/Stake";
 import {ActivityContentLoading} from "@/app/app/stake/components/ActivityContentLoading";
+import {getApplicationSettings} from "@/actions/ApplicationSettings";
+import {ProviderStatus} from "@igniter/db/middleman/enums";
 
 export interface PickOfferStepProps {
     amount: number;
     ownerAddress: string;
     defaultOffer?: StakeDistributionOffer;
-    onOfferSelected: (offer: StakeDistributionOffer) => void;
+    defaultAddressGroupId?: number;
+    preselectedProviderId?: number;
+    preselectedAddressGroupId?: number;
+    onOfferSelected: (offer: StakeDistributionOffer, addressGroupId: number) => void;
     onBack: () => void;
     onClose: () => void;
 }
 
-export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, defaultOffer, onClose}: Readonly<PickOfferStepProps>) {
+export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, defaultOffer, defaultAddressGroupId, preselectedProviderId, preselectedAddressGroupId, onClose}: Readonly<PickOfferStepProps>) {
     const [selectedOffer, setSelectedOffer] = useState<StakeDistributionOffer | undefined>(defaultOffer);
+    const [selectedAddressGroupId, setSelectedAddressGroupId] = useState<number | undefined>(defaultAddressGroupId);
+    const [hasAppliedPreselection, setHasAppliedPreselection] = useState(false);
     const [isShowingUnavailable, setIsShowingUnavailable] = useState<boolean>(false);
     const [offers, setOffers] = useState<StakeDistributionOffer[]>([]);
     const [isLoadingOffers, setIsLoadingOffers] = useState<boolean>(false);
+    const [delegatorFee, setDelegatorFee] = useState<number>(0);
 
     {/* TODO: Calculate the amount based on POKT. Using the function provided by currency context. Show the currency from the context. */}
     const subtitle = `Pick a node runner for your ${toCurrencyFormat(amount)} $POKT stake.`;
 
     const availableOffers = useMemo(() => {
-        return offers.filter((offer) => offer.stakeDistribution.length > 0);
+        return offers.filter((offer) => offer.stakeDistribution.length > 0 && offer.status === ProviderStatus.Healthy);
     }, [offers]);
 
     const unavailableOffers = useMemo(() => {
-        return offers.filter((offer) => offer.stakeDistribution.length === 0);
+        return offers.filter((offer) => offer.stakeDistribution.length === 0 || offer.status !== ProviderStatus.Healthy);
     }, [offers]);
 
     const hasUnavailableOffers = useMemo(() => {
@@ -41,24 +49,75 @@ export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, de
     }, [unavailableOffers])
 
     const selectableOffers = useMemo(() => {
-        return offers.filter((offer) => offer.stakeDistribution.length > 0);
+        return offers.filter((offer) => offer.stakeDistribution.length > 0 && offer.status === ProviderStatus.Healthy);
     }, [offers]);
 
+    const handleAddressGroupSelection = (offer: StakeDistributionOffer, addressGroupId: number) => {
+        setSelectedOffer(offer);
+        setSelectedAddressGroupId(addressGroupId);
+    };
+
     useEffect(() => {
-        if (!selectedOffer && selectableOffers.length) {
-            setSelectedOffer(offers[0]);
+        if (!selectedOffer && !selectedAddressGroupId && selectableOffers.length > 0) {
+            // Count total address groups across all providers
+            const totalAddressGroups = selectableOffers.reduce(
+                (total, offer) => total + offer.addressGroups.length,
+                0
+            );
+
+            // Only auto-select if there's exactly one address group across all providers
+            if (totalAddressGroups === 1) {
+                const firstOffer = selectableOffers[0];
+                const firstAddressGroup = firstOffer?.addressGroups[0];
+                if (firstOffer && firstAddressGroup) {
+                    setSelectedOffer(firstOffer);
+                    setSelectedAddressGroupId(firstAddressGroup.id);
+                }
+            }
         }
-    }, [offers, selectedOffer]);
+    }, [selectableOffers, selectedOffer, selectedAddressGroupId]);
 
     useEffect(() => {
         (async () => {
             setIsLoadingOffers(true);
             try {
-                const calculatedOffers = await CalculateStakeDistribution(amount, ownerAddress);
+                const [calculatedOffers, appSettings] = await Promise.all([
+                    CalculateStakeDistribution(amount, ownerAddress),
+                    getApplicationSettings(),
+                ]);
+
                 setOffers(calculatedOffers);
-                if (selectedOffer) {
-                    const updatedSelectedOffer = calculatedOffers.find((offer) => offer.id === selectedOffer.id && offer.stakeDistribution.length > 0);;
+                setDelegatorFee(appSettings.fee ? Number(appSettings.fee) : 0);
+
+                // Handle preselection from URL params (only on first load)
+                // Only preselect if the provider is healthy
+                if (!hasAppliedPreselection && preselectedProviderId && preselectedAddressGroupId) {
+                    const preselectedOffer = calculatedOffers.find(
+                        (offer) => offer.id === preselectedProviderId &&
+                                   offer.stakeDistribution.length > 0 &&
+                                   offer.status === ProviderStatus.Healthy
+                    );
+                    if (preselectedOffer) {
+                        const addressGroupExists = preselectedOffer.addressGroups.some(
+                            ag => ag.id === preselectedAddressGroupId
+                        );
+                        if (addressGroupExists) {
+                            setSelectedOffer(preselectedOffer);
+                            setSelectedAddressGroupId(preselectedAddressGroupId);
+                        }
+                    }
+                    setHasAppliedPreselection(true);
+                } else if (selectedOffer && selectedAddressGroupId) {
+                    const updatedSelectedOffer = calculatedOffers.find((offer) => offer.id === selectedOffer.id && offer.stakeDistribution.length > 0);
                     setSelectedOffer(updatedSelectedOffer);
+
+                    // Check if the selected address group still exists
+                    if (updatedSelectedOffer) {
+                        const addressGroupExists = updatedSelectedOffer.addressGroups.some(ag => ag.id === selectedAddressGroupId);
+                        if (!addressGroupExists) {
+                            setSelectedAddressGroupId(undefined);
+                        }
+                    }
                 }
             } catch (error) {
                 console.warn('An error occurred while calculating the stake distribution!');
@@ -71,7 +130,7 @@ export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, de
 
     return (
         <div
-            className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] p-[33px] rounded-b-[12px] gap-8">
+            className="flex flex-col w-[580px] border-x border-b border-[--balck-deviders] p-[33px] rounded-b-[12px] gap-8">
             <ActivityHeader
                 onClose={onClose}
                 onBack={onBack}
@@ -83,15 +142,33 @@ export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, de
               <ActivityContentLoading />
             )}
 
+            {!isLoadingOffers && offers.length === 0 && (
+                <div className="flex items-center justify-center pt-12 pb-6">
+                    <span className="text-[14px] text-[var(--color-white-3)]">
+                        No providers available at this time.
+                    </span>
+                </div>
+            )}
+
             <div className="flex flex-col gap-3">
                 {availableOffers.map((offer) => (
                     <ProviderOfferItem
                         key={offer.id}
                         offer={offer}
-                        isSelected={selectedOffer?.id === offer.id}
-                        onSelect={() => setSelectedOffer(offer)}
+                        selectedAddressGroupId={selectedOffer?.id === offer.id ? selectedAddressGroupId : undefined}
+                        onSelectAddressGroup={handleAddressGroupSelection}
+                        delegatorFee={delegatorFee}
+                        userIdentity={ownerAddress}
                     />
                 ))}
+
+                {hasUnavailableOffers && (
+                  <div className="-mb-2 p-[11px_16px] bg-[var(--color-slate-2)] rounded-[8px]">
+                    <span className="text-[14px] text-[var(--color-white-3)]">
+                        Some providers are ineligible for the selected stake amount or are currently unavailable.
+                    </span>
+                  </div>
+                )}
             </div>
 
             {hasUnavailableOffers && !isShowingUnavailable && (
@@ -113,20 +190,14 @@ export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, de
             )}
 
             {hasUnavailableOffers && isShowingUnavailable && (
-                <div className="-mb-4.5 p-[11px_16px] bg-[var(--color-slate-2)] rounded-[8px]">
-                    <span className="text-[14px] text-[var(--color-white-3)]">
-                        Some providers are ineligible for the selected stake amount.
-                    </span>
-                </div>
-            )}
-
-            {hasUnavailableOffers && isShowingUnavailable && (
                 <div className="flex flex-col gap-3">
                     {unavailableOffers.map((offer) => (
                         <ProviderOfferItem
                             key={offer.id}
                             offer={offer}
                             disabled={true}
+                            delegatorFee={delegatorFee}
+                            userIdentity={ownerAddress}
                         />
                     ))}
                 </div>
@@ -134,8 +205,8 @@ export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, de
 
             <Button
                 className="w-full h-[40px]"
-                disabled={!selectedOffer}
-                onClick={() => onOfferSelected(selectedOffer!)}
+                disabled={!selectedOffer || !selectedAddressGroupId}
+                onClick={() => onOfferSelected(selectedOffer!, selectedAddressGroupId!)}
             >
                 Continue
             </Button>

--- a/apps/middleman/src/app/app/stake/components/PickOfferStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/PickOfferStep/index.tsx
@@ -86,6 +86,23 @@ export function PickOfferStep({onOfferSelected, amount, ownerAddress, onBack, de
                     getApplicationSettings(),
                 ]);
 
+                if (preselectedAddressGroupId && preselectedProviderId) {
+                    const preselectedOffer = calculatedOffers.find(
+                      (offer) => offer.id === preselectedProviderId &&
+                        offer.stakeDistribution.length > 0 &&
+                        offer.status === ProviderStatus.Healthy
+                    );
+                    if (preselectedOffer) {
+                        const addressGroupExists = preselectedOffer.addressGroups.some(
+                          ag => ag.id === preselectedAddressGroupId
+                        );
+                        if (addressGroupExists) {
+                            onOfferSelected(preselectedOffer, preselectedAddressGroupId)
+                            return
+                        }
+                    }
+                }
+
                 setOffers(calculatedOffers);
                 setDelegatorFee(appSettings.fee ? Number(appSettings.fee) : 0);
 

--- a/apps/middleman/src/app/app/stake/components/PickStakeAmountStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/PickStakeAmountStep/index.tsx
@@ -51,7 +51,7 @@ export function PickStakeAmountStep({onAmountSelected, defaultAmount, ownerAddre
 
     return (
         <div
-            className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
+            className="flex flex-col w-[580px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
             <ActivityHeader
                 title="Stake"
                 subtitle={`Use the slider below to pick an amount to stake. The minimum stake is ${toCurrencyFormat(minimumStake)} $POKT.`}

--- a/apps/middleman/src/app/app/stake/components/PlanDetailsSection.tsx
+++ b/apps/middleman/src/app/app/stake/components/PlanDetailsSection.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ShareCalculation } from '@/lib/utils/shareCalculations';
+import { ServicesPopover } from './ServicesPopover';
+
+type AddressGroupService = {
+  addSupplierShare: boolean;
+  supplierShare: number;
+  revShare?: Array<{
+    address: string;
+    share: number;
+  }>;
+  service: {
+    name: string;
+  };
+};
+
+export interface PlanDetailsSectionProps {
+  addressGroupName: string;
+  services: AddressGroupService[];
+  shares: ShareCalculation;
+  className?: string;
+  delegatorFee?: number;
+}
+
+export function PlanDetailsSection({
+  addressGroupName,
+  services,
+  shares,
+  className = '',
+  delegatorFee = 0,
+}: PlanDetailsSectionProps) {
+  const servicesCount = services.length;
+
+  return (
+    <span
+      className={`flex flex-row items-center justify-between px-4 py-3 bg-[var(--color-slate-2)] border-b border-[var(--black-dividers)] ${className}`}
+    >
+      <div className="flex flex-row items-center gap-2 text-[13px]">
+        <span className="text-[var(--color-white-3)]">Client Share:</span>
+        <span className="font-mono text-[var(--color-white-1)] mt-1.5">
+          {shares.clientShare.toFixed(1)}%
+        </span>
+      </div>
+      <ServicesPopover
+        addressGroupName={addressGroupName}
+        services={services}
+        servicesCount={servicesCount}
+        triggerClassName="text-[13px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer"
+        delegatorFee={delegatorFee}
+      />
+    </span>
+  );
+}

--- a/apps/middleman/src/app/app/stake/components/PlanDetailsSection.tsx
+++ b/apps/middleman/src/app/app/stake/components/PlanDetailsSection.tsx
@@ -2,6 +2,7 @@
 
 import { ShareCalculation } from '@/lib/utils/shareCalculations';
 import { ServicesPopover } from './ServicesPopover';
+import React from 'react'
 
 type AddressGroupService = {
   addSupplierShare: boolean;
@@ -33,22 +34,24 @@ export function PlanDetailsSection({
   const servicesCount = services.length;
 
   return (
-    <span
-      className={`flex flex-row items-center justify-between px-4 py-3 bg-[var(--color-slate-2)] border-b border-[var(--black-dividers)] ${className}`}
-    >
-      <div className="flex flex-row items-center gap-2 text-[13px]">
-        <span className="text-[var(--color-white-3)]">Client Share:</span>
-        <span className="font-mono text-[var(--color-white-1)] mt-1.5">
+    <>
+      <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
+        <span className="text-[14px] text-[var(--color-white-3)]">Client Share</span>
+        <span className="text-[14px] font-mono text-[var(--color-white-1)] mt-[4px]">
           {shares.clientShare.toFixed(1)}%
         </span>
-      </div>
-      <ServicesPopover
-        addressGroupName={addressGroupName}
-        services={services}
-        servicesCount={servicesCount}
-        triggerClassName="text-[13px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer"
-        delegatorFee={delegatorFee}
-      />
-    </span>
+      </span>
+      <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)] text-[14px]">
+        <span className="text-[14px] text-[var(--color-white-3)]">Services</span>
+        <ServicesPopover
+          addressGroupName={addressGroupName}
+          services={services}
+          servicesCount={servicesCount}
+          triggerClassName="text-[13px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer"
+          delegatorFee={delegatorFee}
+          larger={false}
+        />
+      </span>
+    </>
   );
 }

--- a/apps/middleman/src/app/app/stake/components/ReviewStep/StakingProcess.tsx
+++ b/apps/middleman/src/app/app/stake/components/ReviewStep/StakingProcess.tsx
@@ -35,6 +35,7 @@ export interface StakingProcessProps {
   onStakeCompleted: (result: StakingProcessStatus, transaction?: DbTransaction) => void;
   onSuppliersReceived: (suppliers: SupplierStake[]) => void;
   disabled?: boolean
+  selectedAddressGroupId: number
 }
 
 enum StakingProcessStep {
@@ -44,7 +45,7 @@ enum StakingProcessStep {
   Completed
 }
 
-export function StakingProcess({offer, onStakeCompleted, ownerAddress, region, onSuppliersReceived, disabled}: Readonly<StakingProcessProps>) {
+export function StakingProcess({offer, onStakeCompleted, ownerAddress, region, onSuppliersReceived, disabled, selectedAddressGroupId}: Readonly<StakingProcessProps>) {
   const [open, setOpen] = useState(false);
   const [isCancellable, setIsCancellable] = useState<boolean>(true);
   const [stakingStatus, setStakingStatus] = useState<StakingProcessStatus>({
@@ -66,7 +67,7 @@ export function StakingProcess({offer, onStakeCompleted, ownerAddress, region, o
         return;
       }
       try {
-        const suppliers = await requestSuppliers(offer, settings!, ownerAddress, region);
+        const suppliers = await requestSuppliers(selectedAddressGroupId, offer, settings!, ownerAddress, region);
 
         const stakeTransactions: TransactionMessage[] = suppliers.map((supplier) => {
           return {

--- a/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
@@ -2,36 +2,39 @@
 
 import type { SupplierStake, TransactionMessage } from '@/lib/models/Transactions'
 import { useQuery } from '@tanstack/react-query'
-import {ActivityHeader} from "@igniter/ui/components/ActivityHeader";
+import { ActivityHeader } from '@igniter/ui/components/ActivityHeader'
 import { useWalletConnection } from '@igniter/ui/context/WalletConnection/index'
 import { Skeleton } from '@igniter/ui/components/skeleton'
 import { Button } from '@igniter/ui/components/button'
 import { GetSupplierStakingFee, SimulateFee } from '@/actions/Blockchain'
 import { requestSuppliers } from '@/lib/services/provider'
-import {StakeDistributionOffer} from "@/lib/models/StakeDistributionOffer";
+import { StakeDistributionOffer } from '@/lib/models/StakeDistributionOffer'
 import { getShortAddress, toCurrencyFormat } from '@igniter/ui/lib/utils'
-import {QuickInfoPopOverIcon} from "@igniter/ui/components/QuickInfoPopOverIcon";
-import {CaretSmallIcon, CornerIcon} from "@igniter/ui/assets";
-import {useMemo, useState} from "react"
-import {useApplicationSettings} from "@/app/context/ApplicationSettings";
-import {StakingProcess, StakingProcessStatus} from "@/app/app/stake/components/ReviewStep/StakingProcess";
-import {Transaction} from "@igniter/db/middleman/schema";
-import React from "react";
+import { QuickInfoPopOverIcon } from '@igniter/ui/components/QuickInfoPopOverIcon'
+import { CaretSmallIcon, CornerIcon } from '@igniter/ui/assets'
+import React, { useMemo, useState } from 'react'
+import { useApplicationSettings } from '@/app/context/ApplicationSettings'
+import { StakingProcess, StakingProcessStatus } from '@/app/app/stake/components/ReviewStep/StakingProcess'
+import { Transaction } from '@igniter/db/middleman/schema'
 import AvatarByString from '@igniter/ui/components/AvatarByString'
+import { calculateShares } from '@/lib/utils/shareCalculations'
+import { PlanDetailsSection } from '@/app/app/stake/components/PlanDetailsSection'
 
 function useSimulateFee(
   selectedOffer: StakeDistributionOffer,
+  selectedAddressGroupId: number,
   ownerAddress: string,
 ) {
     const {getPublicKey} = useWalletConnection()
     const settings = useApplicationSettings();
 
     return useQuery({
-        queryKey: ['simulate-fee', selectedOffer, ownerAddress],
+        queryKey: ['simulate-fee', selectedOffer, selectedAddressGroupId, ownerAddress],
         queryFn: async () => {
             const pubKey = await getPublicKey(ownerAddress)
 
             const suppliers = await requestSuppliers(
+              selectedAddressGroupId,
               selectedOffer,
               settings!,
               ownerAddress,
@@ -94,6 +97,7 @@ function useBalance(ownerAddress: string) {
 
 function useBalanceAndNetworkFee(
   selectedOffer: StakeDistributionOffer,
+  selectedAddressGroupId: number,
   ownerAddress: string,
   amount: number,
 ) {
@@ -102,7 +106,7 @@ function useBalanceAndNetworkFee(
         isLoading: isLoadingSimulateFee,
         isError: errorSimulateFee,
         refetch: refetchSimulateFee,
-    } = useSimulateFee(selectedOffer, ownerAddress)
+    } = useSimulateFee(selectedOffer, selectedAddressGroupId, ownerAddress)
     const {
         data: stakeSupplierFee,
         isLoading: isLoadingStakeSupplierFee,
@@ -148,6 +152,7 @@ function useBalanceAndNetworkFee(
 export interface ReviewStepProps {
     amount: number;
     selectedOffer: StakeDistributionOffer;
+    selectedAddressGroupId: number;
     errorMessage?: string;
     ownerAddress: string;
     onStakeCompleted: (status: StakingProcessStatus, transaction?: Transaction) => void;
@@ -156,7 +161,7 @@ export interface ReviewStepProps {
     onClose: () => void;
 }
 
-export function ReviewStep({onStakeCompleted, amount, selectedOffer, ownerAddress, errorMessage, onSuppliersReceived, onBack, onClose}: Readonly<ReviewStepProps>) {
+export function ReviewStep({onStakeCompleted, amount, selectedOffer, selectedAddressGroupId, ownerAddress, errorMessage, onSuppliersReceived, onBack, onClose}: Readonly<ReviewStepProps>) {
     const {
         isLoadingFee,
         errorFee,
@@ -169,12 +174,17 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, ownerAddres
         balanceCoversTotal
     } = useBalanceAndNetworkFee(
       selectedOffer,
+      selectedAddressGroupId,
       ownerAddress,
       amount,
     )
 
     const [isShowingTransactionDetails, setIsShowingTransactionDetails] = useState<boolean>(false);
     const applicationSettings = useApplicationSettings();
+
+    const selectedAddressGroup = selectedOffer.addressGroups.find(ag => ag.id === selectedAddressGroupId);
+    const delegatorFee = applicationSettings?.fee ? Number(applicationSettings.fee) : 0;
+    const shares = selectedAddressGroup ? calculateShares(selectedAddressGroup, delegatorFee) : null;
 
     const prospectTransactions = useMemo(() => {
         return selectedOffer.stakeDistribution.reduce<number[]>((txs, stakeDistribution) => {
@@ -191,7 +201,7 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, ownerAddres
 
     return (
         <div
-            className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
+            className="flex flex-col w-[580px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
             <ActivityHeader
                 onBack={onBack}
                 onClose={onClose}
@@ -376,21 +386,6 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, ownerAddres
                     </span>
                 </div>
                 <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
-                    <span className="flex flex-row items-center gap-2 text-[14px] text-[var(--color-white-3)]">
-                        <span>
-                            Provider Fee
-                        </span>
-                        <QuickInfoPopOverIcon
-                            title="Provider Fee"
-                            description="The % of the rewards that the node operator retain for providing the service."
-                            url={''}
-                        />
-                    </span>
-                    <span className="text-[14px] text-[var(--color-white-1)]">
-                        {selectedOffer.fee}%
-                    </span>
-                </span>
-                <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
                     <span className="text-[14px] text-[var(--color-white-3)]">
                         Provider
                     </span>
@@ -398,6 +393,24 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, ownerAddres
                         {selectedOffer.name}
                     </span>
                 </span>
+                {selectedAddressGroup && shares && (
+                    <>
+                        <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
+                            <span className="text-[14px] text-[var(--color-white-3)]">
+                                Plan
+                            </span>
+                            <span className="text-[14px] text-[var(--color-white-1)]">
+                                {selectedAddressGroup.name}
+                            </span>
+                        </span>
+                        <PlanDetailsSection
+                            addressGroupName={selectedAddressGroup.name}
+                            services={selectedAddressGroup.addressGroupServices}
+                            shares={shares}
+                            delegatorFee={delegatorFee}
+                        />
+                    </>
+                )}
                 {/*TODO: Only show this when there are more than one connected identity? or when the owner address is different than the connected identity signed in?*/}
                 <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
                     <span className="text-[14px] text-[var(--color-white-3)]">
@@ -464,6 +477,7 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, ownerAddres
               offer={selectedOffer}
               onStakeCompleted={onStakeCompleted}
               onSuppliersReceived={onSuppliersReceived}
+              selectedAddressGroupId={selectedAddressGroupId}
             />
         </div>
     );

--- a/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
@@ -159,9 +159,10 @@ export interface ReviewStepProps {
     onSuppliersReceived: (suppliers: SupplierStake[]) => void;
     onBack: () => void;
     onClose: () => void;
+    ownerWasPreselected?: boolean;
 }
 
-export function ReviewStep({onStakeCompleted, amount, selectedOffer, selectedAddressGroupId, ownerAddress, errorMessage, onSuppliersReceived, onBack, onClose}: Readonly<ReviewStepProps>) {
+export function ReviewStep({onStakeCompleted, amount, selectedOffer, selectedAddressGroupId, ownerAddress, errorMessage, onSuppliersReceived, onBack, onClose, ownerWasPreselected}: Readonly<ReviewStepProps>) {
     const {
         isLoadingFee,
         errorFee,
@@ -412,17 +413,25 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, selectedAdd
                     </>
                 )}
                 {/*TODO: Only show this when there are more than one connected identity? or when the owner address is different than the connected identity signed in?*/}
-                <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
-                    <span className="text-[14px] text-[var(--color-white-3)]">
-                        Owner Address
-                    </span>
-                    <span className="flex flex-row items-center text-[14px] text-[var(--color-white-1)]">
-                        <AvatarByString string={ownerAddress} />
-                        <span className="ml-2 font-mono">
-                            {getShortAddress(ownerAddress, 5)}
+                <span className="flex flex-col px-4 py-3 border-b border-[var(--black-dividers)]">
+                    <span className="flex flex-row items-center w-full justify-between">
+                        <span className="text-[14px] text-[var(--color-white-3)]">
+                            Owner Address
+                        </span>
+                        <span className="flex flex-row items-center text-[14px] text-[var(--color-white-1)]">
+                            <AvatarByString string={ownerAddress} />
+                            <span className="ml-2 font-mono">
+                                {getShortAddress(ownerAddress, 5)}
+                            </span>
                         </span>
                     </span>
+                    {ownerWasPreselected && (
+                      <span className={'text-xs text-left text-purple-300 opacity-90'}>
+                        Preselected because the plan you chose is linked to this wallet.
+                      </span>
+                    )}
                 </span>
+
                 <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
                     <span className="flex flex-row items-center gap-2 hover:cursor-pointer" onClick={() => setIsShowingTransactionDetails(!isShowingTransactionDetails)}>
                         {isShowingTransactionDetails && (

--- a/apps/middleman/src/app/app/stake/components/ServicesPopover.tsx
+++ b/apps/middleman/src/app/app/stake/components/ServicesPopover.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@igniter/ui/components/popover';
+
+type AddressGroupService = {
+  addSupplierShare: boolean;
+  supplierShare: number;
+  revShare?: Array<{
+    address: string;
+    share: number;
+  }>;
+  service: {
+    name: string;
+  };
+};
+
+export interface ServicesPopoverProps {
+  addressGroupName: string;
+  services: AddressGroupService[];
+  servicesCount: number;
+  triggerClassName?: string;
+  onTriggerClick?: (e: React.MouseEvent) => void;
+  delegatorFee?: number;
+}
+
+export function ServicesPopover({
+  addressGroupName,
+  services,
+  servicesCount,
+  triggerClassName = "text-[14px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer",
+  onTriggerClick,
+  delegatorFee = 0,
+}: ServicesPopoverProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <span
+          className={triggerClassName}
+          onClick={(e) => {
+            e.stopPropagation();
+            onTriggerClick?.(e);
+          }}
+        >
+          Services: {servicesCount}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent className="flex flex-col w-[320px] bg-[var(--color-slate-2)] p-0 max-h-[500px] overflow-hidden border-2 border-[var(--black-dividers)] shadow-[0_8px_16px_rgba(0,0,0,0.4)]">
+        <div className="sticky top-0 bg-[var(--color-slate-2)] border-b border-[var(--slate-dividers)] z-10">
+          <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px] block">
+            Services for {addressGroupName}
+          </span>
+          <div className="grid grid-cols-[1fr_auto] gap-2 px-4 pb-2 text-[11px] text-[var(--color-white-3)] font-medium">
+            <span>Service</span>
+            <span className="text-right w-[70px]">Client</span>
+          </div>
+        </div>
+        <div className="flex flex-col overflow-y-auto">
+          {services.map((service, sIndex) => {
+            const totalProviderShare =
+              service.revShare?.reduce((sum, rev) => sum + rev.share, 0) || 0;
+            const supplierShare = service.addSupplierShare
+              ? service.supplierShare
+              : 0;
+            const clientShare = 100 - totalProviderShare - supplierShare - delegatorFee;
+
+            return (
+              <div
+                key={sIndex}
+                className={`grid grid-cols-[1fr_auto] gap-2 items-center px-4 py-2 ${
+                  sIndex !== services.length - 1
+                    ? 'border-b border-[var(--slate-dividers)]'
+                    : ''
+                }`}
+              >
+                <span
+                  className="text-[13px] text-[var(--color-white-1)] truncate"
+                  title={service.service.name}
+                >
+                  {service.service.name}
+                </span>
+                <span className="font-mono text-[13px] text-[var(--color-white-1)] text-right w-[70px]">
+                  {clientShare.toFixed(1)}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/middleman/src/app/app/stake/components/ServicesPopover.tsx
+++ b/apps/middleman/src/app/app/stake/components/ServicesPopover.tsx
@@ -21,13 +21,15 @@ export interface ServicesPopoverProps {
   triggerClassName?: string;
   onTriggerClick?: (e: React.MouseEvent) => void;
   delegatorFee?: number;
+  larger?: boolean
 }
 
 export function ServicesPopover({
   addressGroupName,
   services,
   servicesCount,
-  triggerClassName = "text-[14px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer",
+  larger = true,
+  triggerClassName = !larger ? 'flex flex-row items-center gap-2' : "text-[14px] text-[var(--color-white-3)] hover:text-[var(--color-white-1)] underline cursor-pointer",
   onTriggerClick,
   delegatorFee = 0,
 }: ServicesPopoverProps) {
@@ -41,17 +43,17 @@ export function ServicesPopover({
             onTriggerClick?.(e);
           }}
         >
-          Services: {servicesCount}
+          {larger ? `Services: ${servicesCount}` : servicesCount}
         </span>
       </PopoverTrigger>
-      <PopoverContent className="flex flex-col w-[320px] bg-[var(--color-slate-2)] p-0 max-h-[500px] overflow-hidden border-2 border-[var(--black-dividers)] shadow-[0_8px_16px_rgba(0,0,0,0.4)]">
+      <PopoverContent align={'center'} side={'top'} sideOffset={18} className="flex flex-col w-[320px] bg-[var(--color-slate-2)] p-0 max-h-[500px] overflow-hidden border-2 border-[var(--black-dividers)] shadow-[0_8px_16px_rgba(0,0,0,0.4)]">
         <div className="sticky top-0 bg-[var(--color-slate-2)] border-b border-[var(--slate-dividers)] z-10">
           <span className="text-[14px] font-medium text-[var(--color-white-1)] p-[12px_16px] block">
             Services for {addressGroupName}
           </span>
           <div className="grid grid-cols-[1fr_auto] gap-2 px-4 pb-2 text-[11px] text-[var(--color-white-3)] font-medium">
             <span>Service</span>
-            <span className="text-right w-[70px]">Client</span>
+            <span className="text-right w-[70px]">Client Share</span>
           </div>
         </div>
         <div className="flex flex-col overflow-y-auto">

--- a/apps/middleman/src/app/app/stake/components/StakeSuccessStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/StakeSuccessStep/index.tsx
@@ -13,18 +13,25 @@ import {StakeDistributionOffer} from "@/lib/models/StakeDistributionOffer";
 import Amount from '@igniter/ui/components/Amount'
 import { MessageType } from "@/lib/constants";
 import { Operation, SendOperation, StakeOperation } from '@/app/detail/TransactionDetail'
+import { calculateShares } from '@/lib/utils/shareCalculations'
+import { PlanDetailsSection } from '@/app/app/stake/components/PlanDetailsSection'
 
 export interface StakeSuccessProps {
     amount: number;
     selectedOffer: StakeDistributionOffer;
+    selectedAddressGroupId: number;
     transaction: Transaction;
     onClose: () => void;
 }
 
-export function StakeSuccessStep({amount, selectedOffer, transaction, onClose}: Readonly<StakeSuccessProps>) {
+export function StakeSuccessStep({amount, selectedOffer, selectedAddressGroupId, transaction, onClose}: Readonly<StakeSuccessProps>) {
     const [isShowingTransactionDetails, setIsShowingTransactionDetails] = useState<boolean>(false);
     const applicationSettings = useApplicationSettings();
     const [isRedirecting, setIsRedirecting] = useState<boolean>(false);
+
+    const selectedAddressGroup = selectedOffer.addressGroups.find(ag => ag.id === selectedAddressGroupId);
+    const delegatorFee = applicationSettings?.fee ? Number(applicationSettings.fee) : 0;
+    const shares = selectedAddressGroup ? calculateShares(selectedAddressGroup, delegatorFee) : null;
 
     const isViewReady = useMemo(() => {
         return amount && amount > 0 &&
@@ -51,7 +58,7 @@ export function StakeSuccessStep({amount, selectedOffer, transaction, onClose}: 
 
     return (
         <div
-            className="flex flex-col w-[480px] border-x border-b border-[--black-dividers] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
+            className="flex flex-col w-[580px] border-x border-b border-[--black-dividers] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
             <ActivityHeader
                 title="Scheduled!"
                 subtitle="Below are the details of your stake operation."
@@ -146,22 +153,6 @@ export function StakeSuccessStep({amount, selectedOffer, transaction, onClose}: 
                     </div>
                     <div key="stake-details"
                          className="flex flex-col p-0 rounded-[8px] border border-[var(--black-dividers)]">
-                    <span
-                        className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
-                    <span className="flex flex-row items-center gap-2 text-[14px] text-[var(--color-white-3)]">
-                        <span>
-                            Provider Fee
-                        </span>
-                        <QuickInfoPopOverIcon
-                            title="Provider Fee"
-                            description="The % of the rewards that the node operator retain for providing the service."
-                            url={''}
-                        />
-                    </span>
-                    <span className="text-[14px] text-[var(--color-white-1)]">
-                        {selectedOffer.fee}%
-                    </span>
-                </span>
                         <span
                             className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
                             <span className="text-[14px] text-[var(--color-white-3)]">
@@ -171,6 +162,24 @@ export function StakeSuccessStep({amount, selectedOffer, transaction, onClose}: 
                                 {selectedOffer.name}
                             </span>
                         </span>
+                        {selectedAddressGroup && shares && (
+                            <>
+                                <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
+                                    <span className="text-[14px] text-[var(--color-white-3)]">
+                                        Plan
+                                    </span>
+                                    <span className="text-[14px] text-[var(--color-white-1)]">
+                                        {selectedAddressGroup.name}
+                                    </span>
+                                </span>
+                                <PlanDetailsSection
+                                    addressGroupName={selectedAddressGroup.name}
+                                    services={selectedAddressGroup.addressGroupServices}
+                                    shares={shares}
+                                    delegatorFee={delegatorFee}
+                                />
+                            </>
+                        )}
                         <span
                             className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--black-dividers)]">
                             <span className="text-[14px] text-[var(--color-white-3)]">

--- a/apps/middleman/src/app/components/Sidebar.tsx
+++ b/apps/middleman/src/app/components/Sidebar.tsx
@@ -31,7 +31,7 @@ const mainRoutes = [
     icon: ActivityDark,
   },
   {
-    title: "Nodes",
+    title: "Suppliers",
     url: "/app/nodes",
     icon: NodesDark,
   },

--- a/apps/middleman/src/app/components/Sidebar.tsx
+++ b/apps/middleman/src/app/components/Sidebar.tsx
@@ -21,6 +21,11 @@ const mainRoutes = [
     icon: OverviewDark,
   },
   {
+    title: "Providers",
+    url: "/app/providers",
+    icon: ProvidersDark,
+  },
+  {
     title: "Transactions",
     url: "/app/transactions",
     icon: ActivityDark,

--- a/apps/middleman/src/app/detail/NodeDetail.tsx
+++ b/apps/middleman/src/app/detail/NodeDetail.tsx
@@ -79,7 +79,7 @@ export default function NodeDetail({
 
   const summaryRows: Array<SummaryRow> = [
     {
-      label: `Node`,
+      label: `Supplier`,
       value: <Address address={address} />,
     },
     {
@@ -166,10 +166,10 @@ export default function NodeDetail({
             fontWeight: 400,
           }}
         >
-          Node Detail
+          Supplier Detail
         </DrawerTitle>
         <DrawerDescription className={'text-sm'}>
-          Review the details of your node.
+          Review the details of your supplier.
         </DrawerDescription>
       </DrawerHeader>
       <div
@@ -201,7 +201,7 @@ export default function NodeDetail({
       {status === NodeStatus.Staked && (
         <div className={'bg-[color:var(--color-slate-2)] h-[109px] rounded-[8px]'}>
           <p className={'px-4 py-[11px] text-[color:var(--color-white-3)]'}>
-            Recoup your tokens by unstaking this node. Process can take up to{' '}
+            Recoup your tokens by unstaking this supplier. Process can take up to{' '}
             {unstakeDurationData ? (
               <span className="font-mono text-[var(--color-white-1)]">{formatDuration(unstakeDurationData.durationSeconds)}</span>
             ) : (

--- a/apps/middleman/src/lib/models/StakeDistributionOffer.ts
+++ b/apps/middleman/src/lib/models/StakeDistributionOffer.ts
@@ -1,4 +1,38 @@
-import {ProviderFee} from "@igniter/db/middleman/enums";
+import {ProviderFee, ProviderStatus} from "@igniter/db/middleman/enums";
+
+type AddressGroup = {
+  id: number;
+  name: string;
+  linkedAddresses: string[];
+  private: boolean;
+  relayMinerId: number;
+  keysCount: number;
+  relayMiner: {
+    id: number;
+    name: string;
+    identity: string;
+    regionId: number;
+    domain: string;
+    region: {
+      id: number;
+      displayName: string;
+      urlValue: string;
+    };
+  };
+  addressGroupServices: Array<{
+    addressGroupId: number;
+    serviceId: string;
+    addSupplierShare: boolean;
+    supplierShare: number;
+    revShare: Array<{
+      address: string;
+      share: number;
+    }>;
+    service: {
+      name: string;
+    };
+  }>;
+};
 
 export interface StakeDistributionOffer {
     id: number;
@@ -9,7 +43,9 @@ export interface StakeDistributionOffer {
     rewards: string;
     regions: string[];
     operationalFundsAmount: number;
+    status: ProviderStatus;
     stakeDistribution: StakeDistributionItem[];
+    addressGroups: AddressGroup[];
 }
 
 export interface StakeDistributionItem {

--- a/apps/middleman/src/lib/services/provider.ts
+++ b/apps/middleman/src/lib/services/provider.ts
@@ -2,7 +2,7 @@ import { StakeDistributionOffer } from "@/lib/models/StakeDistributionOffer";
 import {SupplierStake} from "@/lib/models/Transactions";
 import {ApplicationSettings} from "@igniter/db/middleman/schema";
 
-export async function requestSuppliers(stakeOffer: StakeDistributionOffer, settings: ApplicationSettings, ownerAddress: string, region: string = '', simulate = false): Promise<SupplierStake[]> {
+export async function requestSuppliers(selectedAddressGroupId: number, stakeOffer: StakeDistributionOffer, settings: ApplicationSettings, ownerAddress: string, region: string = '', simulate = false): Promise<SupplierStake[]> {
     try {
         const response = await fetch("/api/provider-rpc", {
             method: "POST",
@@ -14,6 +14,7 @@ export async function requestSuppliers(stakeOffer: StakeDistributionOffer, setti
                 path: `/api/suppliers?simulate=${simulate ?? false}`,
                 data: {
                     region,
+                    addressGroupId: selectedAddressGroupId,
                     delegatorAddress: settings.delegatorRewardsAddress,
                     revSharePercentage: Number(settings.fee),
                     items: stakeOffer.stakeDistribution,

--- a/apps/middleman/src/lib/utils/shareCalculations.ts
+++ b/apps/middleman/src/lib/utils/shareCalculations.ts
@@ -1,0 +1,74 @@
+type AddressGroupService = {
+  addSupplierShare: boolean;
+  supplierShare: number;
+  revShare?: Array<{
+    address: string;
+    share: number;
+  }>;
+};
+
+type AddressGroup = {
+  addressGroupServices: AddressGroupService[];
+};
+
+export interface ShareCalculation {
+  providerShare: number;
+  supplierShare: number;
+  delegatorShare: number;
+  clientShare: number;
+}
+
+/**
+ * Calculates the average share percentages for an address group
+ * @param addressGroup The address group with its services
+ * @param delegatorFee The delegator fee percentage
+ * @returns The calculated shares for client, provider, supplier, and delegator
+ */
+export function calculateShares(
+  addressGroup: AddressGroup,
+  delegatorFee: number
+): ShareCalculation {
+  const services = addressGroup.addressGroupServices || [];
+
+  if (services.length === 0) {
+    return {
+      providerShare: 0,
+      supplierShare: 0,
+      delegatorShare: delegatorFee,
+      clientShare: 100 - delegatorFee,
+    };
+  }
+
+  // Calculate average provider share (from revShare)
+  const totalProviderShare = services.reduce((sum: number, service: any) => {
+    const revShareTotal =
+      service.revShare?.reduce((acc: number, rev: any) => acc + rev.share, 0) ||
+      0;
+    return sum + revShareTotal;
+  }, 0);
+  const avgProviderShare = totalProviderShare / services.length;
+
+  // Calculate average supplier share (only where addSupplierShare is true)
+  const servicesWithSupplierShare = services.filter(
+    (s: any) => s.addSupplierShare
+  );
+  const totalSupplierShare = servicesWithSupplierShare.reduce(
+    (sum: number, service: any) => {
+      return sum + (service.supplierShare || 0);
+    },
+    0
+  );
+  const avgSupplierShare =
+    servicesWithSupplierShare.length > 0
+      ? totalSupplierShare / servicesWithSupplierShare.length
+      : 0;
+
+  const clientShare = 100 - avgProviderShare - avgSupplierShare - delegatorFee;
+
+  return {
+    providerShare: avgProviderShare,
+    supplierShare: avgSupplierShare,
+    delegatorShare: delegatorFee,
+    clientShare: Math.max(0, clientShare),
+  };
+}

--- a/apps/provider/drizzle/0011_clean_robin_chapel.sql
+++ b/apps/provider/drizzle/0011_clean_robin_chapel.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "application_settings" ADD COLUMN "rewardAddresses" varchar[];

--- a/apps/provider/drizzle/0012_empty_wendell_vaughn.sql
+++ b/apps/provider/drizzle/0012_empty_wendell_vaughn.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."chain_ids" ADD VALUE 'pocket-lego-testnet';

--- a/apps/provider/drizzle/meta/0011_snapshot.json
+++ b/apps/provider/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1193 @@
+{
+  "id": "4e2a5d61-fe40-447e-8422-9c6caeaffe26",
+  "prevId": "2f7df939-453c-42c3-9576-10dba891a6e4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.address_group_services": {
+      "name": "address_group_services",
+      "schema": "",
+      "columns": {
+        "address_group_id": {
+          "name": "address_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addSupplierShare": {
+          "name": "addSupplierShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supplierShare": {
+          "name": "supplierShare",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "revShare": {
+          "name": "revShare",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "address_group_services_address_group_id_address_groups_id_fk": {
+          "name": "address_group_services_address_group_id_address_groups_id_fk",
+          "tableFrom": "address_group_services",
+          "tableTo": "address_groups",
+          "columnsFrom": [
+            "address_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "address_group_services_service_id_services_serviceId_fk": {
+          "name": "address_group_services_service_id_services_serviceId_fk",
+          "tableFrom": "address_group_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "serviceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "address_group_services_address_group_id_service_id_pk": {
+          "name": "address_group_services_address_group_id_service_id_pk",
+          "columns": [
+            "address_group_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_groups": {
+      "name": "address_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "address_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedAddresses": {
+          "name": "linkedAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "relay_miner_id": {
+          "name": "relay_miner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "address_groups_relay_miner_id_relay_miners_id_fk": {
+          "name": "address_groups_relay_miner_id_relay_miners_id_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "relay_miners",
+          "columnsFrom": [
+            "relay_miner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "address_groups_createdBy_users_identity_fk": {
+          "name": "address_groups_createdBy_users_identity_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "address_groups_updatedBy_users_identity_fk": {
+          "name": "address_groups_updatedBy_users_identity_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appIdentity": {
+          "name": "appIdentity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supportEmail": {
+          "name": "supportEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerIdentity": {
+          "name": "ownerIdentity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerEmail": {
+          "name": "ownerEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "chain_ids",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialOperationalFunds": {
+          "name": "initialOperationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "minimumOperationalFunds": {
+          "name": "minimumOperationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "isBootstrapped": {
+          "name": "isBootstrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rpcUrl": {
+          "name": "rpcUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexerApiUrl": {
+          "name": "indexerApiUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewardAddresses": {
+          "name": "rewardAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAtHeight": {
+          "name": "updatedAtHeight",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_settings_createdBy_users_identity_fk": {
+          "name": "application_settings_createdBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "application_settings_updatedBy_users_identity_fk": {
+          "name": "application_settings_updatedBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delegators": {
+      "name": "delegators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "delegators_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegators_createdBy_users_identity_fk": {
+          "name": "delegators_createdBy_users_identity_fk",
+          "tableFrom": "delegators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delegators_updatedBy_users_identity_fk": {
+          "name": "delegators_updatedBy_users_identity_fk",
+          "tableFrom": "delegators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "delegators_identity_unique": {
+          "name": "delegators_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_unique": {
+          "name": "users_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "keys_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "address_states",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "remediationHistory": {
+          "name": "remediationHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegator_identity": {
+          "name": "delegator_identity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_group_id": {
+          "name": "address_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegatorRevSharePercentage": {
+          "name": "delegatorRevSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "lastUpdatedHeight": {
+          "name": "lastUpdatedHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "stakeOwner": {
+          "name": "stakeOwner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "stakeAmountUpokt": {
+          "name": "stakeAmountUpokt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "balanceUpokt": {
+          "name": "balanceUpokt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "services": {
+          "name": "services",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keys_delegator_identity_delegators_identity_fk": {
+          "name": "keys_delegator_identity_delegators_identity_fk",
+          "tableFrom": "keys",
+          "tableTo": "delegators",
+          "columnsFrom": [
+            "delegator_identity"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "keys_address_group_id_address_groups_id_fk": {
+          "name": "keys_address_group_id_address_groups_id_fk",
+          "tableFrom": "keys",
+          "tableTo": "address_groups",
+          "columnsFrom": [
+            "address_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "keys_address_unique": {
+          "name": "keys_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        },
+        "keys_publicKey_unique": {
+          "name": "keys_publicKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "regions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urlValue": {
+          "name": "urlValue",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "regions_createdBy_users_identity_fk": {
+          "name": "regions_createdBy_users_identity_fk",
+          "tableFrom": "regions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "regions_updatedBy_users_identity_fk": {
+          "name": "regions_updatedBy_users_identity_fk",
+          "tableFrom": "regions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "regions_displayName_unique": {
+          "name": "regions_displayName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "displayName"
+          ]
+        },
+        "regions_urlValue_unique": {
+          "name": "regions_urlValue_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "urlValue"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relay_miners": {
+      "name": "relay_miners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "relay_miners_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "unique_identity_region_idx": {
+          "name": "unique_identity_region_idx",
+          "columns": [
+            {
+              "expression": "identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "relay_miners_region_id_regions_id_fk": {
+          "name": "relay_miners_region_id_regions_id_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relay_miners_createdBy_users_identity_fk": {
+          "name": "relay_miners_createdBy_users_identity_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relay_miners_updatedBy_users_identity_fk": {
+          "name": "relay_miners_updatedBy_users_identity_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "services_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computeUnits": {
+          "name": "computeUnits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revSharePercentage": {
+          "name": "revSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoints": {
+          "name": "endpoints",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_createdBy_users_identity_fk": {
+          "name": "services_createdBy_users_identity_fk",
+          "tableFrom": "services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_updatedBy_users_identity_fk": {
+          "name": "services_updatedBy_users_identity_fk",
+          "tableFrom": "services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "services_serviceId_unique": {
+          "name": "services_serviceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serviceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_endpoints_not_empty": {
+          "name": "check_endpoints_not_empty",
+          "value": "json_array_length(endpoints) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.address_states": {
+      "name": "address_states",
+      "schema": "public",
+      "values": [
+        "imported",
+        "available",
+        "delivered",
+        "staking",
+        "remediation_failed",
+        "attention_needed",
+        "staked",
+        "stake_failed",
+        "unstaking",
+        "unstaked",
+        "missing_stake"
+      ]
+    },
+    "public.chain_ids": {
+      "name": "chain_ids",
+      "schema": "public",
+      "values": [
+        "pocket",
+        "pocket-beta",
+        "pocket-alpha"
+      ]
+    },
+    "public.provider_fee": {
+      "name": "provider_fee",
+      "schema": "public",
+      "values": [
+        "up_to",
+        "fixed"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider/drizzle/meta/0012_snapshot.json
+++ b/apps/provider/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1194 @@
+{
+  "id": "8567b546-e626-4bb7-8ed5-350737d12a58",
+  "prevId": "4e2a5d61-fe40-447e-8422-9c6caeaffe26",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.address_group_services": {
+      "name": "address_group_services",
+      "schema": "",
+      "columns": {
+        "address_group_id": {
+          "name": "address_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addSupplierShare": {
+          "name": "addSupplierShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supplierShare": {
+          "name": "supplierShare",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "revShare": {
+          "name": "revShare",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "address_group_services_address_group_id_address_groups_id_fk": {
+          "name": "address_group_services_address_group_id_address_groups_id_fk",
+          "tableFrom": "address_group_services",
+          "tableTo": "address_groups",
+          "columnsFrom": [
+            "address_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "address_group_services_service_id_services_serviceId_fk": {
+          "name": "address_group_services_service_id_services_serviceId_fk",
+          "tableFrom": "address_group_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "serviceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "address_group_services_address_group_id_service_id_pk": {
+          "name": "address_group_services_address_group_id_service_id_pk",
+          "columns": [
+            "address_group_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_groups": {
+      "name": "address_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "address_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedAddresses": {
+          "name": "linkedAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "relay_miner_id": {
+          "name": "relay_miner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "address_groups_relay_miner_id_relay_miners_id_fk": {
+          "name": "address_groups_relay_miner_id_relay_miners_id_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "relay_miners",
+          "columnsFrom": [
+            "relay_miner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "address_groups_createdBy_users_identity_fk": {
+          "name": "address_groups_createdBy_users_identity_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "address_groups_updatedBy_users_identity_fk": {
+          "name": "address_groups_updatedBy_users_identity_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appIdentity": {
+          "name": "appIdentity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supportEmail": {
+          "name": "supportEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerIdentity": {
+          "name": "ownerIdentity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerEmail": {
+          "name": "ownerEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "chain_ids",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialOperationalFunds": {
+          "name": "initialOperationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "minimumOperationalFunds": {
+          "name": "minimumOperationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "isBootstrapped": {
+          "name": "isBootstrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rpcUrl": {
+          "name": "rpcUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexerApiUrl": {
+          "name": "indexerApiUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewardAddresses": {
+          "name": "rewardAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAtHeight": {
+          "name": "updatedAtHeight",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_settings_createdBy_users_identity_fk": {
+          "name": "application_settings_createdBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "application_settings_updatedBy_users_identity_fk": {
+          "name": "application_settings_updatedBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delegators": {
+      "name": "delegators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "delegators_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegators_createdBy_users_identity_fk": {
+          "name": "delegators_createdBy_users_identity_fk",
+          "tableFrom": "delegators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delegators_updatedBy_users_identity_fk": {
+          "name": "delegators_updatedBy_users_identity_fk",
+          "tableFrom": "delegators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "delegators_identity_unique": {
+          "name": "delegators_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_unique": {
+          "name": "users_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "keys_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "address_states",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "remediationHistory": {
+          "name": "remediationHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegator_identity": {
+          "name": "delegator_identity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_group_id": {
+          "name": "address_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegatorRevSharePercentage": {
+          "name": "delegatorRevSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "lastUpdatedHeight": {
+          "name": "lastUpdatedHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "stakeOwner": {
+          "name": "stakeOwner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "stakeAmountUpokt": {
+          "name": "stakeAmountUpokt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "balanceUpokt": {
+          "name": "balanceUpokt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "services": {
+          "name": "services",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keys_delegator_identity_delegators_identity_fk": {
+          "name": "keys_delegator_identity_delegators_identity_fk",
+          "tableFrom": "keys",
+          "tableTo": "delegators",
+          "columnsFrom": [
+            "delegator_identity"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "keys_address_group_id_address_groups_id_fk": {
+          "name": "keys_address_group_id_address_groups_id_fk",
+          "tableFrom": "keys",
+          "tableTo": "address_groups",
+          "columnsFrom": [
+            "address_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "keys_address_unique": {
+          "name": "keys_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        },
+        "keys_publicKey_unique": {
+          "name": "keys_publicKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "regions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urlValue": {
+          "name": "urlValue",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "regions_createdBy_users_identity_fk": {
+          "name": "regions_createdBy_users_identity_fk",
+          "tableFrom": "regions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "regions_updatedBy_users_identity_fk": {
+          "name": "regions_updatedBy_users_identity_fk",
+          "tableFrom": "regions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "regions_displayName_unique": {
+          "name": "regions_displayName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "displayName"
+          ]
+        },
+        "regions_urlValue_unique": {
+          "name": "regions_urlValue_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "urlValue"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relay_miners": {
+      "name": "relay_miners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "relay_miners_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "unique_identity_region_idx": {
+          "name": "unique_identity_region_idx",
+          "columns": [
+            {
+              "expression": "identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "relay_miners_region_id_regions_id_fk": {
+          "name": "relay_miners_region_id_regions_id_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relay_miners_createdBy_users_identity_fk": {
+          "name": "relay_miners_createdBy_users_identity_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relay_miners_updatedBy_users_identity_fk": {
+          "name": "relay_miners_updatedBy_users_identity_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "services_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computeUnits": {
+          "name": "computeUnits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revSharePercentage": {
+          "name": "revSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoints": {
+          "name": "endpoints",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_createdBy_users_identity_fk": {
+          "name": "services_createdBy_users_identity_fk",
+          "tableFrom": "services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_updatedBy_users_identity_fk": {
+          "name": "services_updatedBy_users_identity_fk",
+          "tableFrom": "services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "services_serviceId_unique": {
+          "name": "services_serviceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serviceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_endpoints_not_empty": {
+          "name": "check_endpoints_not_empty",
+          "value": "json_array_length(endpoints) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.address_states": {
+      "name": "address_states",
+      "schema": "public",
+      "values": [
+        "imported",
+        "available",
+        "delivered",
+        "staking",
+        "remediation_failed",
+        "attention_needed",
+        "staked",
+        "stake_failed",
+        "unstaking",
+        "unstaked",
+        "missing_stake"
+      ]
+    },
+    "public.chain_ids": {
+      "name": "chain_ids",
+      "schema": "public",
+      "values": [
+        "pocket",
+        "pocket-beta",
+        "pocket-alpha",
+        "pocket-lego-testnet"
+      ]
+    },
+    "public.provider_fee": {
+      "name": "provider_fee",
+      "schema": "public",
+      "values": [
+        "up_to",
+        "fixed"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider/drizzle/meta/_journal.json
+++ b/apps/provider/drizzle/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1759980853731,
       "tag": "0010_typical_purple_man",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1769192678945,
+      "tag": "0011_clean_robin_chapel",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1769785666765,
+      "tag": "0012_empty_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider/src/actions/Delegators.ts
+++ b/apps/provider/src/actions/Delegators.ts
@@ -34,7 +34,8 @@ export async function UpdateDelegatorsFromSource() {
 
     const delegatorsCdnUrl = process.env.DELEGATORS_CDN_URL!.replace(
       '{chainId}',
-      appSettings.chainId,
+      // workaround until the repo has the file for this chain id
+      appSettings.chainId.replace('lego-testnet' ,'beta'),
     )
 
     if (!delegatorsCdnUrl) {

--- a/apps/provider/src/app/admin/(internal)/keys/export/ExportForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/export/ExportForm.tsx
@@ -53,8 +53,13 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
 
     setIsLoadingKeyCount(true);
     try {
-      const count = await CountKeysByAddressGroupAndState(Number(groupId), keyState);
-      setTotalKeysCount(count);
+      const result = await CountKeysByAddressGroupAndState(Number(groupId), keyState);
+
+      if (!result || !result.success) {
+        throw new Error('Failed to fetch keys count');
+      }
+
+      setTotalKeysCount(result.data);
     } catch (error) {
       console.error("Failed to fetch keys count:", error);
       setTotalKeysCount(null);
@@ -68,7 +73,13 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
 
     setStatus('loading')
     try {
-      const privateKeys = await GetKeysByAddressGroupAndState(Number(addressGroup), keyState);
+      const result = await GetKeysByAddressGroupAndState(Number(addressGroup), keyState);
+
+      if (!result || !result.success) {
+        throw new Error('Failed to fetch keys');
+      }
+
+      const privateKeys = result.data;
 
       const filename = `${addressesGroup.find((a) => a.id === parseInt(addressGroup))?.name}-keys-at-${new Date().toISOString().replace(/[:.]/g, '_')}.json`;
 

--- a/apps/provider/src/app/admin/(internal)/keys/import/ImportProcess.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/import/ImportProcess.tsx
@@ -126,7 +126,12 @@ export default function ImportProcess({file, addressGroupId, onImportCompleted}:
 
   const importKeys = async () => {
     try {
-      await ImportKeys(keys, parseInt(addressGroupId))
+      const result = await ImportKeys(keys, parseInt(addressGroupId))
+
+      if (!result.success) {
+        throw new Error(result.error.message);
+      }
+
       setImportStatus({
         validateFile: 'success',
         importKeys: 'success',

--- a/apps/provider/src/app/admin/setup/ConfigureAppSettings/index.tsx
+++ b/apps/provider/src/app/admin/setup/ConfigureAppSettings/index.tsx
@@ -15,6 +15,9 @@ import { Input } from "@igniter/ui/components/input";
 import React, {useMemo, useRef, useState} from "react";
 import { UpsertApplicationSettings } from "@/actions/ApplicationSettings";
 import type {ApplicationSettings} from "@igniter/db/provider/schema";
+import { Textarea } from '@igniter/ui/components/textarea'
+import { isPoktBech32Address } from '@/lib/crypto'
+import { cn } from '@igniter/ui/lib/utils'
 
 interface FormProps {
   defaultValues: Partial<ApplicationSettings>;
@@ -25,17 +28,39 @@ interface FormProps {
 export const FormSchema = z.object({
   name: z.string().min(1, "Name is required"),
   supportEmail: z.string().email().optional(),
+  rewardAddresses: z.string().refine((value) => {
+    if (!value) {
+      return true;
+    }
+
+    const lines = value.trim().split(/[\n,\s]+/);
+    const addresses = lines.map((line) => line.trim()).filter(isPoktBech32Address);
+
+    return addresses.length !== 0
+  }, 'There are no addresses in the list.')
+    .refine((value) => {
+      if (!value) {
+        return true;
+      }
+
+      const lines = value.trim().split(/[\n,\s]+/);
+      const addresses = lines.map((line) => line.trim()).filter(isPoktBech32Address);
+
+     return addresses.length === lines.length;
+  }, 'There are invalid addresses in the list.'),
 });
 
 type FormValues = z.infer<typeof FormSchema>;
 
 const FormComponent: React.FC<FormProps> = ({ defaultValues, goNext, goBack }) => {
+  console.log(defaultValues)
   const [isLoading, setIsLoading] = useState(false);
   const form = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
       name: defaultValues?.name || "",
       supportEmail: defaultValues?.supportEmail || "",
+      rewardAddresses: defaultValues?.rewardAddresses?.join("\n") || ""
     },
   });
 
@@ -51,10 +76,13 @@ const FormComponent: React.FC<FormProps> = ({ defaultValues, goNext, goBack }) =
       <Form {...form}>
         <form
           ref={formRef}
-          onSubmit={form.handleSubmit(async (values: any) => {
+          onSubmit={form.handleSubmit(async (values: FormValues) => {
             setIsLoading(true);
             try {
-              await UpsertApplicationSettings(values, isUpdate);
+              await UpsertApplicationSettings({
+                ...values,
+                rewardAddresses: values.rewardAddresses?.split(/[\n,\s]+/)?.filter(isPoktBech32Address) || []
+              }, isUpdate);
               goNext();
             } catch (error) {
               console.error(error);
@@ -89,6 +117,37 @@ const FormComponent: React.FC<FormProps> = ({ defaultValues, goNext, goBack }) =
                     <Input {...field} />
                   </FormControl>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              name="rewardAddresses"
+              control={form.control}
+              render={({ field, fieldState: {error} }) => (
+                <FormItem>
+                  <FormLabel>Reward Addresses</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      id="rewardAddresses"
+                      placeholder={`Enter one or more addresses (separated by new lines, commas, or spaces):
+
+pokt1abc123def456ghi789jkl012mno345pqr678stu
+pokt1xyz789abc123def456ghi789jkl012mno345pqr
+pokt1def456ghi789jkl012mno345pqr678stu901vwx`}
+                      {...field}
+                      className="min-h-[140px] max-h-[260px] font-mono !text-[12px] border-[color:--divider] bg-[color:--background] placeholder:text-[color:--secondary]"
+                    />
+                  </FormControl>
+                  <FormMessage className={cn(!error?.message ? 'text-xs! text-[color:var(--color-white-3)]' : null)}>
+                    {error?.message ? error.message : (
+                      <>
+                        Used by Delegators to fetch your rewards. These must match the revenue‑share address(es) you provided to suppliers to receive rewards in the addresses group.
+                        <br/>
+                        The Delegators are going to validate that the domains staked match the domains you are going to configure. If it does not match, your rewards are not going to be shown to the users that want to stake in the Delegators.
+                      </>
+                    )}
+                  </FormMessage>
                 </FormItem>
               )}
             />

--- a/apps/provider/src/lib/models/status.ts
+++ b/apps/provider/src/lib/models/status.ts
@@ -1,4 +1,5 @@
-import type { ProviderFee } from '@igniter/db/provider/schema';
+import { ProviderFee } from '@igniter/db/provider/enums'
+import { AddressGroupWithDetails } from '@igniter/db/provider/schema';
 
 export interface StatusRequest {}
 
@@ -12,4 +13,6 @@ export interface StatusResponse {
   domains: string[];
   regions: string[];
   healthy: boolean;
+  addressGroups: Array<AddressGroupWithDetails>
+  rewardAddresses: Array<string> | null
 }

--- a/apps/provider/src/lib/models/supplier.ts
+++ b/apps/provider/src/lib/models/supplier.ts
@@ -1,5 +1,6 @@
 export interface SupplierStakeRequest {
   region?: number;
+  addressGroupId: number;
   ownerAddress: string;
   revSharePercentage: number;
   delegatorAddress: string;

--- a/packages/db/src/middleman/schema/enums.ts
+++ b/packages/db/src/middleman/schema/enums.ts
@@ -42,6 +42,7 @@ export enum ChainId {
   Pocket = 'pocket',
   PocketBeta = 'pocket-beta',
   PocketAlpha = 'pocket-alpha',
+  PocketTestnet = 'pocket-lego-testnet',
 }
 
 /**

--- a/packages/db/src/middleman/schema/provider.ts
+++ b/packages/db/src/middleman/schema/provider.ts
@@ -1,6 +1,7 @@
 import {
   boolean,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -16,6 +17,39 @@ import { usersTable } from './users'
 import { nodesTable } from './node'
 import { transactionsTable } from './transaction'
 
+type AddressGroupsJson = Array<{
+  id: number;
+  name: string;
+  linkedAddresses: string[];
+  private: boolean;
+  relayMinerId: number;
+  keysCount: number;
+  relayMiner: {
+    id: number;
+    name: string;
+    identity: string;
+    regionId: number;
+    domain: string;
+    region: {
+      id: number;
+      displayName: string;
+      urlValue: string;
+    };
+  };
+  addressGroupServices: Array<{
+    addressGroupId: number;
+    serviceId: string;
+    addSupplierShare: boolean;
+    supplierShare: number;
+    revShare: Array<{
+      address: string;
+      share: number;
+    }>;
+    service: {
+      name: string;
+    };
+  }>;
+}>;
 
 export const providersTable = pgTable('providers', {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
@@ -33,6 +67,8 @@ export const providersTable = pgTable('providers', {
   status: providerStatusEnum().notNull().default(ProviderStatus.Unknown),
   minimumStake: integer().notNull().default(0),
   operationalFunds: integer().notNull().default(5),
+  addressGroups: jsonb('address_groups').$type<AddressGroupsJson>().default([]),
+  rewardAddresses: varchar().array(),
   createdAt: timestamp().defaultNow(),
   updatedAt: timestamp().defaultNow().$onUpdateFn(() => new Date()),
   createdBy: varchar().references(() => usersTable.identity).notNull(),

--- a/packages/db/src/provider/schema/application.ts
+++ b/packages/db/src/provider/schema/application.ts
@@ -24,6 +24,7 @@ import { chainIdEnum } from './enums'
  * - `isBootstrapped`: A boolean value indicating if the application is bootstrapped, required.
  * - `rpcUrl`: The RPC URL for application interaction, required.
  * - `indexerApiUrl`: The API URL for indexing services, optional.
+ * - `rewardAddresses`: Optional array of reward addresses for the application, stored as a string array. Used by Delegators to fetch provider rewards.
  * - `updatedAtHeight`: Optional field that tracks the blockchain height at the last update, stored as a string.
  * - `createdAt`: Timestamp indicating when the setting was created. Automatically set to the current time by default.
  * - `createdBy`: The identity of the user who created the application setting. It is required and references the `identity` field in the `users` table.
@@ -44,6 +45,7 @@ export const applicationSettingsTable = pgTable('application_settings', {
   isBootstrapped: boolean().notNull(),
   rpcUrl: varchar().notNull(),
   indexerApiUrl: varchar(),
+  rewardAddresses: varchar().array(),
   updatedAtHeight: varchar(),
   createdAt: timestamp().defaultNow(),
   createdBy: varchar({ length: 255 }).references(() => usersTable.identity).notNull(),

--- a/packages/db/src/provider/schema/enums.ts
+++ b/packages/db/src/provider/schema/enums.ts
@@ -44,6 +44,7 @@ export enum ChainId {
   Pocket = 'pocket',
   PocketBeta = 'pocket-beta',
   PocketAlpha = 'pocket-alpha',
+  PocketTestnet = 'pocket-lego-testnet',
 }
 
 /**

--- a/packages/ui/src/components/WalletPicker/index.tsx
+++ b/packages/ui/src/components/WalletPicker/index.tsx
@@ -501,6 +501,7 @@ function SignInStep({
           setStatus('auth-error')
         }
       } catch (e) {
+        console.log(e)
         if (e instanceof Error) {
           setStatus(e.message.includes('rejected') ? 'rejected' : 'error')
         } else {

--- a/packages/ui/src/context/WalletConnection/index.tsx
+++ b/packages/ui/src/context/WalletConnection/index.tsx
@@ -170,8 +170,16 @@ export const WalletConnectionProvider = ({
       setAllConnectedIdentities(connectedIdentities);
       setIsConnected(connection.isConnected);
       setConnection(connection);
-      setCookie(WALLET_COOKIE_KEY, providerInfo.connection.name)
-      setCookie(PROVIDER_COOKIE_KEY, providerInfo.name)
+
+      const cookieOptions = {
+        expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365 * 100),
+        secure: true,
+        sameSite: 'Lax'
+      } as const;
+
+      setCookie(WALLET_COOKIE_KEY, providerInfo.connection.name, cookieOptions)
+      setCookie(PROVIDER_COOKIE_KEY, providerInfo.name, cookieOptions)
+
       setAccountListener(providerInfo.provider)
 
       if (connectedIdentities.length === 1) {
@@ -181,6 +189,7 @@ export const WalletConnectionProvider = ({
       return connectedIdentities
     } catch (error) {
       console.error(error);
+      throw error;
     }
 
     return []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: link:../../packages/ui
       '@poktscan/vault-siwp':
         specifier: github:trustsoothe/vault-siwp#shannon-adr36
-        version: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/b08c22fd085a2f9f2f57e028208d9233f3a71e93
+        version: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/ae28086ebbf05441e7bd684431f7c71c193b554c
       '@radix-ui/react-slot':
         specifier: 1.1.1
         version: 1.1.1(@types/react@19.0.8)(react@19.0.1)
@@ -313,7 +313,7 @@ importers:
         version: link:../../packages/ui
       '@poktscan/vault-siwp':
         specifier: github:trustsoothe/vault-siwp#shannon
-        version: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/6abbf451fd4a0b71dce77e09c05f5892fdad2f4b
+        version: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/4d1d22e0add91604257424240fce681641c1df14
       '@stepperize/react':
         specifier: 5.0.1
         version: 5.0.1(react@19.0.1)
@@ -768,7 +768,7 @@ importers:
         version: 5.17.1(@emotion/react@11.14.0(@types/react@19.0.8)(react@19.0.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.0.8)(react@19.0.1))(@types/react@19.0.8)(react@19.0.1))(@types/react@19.0.8)(react@19.0.1)
       '@poktscan/vault-siwp':
         specifier: github:trustsoothe/vault-siwp#shannon-adr36
-        version: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/b08c22fd085a2f9f2f57e028208d9233f3a71e93
+        version: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/ae28086ebbf05441e7bd684431f7c71c193b554c
       '@radix-ui/react-avatar':
         specifier: 1.1.3
         version: 1.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
@@ -3299,12 +3299,12 @@ packages:
     resolution: {integrity: sha512-fw/a/4RldtN11PaF2lcatFB7PrZd2MeYlPh/sCs97JaMkvhv56R79rei/UVgTiwWoPWKIWwdbAhLwhUKqGkeVg==}
     engines: {node: '>=10'}
 
-  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/6abbf451fd4a0b71dce77e09c05f5892fdad2f4b':
-    resolution: {tarball: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/6abbf451fd4a0b71dce77e09c05f5892fdad2f4b}
+  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/4d1d22e0add91604257424240fce681641c1df14':
+    resolution: {tarball: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/4d1d22e0add91604257424240fce681641c1df14}
     version: 0.0.1
 
-  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/b08c22fd085a2f9f2f57e028208d9233f3a71e93':
-    resolution: {tarball: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/b08c22fd085a2f9f2f57e028208d9233f3a71e93}
+  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/ae28086ebbf05441e7bd684431f7c71c193b554c':
+    resolution: {tarball: https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/ae28086ebbf05441e7bd684431f7c71c193b554c}
     version: 0.0.1
 
   '@protobufjs/aspromise@1.1.2':
@@ -13803,7 +13803,7 @@ snapshots:
       '@tendermint/belt': 0.2.1
       '@tendermint/types': 0.1.1
 
-  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/6abbf451fd4a0b71dce77e09c05f5892fdad2f4b':
+  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/4d1d22e0add91604257424240fce681641c1df14':
     dependencies:
       '@cosmjs/encoding': 0.33.1
       '@noble/curves': 1.8.1
@@ -13812,7 +13812,7 @@ snapshots:
       hex-lite: 1.5.0
       valid-url: 1.0.9
 
-  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/b08c22fd085a2f9f2f57e028208d9233f3a71e93':
+  '@poktscan/vault-siwp@https://codeload.github.com/trustsoothe/vault-siwp/tar.gz/ae28086ebbf05441e7bd684431f7c71c193b554c':
     dependencies:
       '@cosmjs/amino': 0.33.1
       '@cosmjs/encoding': 0.33.1

--- a/tilt/apps/middleman/dev/patch-config.yml
+++ b/tilt/apps/middleman/dev/patch-config.yml
@@ -7,7 +7,7 @@ data:
   AUTH_TRUST_HOST: "http://localhost:3000"
   APP_URL: "http://localhost:3000"
   AUTH_URL: "http://localhost:3000"
-  CHAIN_ID: "pocket-beta"
+  CHAIN_ID: "pocket-lego-testnet"
   BLOCKCHAIN_PROTOCOL: "morse"
   OWNER_IDENTITY: "CHANGE_THIS"
   OWNER_EMAIL: "CHANGE_THIS"

--- a/tilt/apps/provider/dev/patch-config.yml
+++ b/tilt/apps/provider/dev/patch-config.yml
@@ -8,7 +8,7 @@ data:
   APP_URL: "http://localhost:3001"
   AUTH_URL: "http://localhost:3001"
   OWNER_IDENTITY: "CHANGE_THIS"
-  CHAIN_ID: "pocket-beta"
+  CHAIN_ID: "pocket-lego-testnet"
   BLOCKCHAIN_PROTOCOL: "morse"
   OWNER_EMAIL: "CHANGE_THIS"
   TEMPORAL_URL: "temporal-frontend.default.svc.cluster.local:7233"


### PR DESCRIPTION
## Summary
This PR introduces a new provider plans system that allows users to select specific staking plans when delegating their stake. It adds a new Providers page to browse available plans and updates the stake flow to work with the selected plan's address group.

## Key Features

### 🆕 New Providers Page (`/app/providers`)
- Browse all available providers and their public staking plans
- View client share percentages for each plan
- See which plans are personal (linked to specific wallet addresses)
- Real-time provider health status indicators

### 🔄 Enhanced Stake Flow
- **Plan Selection**: Users can now select a specific plan when choosing a provider
- **Improved UI**: Simplified revenue share display to focus on client share
- **Personal Plan Indicators**: Visual badges for wallet-linked exclusive plans
- **Services Popover**: Updated to display client share per service

## Database Changes

### Middleman App
- Added `PocketTestnet` to `ChainId` enum
- Modified `provider` table to store provider public address groups

### Provider App
- Added `PocketTestnet` to `ChainId` enum
- Added `rewardAddresses` to application settings to later fetch provider performance on middleman app

## Technical Details

### API Changes
- `ListProvidersWithPublicPlans()`: New action to fetch providers with public plans
- `GetStakeDistributionOffers()`: Updated to work with selected address groups
- Provider status endpoint: Updated public address groups exposure

## Breaking Changes
None - This is a new feature addition with backward-compatible changes.
