### PR TITLE
Add governance nginx for local dev

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,3 +18,18 @@ PROVIDER_OWNER_IDENTITY=
 
 # Indicates the buffer that has been removed from minimum stake on chain to allow nodes to operate after slashes. This amount is in uPOKT
 MINIMUM_STAKE_BUFFER=500000000
+
+# Governance files served by local nginx in dev.
+# For each type (DELEGATOR/PROVIDER), set EITHER the _JSON or the _JSON_FILE variable, not both.
+# If neither is set, an empty array [] is served.
+# JSON format: [{"name": "...", "identity": "...", "identityHistory": [], "url": "..."}]
+
+# Inline JSON string for delegator governance file (consumed by provider app)
+DELEGATOR_JSON=[{"name":"LocalDelegator","identity":"SET_PUBLIC_KEY_OF_DELEGATOR","identityHistory":[]}]
+# OR local path to a delegator JSON file
+DELEGATOR_JSON_FILE=
+
+# Inline JSON string for provider governance file (consumed by middleman app)
+PROVIDER_JSON=[{"name":"LocalProvider","identity":"SET_PUBLIC_KEY_OF_PROVIDER","identityHistory":[],"url":"http://provider.default.svc.cluster.local:3001"}]
+# OR local path to a provider JSON file
+PROVIDER_JSON_FILE=

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,10 @@ yarn-error.log*
 *.crt
 *.key
 
+# Governance data files (real copies with actual values)
+tilt/tools/governance/delegators.json
+tilt/tools/governance/providers.json
+
 # deployment files
 /**/*.crt
 /**/*.key

--- a/tilt/apps/middleman/Tiltfile
+++ b/tilt/apps/middleman/Tiltfile
@@ -34,6 +34,7 @@ objects = decode_yaml_stream(kustomize("./dev"))
 for o in objects:
   if o['metadata']['name'] == 'middleman-config':
     o['data']['OWNER_IDENTITY'] = OWNER_IDENTITY
+    o['data']['PROVIDERS_CDN_URL'] = 'http://governance-nginx.default.svc.cluster.local/providers.json'
     break
 
 for o in objects:
@@ -54,5 +55,5 @@ k8s_resource(
       'postgres-middleman-connection:secret',
     ],
     labels=['apps'],
-    resource_deps=["postgresql", "temporal"],
+    resource_deps=["postgresql", "temporal", "governance-nginx"],
 )

--- a/tilt/apps/middleman/dev/patch-config.yml
+++ b/tilt/apps/middleman/dev/patch-config.yml
@@ -4,11 +4,11 @@ metadata:
   name: middleman-config
 data:
   PROVIDERS_CDN_URL: "https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/{chainId}/providers.json"
-  AUTH_TRUST_HOST: "http://localhost:3000"
+  AUTH_TRUST_HOST: "true"
   APP_URL: "http://localhost:3000"
   AUTH_URL: "http://localhost:3000"
   CHAIN_ID: "pocket-lego-testnet"
-  BLOCKCHAIN_PROTOCOL: "morse"
+  BLOCKCHAIN_PROTOCOL: "shannon"
   OWNER_IDENTITY: "CHANGE_THIS"
   OWNER_EMAIL: "CHANGE_THIS"
   TEMPORAL_URL: "temporal-frontend.default.svc.cluster.local:7233"

--- a/tilt/apps/provider/Tiltfile
+++ b/tilt/apps/provider/Tiltfile
@@ -34,6 +34,7 @@ objects = decode_yaml_stream(kustomize("./dev"))
 for o in objects:
   if o['metadata']['name'] == 'provider-config':
     o['data']['OWNER_IDENTITY'] = OWNER_IDENTITY
+    o['data']['DELEGATORS_CDN_URL'] = 'http://governance-nginx.default.svc.cluster.local/delegators.json'
     break
 
 for o in objects:
@@ -54,5 +55,5 @@ k8s_resource(
     ],
     extra_pod_selectors=[{"app": "provider", "component": "web"}],
     labels=['apps'],
-    resource_deps=["postgresql", "temporal"],
+    resource_deps=["postgresql", "temporal", "governance-nginx"],
 )

--- a/tilt/apps/provider/dev/patch-config.yml
+++ b/tilt/apps/provider/dev/patch-config.yml
@@ -4,12 +4,12 @@ metadata:
   name: provider-config
 data:
   DELEGATORS_CDN_URL: "https://soothe-vault.nyc3.cdn.digitaloceanspaces.com/{chainId}/delegators.json"
-  AUTH_TRUST_HOST: "http://localhost:3001"
+  AUTH_TRUST_HOST: "true"
   APP_URL: "http://localhost:3001"
   AUTH_URL: "http://localhost:3001"
   OWNER_IDENTITY: "CHANGE_THIS"
   CHAIN_ID: "pocket-lego-testnet"
-  BLOCKCHAIN_PROTOCOL: "morse"
+  BLOCKCHAIN_PROTOCOL: "shannon"
   OWNER_EMAIL: "CHANGE_THIS"
   TEMPORAL_URL: "temporal-frontend.default.svc.cluster.local:7233"
   TEMPORAL_NAMESPACE: "provider"

--- a/tilt/tools/Tiltfile
+++ b/tilt/tools/Tiltfile
@@ -1,2 +1,3 @@
 include('./postgres/Tiltfile')
 include('./temporal/Tiltfile')
+include('./governance/Tiltfile')

--- a/tilt/tools/governance/Tiltfile
+++ b/tilt/tools/governance/Tiltfile
@@ -1,0 +1,186 @@
+# Governance nginx - serves local delegator.json and provider.json files
+# for provider and middleman apps to consume in dev.
+#
+# Env vars (set in .env):
+#   DELEGATOR_JSON      - inline JSON string for delegator file
+#   DELEGATOR_JSON_FILE - local path to a delegator JSON file
+#   PROVIDER_JSON       - inline JSON string for provider file
+#   PROVIDER_JSON_FILE  - local path to a provider JSON file
+#
+# Rules:
+#   - Setting both _JSON and _JSON_FILE for the same type will fail
+#   - If neither is set, defaults to empty array []
+
+# --- Path helpers ---
+# read_file resolves relative to this Tiltfile's directory (tilt/tools/governance/),
+# so we prefix relative paths to resolve from the project root instead.
+ROOT_PREFIX = '../../../'
+
+def resolve_path(path):
+  if path.startswith('/'):
+    return path
+  return ROOT_PREFIX + path
+
+# --- Read and validate env vars ---
+
+delegator_json = os.getenv('DELEGATOR_JSON', '')
+delegator_json_file = os.getenv('DELEGATOR_JSON_FILE', '')
+provider_json = os.getenv('PROVIDER_JSON', '')
+provider_json_file = os.getenv('PROVIDER_JSON_FILE', '')
+
+if delegator_json != '' and delegator_json_file != '':
+  fail('Cannot set both DELEGATOR_JSON and DELEGATOR_JSON_FILE. Use only one.')
+
+if provider_json != '' and provider_json_file != '':
+  fail('Cannot set both PROVIDER_JSON and PROVIDER_JSON_FILE. Use only one.')
+
+# --- Resolve delegator content ---
+
+delegator_content = '[]'
+
+if delegator_json != '':
+  delegator_content = delegator_json
+elif delegator_json_file != '':
+  delegator_content = str(read_file(resolve_path(delegator_json_file)))
+
+# --- Resolve provider content ---
+
+provider_content = '[]'
+
+if provider_json != '':
+  provider_content = provider_json
+elif provider_json_file != '':
+  provider_content = str(read_file(resolve_path(provider_json_file)))
+
+# --- Watch file paths for live reload ---
+
+if delegator_json_file != '':
+  watch_file(resolve_path(delegator_json_file))
+
+if provider_json_file != '':
+  watch_file(resolve_path(provider_json_file))
+
+# --- nginx config ---
+
+nginx_conf = """
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        root /usr/share/nginx/html;
+        default_type application/json;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}
+"""
+
+# --- Build k8s objects ---
+
+objects = []
+
+# ConfigMap with the JSON files and nginx config
+objects.append({
+  'apiVersion': 'v1',
+  'kind': 'ConfigMap',
+  'metadata': {
+    'name': 'governance-data',
+  },
+  'data': {
+    'delegators.json': delegator_content,
+    'providers.json': provider_content,
+    'default.conf': nginx_conf,
+  },
+})
+
+# Deployment
+objects.append({
+  'apiVersion': 'apps/v1',
+  'kind': 'Deployment',
+  'metadata': {
+    'name': 'governance-nginx',
+  },
+  'spec': {
+    'replicas': 1,
+    'selector': {
+      'matchLabels': {
+        'app': 'governance-nginx',
+      },
+    },
+    'template': {
+      'metadata': {
+        'labels': {
+          'app': 'governance-nginx',
+        },
+      },
+      'spec': {
+        'containers': [{
+          'name': 'nginx',
+          'image': 'nginx:alpine',
+          'ports': [{
+            'containerPort': 80,
+          }],
+          'volumeMounts': [
+            {
+              'name': 'data',
+              'mountPath': '/usr/share/nginx/html/delegators.json',
+              'subPath': 'delegators.json',
+            },
+            {
+              'name': 'data',
+              'mountPath': '/usr/share/nginx/html/providers.json',
+              'subPath': 'providers.json',
+            },
+            {
+              'name': 'data',
+              'mountPath': '/etc/nginx/conf.d/default.conf',
+              'subPath': 'default.conf',
+            },
+          ],
+          'readinessProbe': {
+            'httpGet': {
+              'path': '/delegators.json',
+              'port': 80,
+            },
+            'initialDelaySeconds': 5,
+            'periodSeconds': 10,
+          },
+        }],
+        'volumes': [{
+          'name': 'data',
+          'configMap': {
+            'name': 'governance-data',
+          },
+        }],
+      },
+    },
+  },
+})
+
+# Service
+objects.append({
+  'apiVersion': 'v1',
+  'kind': 'Service',
+  'metadata': {
+    'name': 'governance-nginx',
+  },
+  'spec': {
+    'selector': {
+      'app': 'governance-nginx',
+    },
+    'ports': [{
+      'port': 80,
+      'targetPort': 80,
+    }],
+  },
+})
+
+# --- Apply ---
+
+k8s_yaml(encode_yaml_stream(objects), allow_duplicates=False)
+
+k8s_resource(
+  'governance-nginx',
+  objects=['governance-data:configmap'],
+  labels=['tooling'],
+)

--- a/tilt/tools/governance/delegators.sample.json
+++ b/tilt/tools/governance/delegators.sample.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "LocalDelegator",
+    "identity": "SET_PUBLIC_KEY_OF_DELEGATOR",
+    "identityHistory": []
+  }
+]

--- a/tilt/tools/governance/providers.sample.json
+++ b/tilt/tools/governance/providers.sample.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "LocalProvider",
+    "identity": "SET_PUBLIC_KEY_OF_PROVIDER",
+    "identityHistory": [],
+    "url": "http://provider.default.svc.cluster.local:3001"
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `governance-nginx` Tilt resource serving `delegators.json` and `providers.json` inside the cluster
- Content sourced from `.env` via inline JSON (`DELEGATOR_JSON`/`PROVIDER_JSON`) or file path (`_FILE` variants)
- Provider and middleman CDN URLs overridden in-memory to point to local nginx
- Defaults to empty `[]` if no env vars set; fails if both JSON and FILE are set for same type

## Test plan
- [x] Verified ConfigMap, pod, and service deploy correctly
- [x] Verified both JSON files served correctly via in-cluster curl
- [x] Verified provider/middleman apps consume the local URLs