### PR TITLE
Fix Provider rewards and APR formula

### DIFF
--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -807,6 +807,25 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
     } catch (e) {
       statusResult = { ...(e as object) } as Provider
     }
+
+    // Preserve existing reward data in address groups so the status update doesn't wipe it
+    if (statusResult.addressGroups && provider.addressGroups) {
+      const existingGroupsMap = new Map(
+        (provider.addressGroups as Array<{ id: number; grossRewardsPerService?: unknown; rewardsSuppliersCount?: unknown; rewardsUpdatedAt?: unknown }>)
+          .map(ag => [ag.id, ag])
+      )
+      statusResult.addressGroups = statusResult.addressGroups.map((ag) => {
+        const existing = existingGroupsMap.get(ag.id)
+        if (!existing) return ag
+        return {
+          ...ag,
+          grossRewardsPerService: existing.grossRewardsPerService,
+          rewardsSuppliersCount: existing.rewardsSuppliersCount,
+          rewardsUpdatedAt: existing.rewardsUpdatedAt,
+        } as typeof ag
+      })
+    }
+
     await dal.provider.updateProviders([statusResult])
 
     const appSettings = await dal.appSettings.getFirst()

--- a/apps/middleman/drizzle/0008_add_node_services.sql
+++ b/apps/middleman/drizzle/0008_add_node_services.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "nodes" ADD COLUMN "services" jsonb DEFAULT '[]'::jsonb;
+ALTER TABLE "nodes" ADD COLUMN IF NOT EXISTS "services" jsonb DEFAULT '[]'::jsonb;

--- a/apps/middleman/drizzle/meta/_journal.json
+++ b/apps/middleman/drizzle/meta/_journal.json
@@ -61,7 +61,7 @@
     {
       "idx": 8,
       "version": "7",
-      "when": 1741003200000,
+      "when": 1772711672123,
       "tag": "0008_add_node_services",
       "breakpoints": true
     },

--- a/apps/middleman/src/app/app/providers/clientPage.tsx
+++ b/apps/middleman/src/app/app/providers/clientPage.tsx
@@ -263,7 +263,7 @@ function ProviderCard({
                         <span className="font-medium text-[var(--color-white-1)]">APR</span>
                         <span className="text-[13px] text-[var(--color-white-3)]">
                           Annual Percentage Rate, estimated from recent performance.
-                          Calculated as: (Performance POKT/supplier/day × 365 ÷ minimum stake) × 100.
+                          Calculated as: (Est. Yield POKT/supplier/day × 365 ÷ minimum stake) × 100.
                         </span>
                       </div>
                     </div>
@@ -311,8 +311,8 @@ function ProviderCard({
               const linkedAccount = getLinkedAccount(addressGroup.linkedAddresses);
               const planPerformance = calculateAddressGroupPerformance(addressGroup);
               const effectiveYield = calculateEffectiveYield(planPerformance, shares.clientShare);
-              const apr = planPerformance !== null && minimumStake > 0
-                ? (planPerformance * 365 / minimumStake) * 100
+              const apr = effectiveYield !== null && minimumStake > 0
+                ? (effectiveYield * 365 / minimumStake) * 100
                 : null;
 
               return (

--- a/apps/middleman/src/app/app/stake/components/PickOfferStep/ProviderOfferItem.tsx
+++ b/apps/middleman/src/app/app/stake/components/PickOfferStep/ProviderOfferItem.tsx
@@ -79,7 +79,7 @@ export function ProviderOfferItem({ selectedAddressGroupId, offer, onSelectAddre
                                                 <span className="font-medium text-[var(--color-white-1)]">APR</span>
                                                 <span className="text-[13px] text-[var(--color-white-3)]">
                                                     Annual Percentage Rate, estimated from recent performance.
-                                                    Calculated as: (Performance POKT/supplier/day × 365 ÷ minimum stake) × 100.
+                                                    Calculated as: (Est. Yield POKT/supplier/day × 365 ÷ minimum stake) × 100.
                                                 </span>
                                             </div>
                                         </div>
@@ -117,8 +117,8 @@ export function ProviderOfferItem({ selectedAddressGroupId, offer, onSelectAddre
                             const isSelected = addressGroup.id === selectedAddressGroupId
                             const planPerformance = calculateAddressGroupPerformance(addressGroup)
                             const effectiveYield = calculateEffectiveYield(planPerformance, shares.clientShare)
-                            const apr = planPerformance !== null && minimumStake > 0
-                                ? (planPerformance * 365 / minimumStake) * 100
+                            const apr = effectiveYield !== null && minimumStake > 0
+                                ? (effectiveYield * 365 / minimumStake) * 100
                                 : null
 
                             return (

--- a/apps/middleman/src/app/app/stake/components/ServicesPopover.tsx
+++ b/apps/middleman/src/app/app/stake/components/ServicesPopover.tsx
@@ -141,7 +141,7 @@ function MetricsFooter({ rewardsFresh }: { rewardsFresh: boolean }) {
           </div>
           <div className="flex flex-col gap-0.5">
             <span className="font-medium text-[var(--color-white-2)]">APR</span>
-            <span className="text-[var(--color-white-3)]">Annual Percentage Rate: (Performance × 365 ÷ minimum stake) × 100.</span>
+            <span className="text-[var(--color-white-3)]">Annual Percentage Rate: (Est. Yield × 365 ÷ minimum stake) × 100.</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
  - Fix provider status wiping reward data: processProviderStatus was calling updateProviders([statusResult]) with fresh data from the provider API, which overwrote address_groups in the DB and stripped grossRewardsPerService, rewardsSuppliersCount, and rewardsUpdatedAt — causing rewards to intermittently  disappear. The fix preserves existing reward fields before the status write.
  - Fix APR calculation to include client share: APR was computed from raw gross performance instead of the effective yield (performance × client share), overstating returns. Now uses effectiveYield consistently with Est. Yield, in both /app/providers and /app/stake.
  - Fix migration 0008 ordering: The _journal.json timestamp for 0008_add_node_services was set in the past (March 2025), causing Drizzle to skip it in production when 0009 was already applied. Corrected the timestamp and added IF NOT EXISTS to the SQL to make it safe to apply in all environments.