### PR TITLE
Middleman UX improvements and supplier remediation sequence retry

### DIFF
--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -896,7 +896,7 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
     `
     const supplierStatsQuery = `
       query SupplierStatsByDomains($domains: [String!]!) {
-        data: getSupplierStatsByDomains(domains: $domains)
+        data: getSupplierStatsByDomains(pDomains: $domains)
       }
     `
 
@@ -918,7 +918,7 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
         ? fetch(indexerApiUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ query: supplierStatsQuery, variables: { pDomains: allDomains } }),
+            body: JSON.stringify({ query: supplierStatsQuery, variables: { domains: allDomains } }),
           })
             .then((r) => r.json() as Promise<{ data: { data: { suppliers_count: number; total_staked_tokens: number } } }>)
             .catch((e) => { log.error('Failed to fetch supplier stats', { error: e }); return null })

--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -918,7 +918,7 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
         ? fetch(indexerApiUrl, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ query: supplierStatsQuery, variables: { domains: allDomains } }),
+            body: JSON.stringify({ query: supplierStatsQuery, variables: { pDomains: allDomains } }),
           })
             .then((r) => r.json() as Promise<{ data: { data: { suppliers_count: number; total_staked_tokens: number } } }>)
             .catch((e) => { log.error('Failed to fetch supplier stats', { error: e }); return null })

--- a/apps/middleman/src/actions/Nodes.ts
+++ b/apps/middleman/src/actions/Nodes.ts
@@ -1,9 +1,14 @@
 'use server'
 
-import { getNode, getNodesByUser, getOwnerAddressesByUser, getStakedNodesAddress } from '@/lib/dal/nodes'
+import { getNode, getNodesByUser, getOwnerAddressesByUser, getProviderCountByUser, getStakedNodesAddress } from '@/lib/dal/nodes'
 import {getCurrentUserIdentity} from "@/lib/utils/actions";
 import { getApplicationSettings } from '@/lib/dal/applicationSettings'
 import { normalizeIdentityToAddress } from '@/lib/crypto'
+import { summaryDocument, StakeStatus } from '@igniter/graphql'
+import { getServerApolloClient } from '@igniter/ui/graphql/server'
+import { getLatestBlock } from '@igniter/ui/api/blocks'
+import { amountToPokt } from '@igniter/ui/lib/utils'
+import { batchArray } from '@igniter/ui/lib/batch'
 
 export async function GetUserNodes() {
   const userIdentity = await getCurrentUserIdentity();
@@ -46,4 +51,121 @@ export async function GetNode(address: string) {
 export async function GetOwnerAddresses() {
   const userIdentity = await getCurrentUserIdentity();
   return await getOwnerAddressesByUser(userIdentity)
+}
+
+export async function GetProviderCount(): Promise<number> {
+  const userIdentity = await getCurrentUserIdentity();
+  return await getProviderCountByUser(userIdentity)
+}
+
+export interface ProviderBreakdownData {
+  identity: string
+  name: string
+  suppliers: number
+  stakedPokt: number
+  rewards24h: number
+  rewards48h: number
+}
+
+export async function GetProviderBreakdown(): Promise<ProviderBreakdownData[]> {
+  const [userNodes, ownerAddresses, applicationSettings] = await Promise.all([
+    GetUserNodes(),
+    GetOwnerAddresses(),
+    getApplicationSettings(),
+  ])
+
+  // Resolve graphQL URL
+  let graphqlUrl = applicationSettings.indexerApiUrl
+  if (!graphqlUrl) {
+    if (applicationSettings.chainId === 'pocket') {
+      graphqlUrl = process.env.MAINNET_INDEXER_API_URL || ''
+    } else if (applicationSettings.chainId === 'pocket-beta') {
+      graphqlUrl = process.env.BETA_INDEXER_API_URL || ''
+    } else {
+      graphqlUrl = process.env.ALPHA_INDEXER_API_URL || ''
+    }
+  }
+
+  // Group nodes by provider
+  const providerGroups = new Map<string, { name: string; nodes: typeof userNodes }>()
+  for (const node of userNodes) {
+    const id = node.providerId ?? '__imported__'
+    const name = node.provider?.name ?? 'Imported Node'
+    let group = providerGroups.get(id)
+    if (!group) {
+      group = { name, nodes: [] }
+      providerGroups.set(id, group)
+    }
+    group.nodes.push(node)
+  }
+
+  const providerEntries = Array.from(providerGroups.entries())
+  const latestBlock = await getLatestBlock(graphqlUrl)
+  const client = getServerApolloClient(graphqlUrl)
+
+  const blockDate = new Date(
+    latestBlock.timestamp.endsWith('Z')
+      ? latestBlock.timestamp
+      : latestBlock.timestamp + 'Z',
+  )
+  const currentDate = blockDate.toISOString()
+  const last24Hours = new Date(blockDate.getTime() - 24 * 60 * 60 * 1000).toISOString()
+  const last48Hours = new Date(blockDate.getTime() - 48 * 60 * 60 * 1000).toISOString()
+
+  const results = await Promise.allSettled(
+    providerEntries.map(async ([, group]) => {
+      const supplierAddresses = group.nodes.map((n) => n.address)
+      const batches = batchArray(supplierAddresses)
+
+      const batchResults = await Promise.all(
+        batches.map((batch) =>
+          client.query({
+            query: summaryDocument,
+            variables: {
+              filter: {
+                stakeStatus: { equalTo: StakeStatus.Staked },
+                id: { in: batch },
+                ownerId: { in: ownerAddresses },
+              },
+              currentDate,
+              last24Hours,
+              last48Hours,
+              addresses: ownerAddresses,
+              supplierAddresses: batch,
+            },
+          }),
+        ),
+      )
+
+      return batchResults.reduce(
+        (acc, { data: d }) => ({
+          last24h: Number(acc.last24h ?? 0) + Number(d.last24h ?? 0),
+          last48h: Number(acc.last48h ?? 0) + Number(d.last48h ?? 0),
+        }),
+        { last24h: 0, last48h: 0 } as { last24h: number; last48h: number },
+      )
+    }),
+  )
+
+  const providers: ProviderBreakdownData[] = providerEntries.map(
+    ([identity, group], index) => {
+      const result = results[index]
+      const data = result?.status === 'fulfilled' ? result.value : null
+
+      return {
+        identity,
+        name: group.name,
+        suppliers: group.nodes.length,
+        stakedPokt: group.nodes.reduce(
+          (sum, n) => sum + amountToPokt(n.stakeAmount),
+          0,
+        ),
+        rewards24h: amountToPokt(data?.last24h ?? 0),
+        rewards48h: amountToPokt(data?.last48h ?? 0),
+      }
+    },
+  )
+
+  providers.sort((a, b) => b.suppliers - a.suppliers)
+  return providers
 }

--- a/apps/middleman/src/actions/Nodes.ts
+++ b/apps/middleman/src/actions/Nodes.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import type { NodeWithDetails } from '@igniter/db/middleman/schema'
 import { getNode, getNodesByUser, getOwnerAddressesByUser, getProviderCountByUser, getStakedNodesAddress } from '@/lib/dal/nodes'
 import {getCurrentUserIdentity} from "@/lib/utils/actions";
 import { getApplicationSettings } from '@/lib/dal/applicationSettings'
@@ -86,15 +87,15 @@ export async function GetProviderBreakdown(): Promise<ProviderBreakdownData[]> {
     }
   }
 
-  // Group nodes by provider
-  const providerGroups = new Map<string, { name: string; nodes: typeof userNodes }>()
+  // Group nodes by provider, skipping nodes without a provider
+  const providerGroups = new Map<string, { name: string; nodes: NodeWithDetails[] }>()
   for (const node of userNodes) {
-    const id = node.providerId ?? '__imported__'
-    const name = node.provider?.name ?? 'Imported Node'
-    let group = providerGroups.get(id)
+    if (!node.providerId) continue
+    const name = node.provider?.name ?? node.providerId
+    let group = providerGroups.get(node.providerId)
     if (!group) {
       group = { name, nodes: [] }
-      providerGroups.set(id, group)
+      providerGroups.set(node.providerId, group)
     }
     group.nodes.push(node)
   }
@@ -114,7 +115,7 @@ export async function GetProviderBreakdown(): Promise<ProviderBreakdownData[]> {
 
   const results = await Promise.allSettled(
     providerEntries.map(async ([, group]) => {
-      const supplierAddresses = group.nodes.map((n) => n.address)
+      const supplierAddresses: Array<string> = group.nodes.map((n) => n.address)
       const batches = batchArray(supplierAddresses)
 
       const batchResults = await Promise.all(

--- a/apps/middleman/src/app/app/(lists)/nodes/ChainOverview.tsx
+++ b/apps/middleman/src/app/app/(lists)/nodes/ChainOverview.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import React, { useCallback, useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { GetUserNodes } from '@/actions/Nodes'
+import { amountToPokt, toCurrencyFormat } from '@igniter/ui/lib/utils'
+import DistributionPieChart from '@igniter/ui/components/PieChart/PieChart'
+import type { PieChartItem } from '@igniter/ui/components/PieChart/PieChart'
+import { Button } from '@igniter/ui/components/button'
+import { Download } from 'lucide-react'
+import { Skeleton } from '@igniter/ui/components/skeleton'
+
+interface ChainProviderRow {
+  service: string
+  provider: string
+  suppliers: number
+  stakedPokt: number
+}
+
+type SortKey = 'service' | 'provider' | 'suppliers' | 'stakedPokt'
+type SortDir = 'asc' | 'desc'
+
+function computeChainOverview(
+  nodes: Awaited<ReturnType<typeof GetUserNodes>>,
+): ChainProviderRow[] {
+  const map = new Map<string, ChainProviderRow>()
+
+  for (const node of nodes) {
+    const providerName = node.provider?.name ?? 'Imported Node'
+
+    if (!node.services) continue
+
+    for (const svc of node.services) {
+      const key = `${svc.serviceId}::${providerName}`
+      let entry = map.get(key)
+      if (!entry) {
+        entry = {
+          service: svc.serviceId,
+          provider: providerName,
+          suppliers: 0,
+          stakedPokt: 0,
+        }
+        map.set(key, entry)
+      }
+      entry.suppliers += 1
+      entry.stakedPokt += amountToPokt(node.stakeAmount)
+    }
+  }
+
+  return Array.from(map.values())
+}
+
+function buildPieData(
+  rows: ChainProviderRow[],
+): PieChartItem[] {
+  const totals = new Map<string, number>()
+
+  for (const row of rows) {
+    totals.set(row.service, (totals.get(row.service) ?? 0) + row.suppliers)
+  }
+
+  const totalSuppliers = Array.from(totals.values()).reduce((a, b) => a + b, 0)
+
+  return Array.from(totals.entries()).map(([id, value]) => ({
+    id,
+    value,
+    percent: totalSuppliers > 0 ? (value / totalSuppliers) * 100 : 0,
+  }))
+}
+
+const HEADER_CLASSES = 'px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider cursor-pointer select-none hover:text-foreground transition-colors'
+const CELL_CLASSES = 'px-3 py-2 text-sm'
+
+function exportChainOverviewCsv(rows: ChainProviderRow[]) {
+  const header = 'Service,Provider,Suppliers,Staked POKT'
+  const csvRows = rows.map(
+    (r) => `"${r.service}","${r.provider}",${r.suppliers},${r.stakedPokt.toFixed(2)}`,
+  )
+  const csv = [header, ...csvRows].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `chain-overview-${new Date().toISOString().slice(0, 10)}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+export default function ChainOverview() {
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['nodes'],
+    queryFn: GetUserNodes,
+    refetchInterval: 60000,
+  })
+
+  const [search, setSearch] = useState('')
+  const [sortKey, setSortKey] = useState<SortKey>('suppliers')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const allRows = useMemo(() => {
+    if (!data) return []
+    return computeChainOverview(data)
+  }, [data])
+
+  const filteredRows = useMemo(() => {
+    if (!search.trim()) return allRows
+    const q = search.toLowerCase()
+    return allRows.filter(
+      (row) =>
+        row.service.toLowerCase().includes(q) ||
+        row.provider.toLowerCase().includes(q),
+    )
+  }, [allRows, search])
+
+  const sortedRows = useMemo(() => {
+    return [...filteredRows].sort((a, b) => {
+      const aVal = a[sortKey]
+      const bVal = b[sortKey]
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return sortDir === 'asc'
+          ? aVal.localeCompare(bVal)
+          : bVal.localeCompare(aVal)
+      }
+      return sortDir === 'asc'
+        ? (aVal as number) - (bVal as number)
+        : (bVal as number) - (aVal as number)
+    })
+  }, [filteredRows, sortKey, sortDir])
+
+  const suppliersByService = useMemo(
+    () => buildPieData(allRows),
+    [allRows],
+  )
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
+
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return null
+    return sortDir === 'asc' ? ' ↑' : ' ↓'
+  }
+
+  const handleExport = useCallback(() => exportChainOverviewCsv(sortedRows), [sortedRows])
+
+  if (!isLoading && !isError && !allRows.length) return null
+
+  const cardClasses = 'rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4'
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-semibold">Services Overview</h3>
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-4">
+          <div className={`${cardClasses} min-w-0`}>
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <input
+                type="text"
+                placeholder="Search by service or provider..."
+                disabled
+                className="w-full max-w-sm rounded-md border border-[color:--divider] bg-[color:--main-background] px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:opacity-50"
+              />
+              <Button variant="outline" size="sm" disabled className="gap-1.5 shrink-0">
+                <Download className="h-3.5 w-3.5" />
+                Export CSV
+              </Button>
+            </div>
+            <div className="overflow-hidden rounded-lg border border-[color:--divider]">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-[color:--divider] bg-muted">
+                    <th className={HEADER_CLASSES}>Service</th>
+                    <th className={HEADER_CLASSES}>Provider</th>
+                    <th className={`${HEADER_CLASSES} text-right`}>Suppliers</th>
+                    <th className={`${HEADER_CLASSES} text-right`}>Staked POKT</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <tr key={i} className="border-b border-[color:--divider] last:border-b-0 pointer-events-none">
+                      <td className={CELL_CLASSES}><Skeleton className="w-4/5 h-4 !bg-[color:#383838]" /></td>
+                      <td className={CELL_CLASSES}><Skeleton className="w-3/5 h-4 !bg-[color:#383838]" /></td>
+                      <td className={`${CELL_CLASSES} text-right`}><Skeleton className="w-2/5 h-4 ml-auto !bg-[color:#383838]" /></td>
+                      <td className={`${CELL_CLASSES} text-right`}><Skeleton className="w-3/5 h-4 ml-auto !bg-[color:#383838]" /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div className={`${cardClasses} flex items-center justify-center px-14`}>
+            <div className="flex flex-row items-center gap-6">
+              <Skeleton className="h-[220px] w-[220px] rounded-full shrink-0 !bg-[color:#383838]" />
+              <div className="flex flex-col gap-1.5">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <Skeleton className="h-5 w-[42px] rounded-sm shrink-0 !bg-[color:#383838]" />
+                    <Skeleton className="h-4 w-20 !bg-[color:#383838]" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-semibold">Services Overview</h3>
+        <div className={`${cardClasses} flex flex-col items-center justify-center py-8 gap-3`}>
+          <p className="text-sm text-muted-foreground">
+            There was an error loading the services overview.
+          </p>
+          <Button onClick={() => refetch()} variant="outline" size="sm">
+            Retry
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-lg font-semibold">Services Overview</h3>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-4">
+        {/* Table card */}
+        <div className={`${cardClasses} min-w-0`}>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <input
+              type="text"
+              placeholder="Search by service or provider..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full max-w-sm rounded-md border border-[color:--divider] bg-[color:--main-background] px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[color:--color-blue-1]"
+            />
+            <Button variant="outline" size="sm" onClick={handleExport} className="gap-1.5 shrink-0">
+              <Download className="h-3.5 w-3.5" />
+              CSV
+            </Button>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-[color:--divider]">
+            <div className="max-h-[260px] overflow-y-auto">
+              <table className="w-full">
+                <thead className="sticky top-0 z-10">
+                  <tr className="border-b border-[color:--divider] bg-muted">
+                    <th className={HEADER_CLASSES} onClick={() => handleSort('service')}>
+                      Service{sortIndicator('service')}
+                    </th>
+                    <th className={HEADER_CLASSES} onClick={() => handleSort('provider')}>
+                      Provider{sortIndicator('provider')}
+                    </th>
+                    <th className={`${HEADER_CLASSES} text-right`} onClick={() => handleSort('suppliers')}>
+                      Suppliers{sortIndicator('suppliers')}
+                    </th>
+                    <th className={`${HEADER_CLASSES} text-right`} onClick={() => handleSort('stakedPokt')}>
+                      Staked POKT{sortIndicator('stakedPokt')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedRows.map((row) => (
+                    <tr
+                      key={`${row.service}-${row.provider}`}
+                      className="border-b border-[color:--divider] last:border-b-0 hover:bg-muted/30 transition-colors"
+                    >
+                      <td className={`${CELL_CLASSES} font-mono`}>{row.service}</td>
+                      <td className={CELL_CLASSES}>{row.provider}</td>
+                      <td className={`${CELL_CLASSES} text-right font-mono`}>{row.suppliers}</td>
+                      <td className={`${CELL_CLASSES} text-right font-mono`}>
+                        {toCurrencyFormat(row.stakedPokt, 0)}
+                      </td>
+                    </tr>
+                  ))}
+                  {sortedRows.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="px-3 py-6 text-center text-sm text-muted-foreground">
+                        No results found
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        {/* Pie chart */}
+        <div className={`${cardClasses} flex items-center justify-center px-14`}>
+          <DistributionPieChart
+            data={suppliersByService}
+            label="Suppliers by Service"
+            legendPosition="right"
+            size={220}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/middleman/src/app/app/(lists)/nodes/ProviderStats.tsx
+++ b/apps/middleman/src/app/app/(lists)/nodes/ProviderStats.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { GetUserNodes } from '@/actions/Nodes'
+import { amountToPokt, toCompactFormat, toCurrencyFormat } from '@igniter/ui/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@igniter/ui/components/tooltip'
+import { Popover, PopoverContent, PopoverTrigger } from '@igniter/ui/components/popover'
+import { ChevronRight } from 'lucide-react'
+import { Skeleton } from '@igniter/ui/components/skeleton'
+import { Button } from '@igniter/ui/components/button'
+
+interface ProviderStat {
+  identity: string
+  name: string
+  suppliers: number
+  stakedPokt: number
+  services: string[]
+}
+
+function computeProviderStats(
+  nodes: Awaited<ReturnType<typeof GetUserNodes>>,
+): ProviderStat[] {
+  const map = new Map<
+    string,
+    { name: string; suppliers: number; stakedPokt: number; services: Set<string> }
+  >()
+
+  for (const node of nodes) {
+    const id = node.providerId ?? '__imported__'
+    const name = node.provider?.name ?? 'Imported Node'
+
+    let entry = map.get(id)
+    if (!entry) {
+      entry = { name, suppliers: 0, stakedPokt: 0, services: new Set() }
+      map.set(id, entry)
+    }
+
+    entry.suppliers += 1
+    entry.stakedPokt += amountToPokt(node.stakeAmount)
+
+    if (node.services) {
+      for (const svc of node.services) {
+        entry.services.add(svc.serviceId)
+      }
+    }
+  }
+
+  return Array.from(map.entries())
+    .map(([identity, stat]) => ({
+      identity,
+      name: stat.name,
+      suppliers: stat.suppliers,
+      stakedPokt: stat.stakedPokt,
+      services: Array.from(stat.services).sort(),
+    }))
+    .sort((a, b) => b.suppliers - a.suppliers)
+}
+
+function ProviderCard({ stat }: { stat: ProviderStat }) {
+  return (
+    <div className="rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4 flex flex-col gap-2">
+      <p className="text-sm font-semibold truncate">{stat.name}</p>
+
+      <div className="flex flex-col gap-1 text-sm text-muted-foreground">
+        <div className="flex justify-between">
+          <span>Suppliers</span>
+          <span className="text-foreground font-medium">{stat.suppliers}</span>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <span>Staked</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-foreground font-medium cursor-default">
+                {toCompactFormat(stat.stakedPokt)} POKT
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {toCurrencyFormat(stat.stakedPokt, 0)} POKT
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        <div className="flex justify-between items-center">
+          <span>Services</span>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button className="flex items-center gap-0.5 text-foreground font-medium hover:text-[color:--color-blue-1] transition-colors cursor-pointer">
+                {stat.services.length}
+                <ChevronRight className="w-3.5 h-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-56 p-3" align="end">
+              <p className="text-sm font-semibold mb-2">Services</p>
+              <ul className="flex flex-col gap-1 max-h-60 overflow-y-auto">
+                {stat.services.map((svc) => (
+                  <li key={svc} className="text-sm text-muted-foreground font-mono">
+                    {svc}
+                  </li>
+                ))}
+              </ul>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function ProviderStats() {
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['nodes'],
+    queryFn: GetUserNodes,
+    refetchInterval: 60000,
+  })
+
+  const stats = useMemo(() => {
+    if (!data) return []
+    return computeProviderStats(data)
+  }, [data])
+
+  if (!isLoading && !isError && stats.length <= 1) return null
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-semibold">Provider Stats</h3>
+        <div
+          className="grid gap-3"
+          style={{
+            gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+          }}
+        >
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4 flex flex-col gap-3">
+              <Skeleton className="h-4 w-24 !bg-[color:#383838]" />
+              <Skeleton className="h-4 w-full !bg-[color:#383838]" />
+              <Skeleton className="h-4 w-full !bg-[color:#383838]" />
+              <Skeleton className="h-4 w-full !bg-[color:#383838]" />
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-3">
+        <h3 className="text-lg font-semibold">Provider Stats</h3>
+        <div className="rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4 flex flex-col items-center justify-center py-8 gap-3">
+          <p className="text-sm text-muted-foreground">
+            There was an error loading the provider stats.
+          </p>
+          <Button onClick={() => refetch()} variant="outline" size="sm">
+            Retry
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (stats.length <= 1) return null
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-lg font-semibold">Provider Stats</h3>
+      <div
+        className="grid gap-3"
+        style={{
+          gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+        }}
+      >
+        {stats.map((stat) => (
+          <ProviderCard key={stat.identity} stat={stat} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/middleman/src/app/app/(lists)/nodes/page.tsx
+++ b/apps/middleman/src/app/app/(lists)/nodes/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import React from 'react'
 import NodesTable from '@/app/app/(lists)/nodes/table'
+import ProviderStats from '@/app/app/(lists)/nodes/ProviderStats'
+import ChainOverview from '@/app/app/(lists)/nodes/ChainOverview'
 import { GetAppName } from '@/actions/ApplicationSettings'
 import Link from 'next/link'
 import { Button } from '@igniter/ui/components/button'
@@ -36,9 +38,6 @@ export default async function Page() {
                 <Link href="/app/import-suppliers">
                   <Button variant="outline">Import Suppliers</Button>
                 </Link>
-                <Link href="/app/unstake">
-                  <Button variant="outline">Unstake</Button>
-                </Link>
                 <Link href="/app/stake">
                   <Button>New Stake</Button>
                 </Link>
@@ -47,7 +46,9 @@ export default async function Page() {
           </div>
         </div>
       </div>
-      <div className="mx-10 pt-10">
+      <div className="mx-10 pt-10 flex flex-col gap-8">
+        <ProviderStats />
+        <ChainOverview />
         <NodesTable />
       </div>
     </>

--- a/apps/middleman/src/app/app/(lists)/nodes/table/columns.tsx
+++ b/apps/middleman/src/app/app/(lists)/nodes/table/columns.tsx
@@ -219,7 +219,6 @@ export const filters: FilterGroup<NodeDetails>[] = [
           label: "All Nodes",
           value: "",
           column: "status",
-          isDefault: true,
         },
         {
           label: "Staked",
@@ -231,7 +230,11 @@ export const filters: FilterGroup<NodeDetails>[] = [
           label: "Unstaking",
           value: "unstaking",
           column: "status",
-          isDefault: true,
+        },
+        {
+          label: "Unstaked",
+          value: "unstaked",
+          column: "status",
         },
       ],
     ],
@@ -258,6 +261,21 @@ export const sorts: SortOption<NodeDetails>[][] = [
       column: "height",
       direction: "desc",
       isDefault: true,
+    },
+    {
+      label: "Stake Amount",
+      column: "stakeAmount",
+      direction: "desc",
+    },
+    {
+      label: "Balance",
+      column: "balance",
+      direction: "desc",
+    },
+    {
+      label: "Created At",
+      column: "createdAt",
+      direction: "desc",
     },
   ],
 ];

--- a/apps/middleman/src/app/app/(lists)/nodes/table/index.tsx
+++ b/apps/middleman/src/app/app/(lists)/nodes/table/index.tsx
@@ -101,6 +101,8 @@ export default function NodesTable() {
       isError={isError}
       refetch={refetch}
       csvFilename={'nodes'}
+      searchableColumns={['address', 'ownerAddress', 'provider']}
+      searchPlaceholder="Search by address or provider..."
     />
   )
 }

--- a/apps/middleman/src/app/app/overview/ProviderBreakdown.tsx
+++ b/apps/middleman/src/app/app/overview/ProviderBreakdown.tsx
@@ -4,7 +4,7 @@ import type { PieChartItem } from '@igniter/ui/components/PieChart/PieChart'
 import { Download } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import React, { useCallback, useMemo, useState } from 'react'
-import { GetProviderBreakdown, GetProviderCount, type ProviderBreakdownData } from '@/actions/Nodes'
+import { GetProviderBreakdown, type ProviderBreakdownData } from '@/actions/Nodes'
 import DistributionPieChart from '@igniter/ui/components/PieChart/PieChart'
 import { Skeleton } from '@igniter/ui/components/skeleton'
 import { toCurrencyFormat } from '@igniter/ui/lib/utils'
@@ -47,17 +47,12 @@ function exportToCsv(providers: ProviderBreakdownData[]) {
 
 const cardClasses = 'rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4'
 
-export default function ProviderBreakdown() {
-  const { data: providerCount } = useQuery({
-    queryKey: ['providerCount'],
-    queryFn: GetProviderCount,
-  })
-
+export default function ProviderBreakdown({ providerCount }: { providerCount: number }) {
   const { data: providers, isLoading, isError, refetch } = useQuery({
     queryKey: ['providerBreakdown'],
     queryFn: GetProviderBreakdown,
     refetchInterval: 60000,
-    enabled: (providerCount ?? 0) > 1,
+    enabled: providerCount > 1,
   })
 
   const [rewardsPeriod, setRewardsPeriod] = useState<'24h' | '48h'>('24h')
@@ -106,7 +101,7 @@ export default function ProviderBreakdown() {
     [sortedProviders, rewardsPeriod],
   )
 
-  if ((providerCount ?? 0) <= 1) return null
+  if (providerCount <= 1) return null
 
   if (isLoading) {
     return (

--- a/apps/middleman/src/app/app/overview/ProviderBreakdown.tsx
+++ b/apps/middleman/src/app/app/overview/ProviderBreakdown.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import type { PieChartItem } from '@igniter/ui/components/PieChart/PieChart'
+import { Download } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import React, { useCallback, useMemo, useState } from 'react'
+import { GetProviderBreakdown, GetProviderCount, type ProviderBreakdownData } from '@/actions/Nodes'
+import DistributionPieChart from '@igniter/ui/components/PieChart/PieChart'
+import { Skeleton } from '@igniter/ui/components/skeleton'
+import { toCurrencyFormat } from '@igniter/ui/lib/utils'
+import { Button } from '@igniter/ui/components/button'
+
+type SortKey = 'name' | 'suppliers' | 'stakedPokt' | 'rewards24h' | 'rewards48h'
+type SortDir = 'asc' | 'desc'
+
+const HEADER_CLASSES =
+  'px-2 py-1.5 md:px-3 md:py-2 text-left text-[10px] md:text-xs font-medium text-muted-foreground uppercase tracking-wider cursor-pointer select-none hover:text-foreground transition-colors'
+const CELL_CLASSES = 'px-2 py-1.5 md:px-3 md:py-2 text-xs md:text-sm'
+
+function buildPieData(
+  providers: ProviderBreakdownData[],
+  metric: keyof Pick<ProviderBreakdownData, 'suppliers' | 'stakedPokt' | 'rewards24h' | 'rewards48h'>,
+): PieChartItem[] {
+  const total = providers.reduce((sum, p) => sum + p[metric], 0)
+  return providers.map((p) => ({
+    id: p.name,
+    value: p[metric],
+    percent: total > 0 ? (p[metric] / total) * 100 : 0,
+  }))
+}
+
+function exportToCsv(providers: ProviderBreakdownData[]) {
+  const header = 'Provider,Suppliers,Staked POKT,24h Rewards,48h Rewards'
+  const rows = providers.map(
+    (p) =>
+      `"${p.name}",${p.suppliers},${p.stakedPokt.toFixed(2)},${p.rewards24h.toFixed(2)},${p.rewards48h.toFixed(2)}`,
+  )
+  const csv = [header, ...rows].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `provider-breakdown-${new Date().toISOString().slice(0, 10)}.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+const cardClasses = 'rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4'
+
+export default function ProviderBreakdown() {
+  const { data: providerCount } = useQuery({
+    queryKey: ['providerCount'],
+    queryFn: GetProviderCount,
+  })
+
+  const { data: providers, isLoading, isError, refetch } = useQuery({
+    queryKey: ['providerBreakdown'],
+    queryFn: GetProviderBreakdown,
+    refetchInterval: 60000,
+    enabled: (providerCount ?? 0) > 1,
+  })
+
+  const [rewardsPeriod, setRewardsPeriod] = useState<'24h' | '48h'>('24h')
+  const [sortKey, setSortKey] = useState<SortKey>('suppliers')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+
+  const sortedProviders = useMemo(() => {
+    if (!providers) return []
+    return [...providers].sort((a, b) => {
+      const aVal = a[sortKey]
+      const bVal = b[sortKey]
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return sortDir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+      }
+      return sortDir === 'asc' ? (aVal as number) - (bVal as number) : (bVal as number) - (aVal as number)
+    })
+  }, [providers, sortKey, sortDir])
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
+
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return null
+    return sortDir === 'asc' ? ' ↑' : ' ↓'
+  }
+
+  const handleExport = useCallback(() => exportToCsv(sortedProviders), [sortedProviders])
+
+  const stakePieData = useMemo(
+    () => buildPieData(sortedProviders, 'suppliers'),
+    [sortedProviders],
+  )
+
+  const rewardsPieData = useMemo(
+    () =>
+      buildPieData(
+        sortedProviders,
+        rewardsPeriod === '24h' ? 'rewards24h' : 'rewards48h',
+      ),
+    [sortedProviders, rewardsPeriod],
+  )
+
+  if ((providerCount ?? 0) <= 1) return null
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-6 w-48 !bg-[color:#383838]" />
+        <div className="flex flex-col xl:flex-row gap-4">
+          <div className={`${cardClasses} flex-1 min-w-0`}>
+            <div className="flex flex-col gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-8 w-full !bg-[color:#383838]" />
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-col gap-4 xl:w-[420px] shrink-0">
+            <div className={`${cardClasses} flex items-center justify-center py-6`}>
+              <Skeleton className="h-[160px] w-[160px] rounded-full !bg-[color:#383838]" />
+            </div>
+            <div className={`${cardClasses} flex items-center justify-center py-6`}>
+              <Skeleton className="h-[160px] w-[160px] rounded-full !bg-[color:#383838]" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-4">
+        <h3 className="text-lg font-semibold">Provider Breakdown</h3>
+        <div className={`${cardClasses} flex flex-col items-center justify-center py-8 gap-3`}>
+          <p className="text-sm text-muted-foreground">
+            There was an error loading the provider breakdown.
+          </p>
+          <Button onClick={() => refetch()} variant="outline" size="sm">
+            Retry
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Provider Breakdown</h3>
+        <Button variant="outline" size="sm" onClick={handleExport} className="gap-1.5">
+          <Download className="h-3.5 w-3.5" />
+          CSV
+        </Button>
+      </div>
+
+      <div className="flex flex-col xl:flex-row gap-4">
+        {/* Table card */}
+        <div className={`${cardClasses} flex-1 min-w-0 overflow-x-auto`}>
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[color:--divider] bg-muted/50">
+                <th className={HEADER_CLASSES} onClick={() => handleSort('name')}>
+                  Provider{sortIndicator('name')}
+                </th>
+                <th className={`${HEADER_CLASSES} text-right`} onClick={() => handleSort('suppliers')}>
+                  Suppliers{sortIndicator('suppliers')}
+                </th>
+                <th className={`${HEADER_CLASSES} text-right`} onClick={() => handleSort('stakedPokt')}>
+                  Staked POKT{sortIndicator('stakedPokt')}
+                </th>
+                <th className={`${HEADER_CLASSES} text-right`} onClick={() => handleSort('rewards24h')}>
+                  24h Rewards{sortIndicator('rewards24h')}
+                </th>
+                <th className={`${HEADER_CLASSES} text-right`} onClick={() => handleSort('rewards48h')}>
+                  48h Rewards{sortIndicator('rewards48h')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedProviders.map((p) => (
+                <tr
+                  key={p.identity}
+                  className="border-b border-[color:--divider] last:border-b-0 hover:bg-muted/30 transition-colors"
+                >
+                  <td className={`${CELL_CLASSES} font-medium`}>{p.name}</td>
+                  <td className={`${CELL_CLASSES} text-right font-mono`}>
+                    {toCurrencyFormat(p.suppliers, 0)}
+                  </td>
+                  <td className={`${CELL_CLASSES} text-right font-mono`}>
+                    {toCurrencyFormat(p.stakedPokt, 0)}
+                  </td>
+                  <td className={`${CELL_CLASSES} text-right font-mono`}>
+                    {toCurrencyFormat(p.rewards24h, 2)}
+                  </td>
+                  <td className={`${CELL_CLASSES} text-right font-mono`}>
+                    {toCurrencyFormat(p.rewards48h, 2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pie charts */}
+        <div className="flex flex-col gap-4 xl:w-[420px] shrink-0">
+          {/* Stake Distribution card */}
+          <div className={`${cardClasses} flex items-center justify-center`}>
+            <DistributionPieChart
+              data={stakePieData}
+              label="Stake Distribution"
+            />
+          </div>
+
+          {/* Rewards card */}
+          <div className={`${cardClasses} flex flex-col items-center justify-center gap-2`}>
+            <div className="flex items-center justify-center gap-2">
+              <p className="text-sm font-medium text-muted-foreground">
+                Rewards
+              </p>
+              <div className="flex rounded-md border border-[color:--divider] overflow-hidden text-xs">
+                <button
+                  onClick={() => setRewardsPeriod('24h')}
+                  className={`px-2 py-0.5 transition-colors cursor-pointer ${
+                    rewardsPeriod === '24h'
+                      ? 'bg-[color:--color-blue-1] text-white'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  24h
+                </button>
+                <button
+                  onClick={() => setRewardsPeriod('48h')}
+                  className={`px-2 py-0.5 transition-colors cursor-pointer ${
+                    rewardsPeriod === '48h'
+                      ? 'bg-[color:--color-blue-1] text-white'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  48h
+                </button>
+              </div>
+            </div>
+            <DistributionPieChart data={rewardsPieData} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/middleman/src/app/app/overview/page.tsx
+++ b/apps/middleman/src/app/app/overview/page.tsx
@@ -10,6 +10,7 @@ import { getApplicationSettings, GetAppName } from '@/actions/ApplicationSetting
 import InitializeHeightContext from '@igniter/ui/context/Height/InitializeContext'
 import Link from 'next/link'
 import { Button } from '@igniter/ui/components/button'
+import ProviderBreakdown from './ProviderBreakdown'
 
 export const dynamic = "force-dynamic";
 
@@ -105,6 +106,8 @@ async function Rewards() {
           </Suspense>
         </div>
 
+        <ProviderBreakdown />
+
         <Suspense
           key={ownerAddresses.join(',')}
           fallback={
@@ -122,3 +125,4 @@ async function Rewards() {
     </ApolloWrapper>
   )
 }
+

--- a/apps/middleman/src/app/app/overview/page.tsx
+++ b/apps/middleman/src/app/app/overview/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { NodeWithDetails } from '@igniter/db/src/middleman/schema'
 import React, { Suspense } from 'react';
 import { GetOwnerAddresses, GetUserNodes } from '@/actions/Nodes'
 import ApolloWrapper from '@igniter/ui/graphql/client'
@@ -84,7 +85,8 @@ async function Rewards() {
     }
   }
 
-  const supplierAddresses = userNodes.map(n => n.address)
+  const supplierAddresses = userNodes.map((n: NodeWithDetails) => n.address)
+  const providerCount = new Set(userNodes.map((n: NodeWithDetails) => n.providerId).filter(Boolean)).size
 
   return (
     <ApolloWrapper url={graphqlUrl}>
@@ -106,7 +108,7 @@ async function Rewards() {
           </Suspense>
         </div>
 
-        <ProviderBreakdown />
+        <ProviderBreakdown providerCount={providerCount} />
 
         <Suspense
           key={ownerAddresses.join(',')}

--- a/apps/middleman/src/app/app/unstake/page.tsx
+++ b/apps/middleman/src/app/app/unstake/page.tsx
@@ -26,7 +26,7 @@ enum UnstakeActivitySteps {
 }
 
 export default function UnstakePage() {
-  const { connectedIdentity, connectedIdentities, isConnected } = useWalletConnection();
+  const { connectedIdentities, isConnected } = useWalletConnection();
   const [step, setStep] = useState<UnstakeActivitySteps>(UnstakeActivitySteps.Information);
   const [selectedOwnerAddress, setSelectedOwnerAddress] = useState<string>('');
   const [selectedNodeAddresses, setSelectedNodeAddresses] = useState<string[]>([]);
@@ -164,7 +164,7 @@ export default function UnstakePage() {
           {step === UnstakeActivitySteps.Review && (
             <ReviewStep
               selectedNodeAddresses={selectedNodeAddresses}
-              ownerAddress={connectedIdentity!}
+              ownerAddress={selectedOwnerAddress}
               errorMessage={unstakingErrorMessage}
               onUnstakeCompleted={(result, transaction) => {
                 if (allStagesSucceeded(result)) {

--- a/apps/middleman/src/lib/dal/nodes.ts
+++ b/apps/middleman/src/lib/dal/nodes.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { getDb } from "@/db";
-import { and, desc, eq, inArray, sql } from 'drizzle-orm'
+import { and, countDistinct, desc, eq, inArray, sql } from 'drizzle-orm'
 import {
   nodesTable,
   NodeWithDetails,
@@ -88,4 +88,13 @@ export async function getExistingNodes(addresses: Array<string>, userIdentity: s
       inArray(nodesTable.address, addresses)
     )
   }).then((nodes) => nodes.map((node) => node.address));
+}
+
+export async function getProviderCountByUser(userIdentity: string): Promise<number> {
+  const result = await getDb()
+    .select({ count: countDistinct(nodesTable.providerId) })
+    .from(nodesTable)
+    .where(eq(nodesTable.createdBy, userIdentity))
+
+  return result[0]?.count ?? 0
 }

--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -1,4 +1,5 @@
 import type {PocketBlockchain, StakeSupplierParams, Supplier} from '@igniter/pocket'
+import {isSequenceMismatchError, parseExpectedSequence} from '@igniter/pocket'
 import type {ApplicationSettings, InsertKey, KeyWithGroup, Service} from '@igniter/db/provider/schema'
 import {ApplicationFailure, log} from '@temporalio/activity'
 import DAL from '@/lib/dal/DAL'
@@ -451,7 +452,35 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
       servicesToStakeCount: stakeParams.services.length,
     })
 
-    const txResult = await pocketRpcClient.stakeSupplier(stakeParams)
+    let txResult = await pocketRpcClient.stakeSupplier(stakeParams)
+
+    // Retry once with the expected sequence if we hit a sequence mismatch error
+    if (!txResult.success && txResult.message && isSequenceMismatchError(txResult.message)) {
+      const expectedSequence = parseExpectedSequence(txResult.message)
+      log.warn('remediateSupplier: Sequence mismatch detected', {
+        address: params.address,
+        originalError: txResult.message,
+        parsedExpectedSequence: expectedSequence,
+      })
+      if (expectedSequence != null) {
+        log.info('remediateSupplier: Retrying stake transaction with expected sequence', {
+          address: params.address,
+          expectedSequence,
+        })
+        txResult = await pocketRpcClient.stakeSupplier(stakeParams, expectedSequence)
+        log.info('remediateSupplier: Retry stake transaction result', {
+          address: params.address,
+          success: txResult.success,
+          code: txResult.code,
+          message: txResult.message,
+        })
+      } else {
+        log.error('remediateSupplier: Could not parse expected sequence from error message, skipping retry', {
+          address: params.address,
+          originalError: txResult.message,
+        })
+      }
+    }
 
     log.debug('remediateSupplier: Stake transaction result', {txResult})
 

--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -474,6 +474,14 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
           code: txResult.code,
           message: txResult.message,
         })
+        // If the retry also fails with a sequence mismatch, throw so Temporal can re-attempt
+        // with a fresh sequence fetch. This handles cases where the sequence advances by 2+
+        // between attempts (e.g., concurrent remediation activities for the same owner).
+        if (!txResult.success && txResult.message && isSequenceMismatchError(txResult.message)) {
+          throw ApplicationFailure.retryable(
+            `remediateSupplier: Sequence mismatch persisted after retry for ${params.address}: ${txResult.message}`,
+          )
+        }
       } else {
         log.error('remediateSupplier: Could not parse expected sequence from error message, skipping retry', {
           address: params.address,

--- a/apps/provider-workflows/src/workflows/SupplierRemediation.ts
+++ b/apps/provider-workflows/src/workflows/SupplierRemediation.ts
@@ -42,7 +42,7 @@ export interface SupplierRemediationInput {
 export async function SupplierRemediation(input: SupplierRemediationInput): Promise<{ height: number, minId: number, maxId: number }> {
   const { getLatestBlock, getKeysMinAndMax } =
     proxyActivities<ReturnType<typeof providerActivities>>({
-      startToCloseTimeout: '240s',
+      startToCloseTimeout: '390s',
       retry: {
         maximumAttempts: 3,
       },

--- a/apps/provider-workflows/src/workflows/SupplierRemediation.ts
+++ b/apps/provider-workflows/src/workflows/SupplierRemediation.ts
@@ -42,7 +42,7 @@ export interface SupplierRemediationInput {
 export async function SupplierRemediation(input: SupplierRemediationInput): Promise<{ height: number, minId: number, maxId: number }> {
   const { getLatestBlock, getKeysMinAndMax } =
     proxyActivities<ReturnType<typeof providerActivities>>({
-      startToCloseTimeout: '120s',
+      startToCloseTimeout: '240s',
       retry: {
         maximumAttempts: 3,
       },

--- a/apps/provider-workflows/src/workflows/SupplierRemediationRange.ts
+++ b/apps/provider-workflows/src/workflows/SupplierRemediationRange.ts
@@ -30,7 +30,7 @@ export async function SupplierRemediationByRange(input: SupplierRemediationByRan
   log.info('SupplierRemediationByRange: execution started', { minId: input.minId, maxId: input.maxId })
   const { loadKeysInRange, remediateSupplier } =
     proxyActivities<ReturnType<typeof providerActivities>>({
-      startToCloseTimeout: '120s',
+      startToCloseTimeout: '240s',
       retry: {
         maximumAttempts: 10,
       },

--- a/apps/provider-workflows/src/workflows/SupplierRemediationRange.ts
+++ b/apps/provider-workflows/src/workflows/SupplierRemediationRange.ts
@@ -30,9 +30,9 @@ export async function SupplierRemediationByRange(input: SupplierRemediationByRan
   log.info('SupplierRemediationByRange: execution started', { minId: input.minId, maxId: input.maxId })
   const { loadKeysInRange, remediateSupplier } =
     proxyActivities<ReturnType<typeof providerActivities>>({
-      startToCloseTimeout: '240s',
+      startToCloseTimeout: '390s',
       retry: {
-        maximumAttempts: 10,
+        maximumAttempts: 3,
       },
     })
 

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -1,5 +1,6 @@
 import {
   BroadcastTxError,
+  calculateFee,
   GasPrice,
   ProtobufRpcClient,
   QueryClient,
@@ -7,6 +8,7 @@ import {
   StargateClient, TimeoutError,
 } from '@cosmjs/stargate'
 import {DirectSecp256k1Wallet, GeneratedType, Registry} from '@cosmjs/proto-signing'
+import {TxRaw} from 'cosmjs-types/cosmos/tx/v1beta1/tx'
 import {
   Comet38Client,
   connectComet,
@@ -36,6 +38,24 @@ import {getLogger, Logger} from '@igniter/logger'
 
 export * from './types'
 export * from './constants';
+
+/**
+ * Parses the expected sequence number from a Cosmos SDK account sequence mismatch error.
+ * Error format: "account sequence mismatch, expected X, got Y: incorrect account sequence"
+ * @returns The expected sequence number, or null if the error doesn't match.
+ */
+export function parseExpectedSequence(errorMessage: string): number | null {
+  const match = errorMessage.match(/account sequence mismatch, expected (\d+), got (\d+)/)
+  if (!match) return null
+  return parseInt(match[1]!, 10)
+}
+
+/**
+ * Returns true if the error message indicates a Cosmos SDK account sequence mismatch.
+ */
+export function isSequenceMismatchError(errorMessage: string): boolean {
+  return errorMessage.includes('account sequence mismatch')
+}
 
 /**
  * Creates a Protobuf-based RPC client for querying a blockchain using a QueryClient.
@@ -308,10 +328,10 @@ export class PocketBlockchain {
     }
   }
 
-  async stakeSupplier(params: StakeSupplierParams): Promise<SendTransactionResult> {
+  async stakeSupplier(params: StakeSupplierParams, explicitSequence?: number): Promise<SendTransactionResult> {
     const { signerPrivateKey, signer, ...value } = params
 
-    this.logger.info({ params: { signer, ...value } },'stakeSupplier: Execution started')
+    this.logger.info({ params: { signer, ...value }, explicitSequence },'stakeSupplier: Execution started')
 
     if (!isValidPrivateKey(signerPrivateKey)) throw new Error('Invalid secp256k1 private key')
     if (!signer) throw new Error('`signer` (bech32) is required')
@@ -351,9 +371,29 @@ export class PocketBlockchain {
         signer,
         messages: [msg],
         fee: 'auto',
+        explicitSequence,
       },'stakeSupplier: Signing and broadcasting transaction')
 
-      const result = await signingClient.signAndBroadcast(signer, [msg], 'auto', '', BigInt(currentHeight + 5))
+      let result
+      if (explicitSequence != null) {
+        // Use explicit sequence to avoid sequence mismatch on retry
+        this.logger.info({ signer, explicitSequence }, 'stakeSupplier: Using explicit sequence for signing')
+        const gasEstimation = await signingClient.simulate(signer, [msg], '')
+        const fee = calculateFee(Math.round(gasEstimation * 1.3), this.gasPrice!)
+        const { accountNumber } = await signingClient.getSequence(signer)
+        const chainId = await signingClient.getChainId()
+        this.logger.debug({ signer, accountNumber, explicitSequence, chainId }, 'stakeSupplier: Signing with explicit signer data')
+        const txRaw = await signingClient.sign(signer, [msg], fee, '', {
+          accountNumber,
+          sequence: explicitSequence,
+          chainId,
+        }, BigInt(currentHeight + 5))
+        const txBytes = TxRaw.encode(txRaw).finish()
+        this.logger.debug({ signer }, 'stakeSupplier: Broadcasting transaction with explicit sequence')
+        result = await signingClient.broadcastTx(txBytes)
+      } else {
+        result = await signingClient.signAndBroadcast(signer, [msg], 'auto', '', BigInt(currentHeight + 5))
+      }
 
       this.logger.info({ result },'stakeSupplier: Execution ended. Transaction sent.')
 

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -378,7 +378,13 @@ export class PocketBlockchain {
       if (explicitSequence != null) {
         // Use explicit sequence to avoid sequence mismatch on retry
         this.logger.info({ signer, explicitSequence }, 'stakeSupplier: Using explicit sequence for signing')
-        const gasEstimation = await signingClient.simulate(signer, [msg], '')
+        let gasEstimation: number
+        try {
+          gasEstimation = await signingClient.simulate(signer, [msg], '')
+        } catch (simErr: any) {
+          this.logger.warn({ signer, error: simErr?.message ? simErr.message : simErr }, 'stakeSupplier: simulate failed in explicit-sequence path, using fallback gas estimate')
+          gasEstimation = 350_000
+        }
         const fee = calculateFee(Math.round(gasEstimation * 1.3), this.gasPrice!)
         const { accountNumber } = await signingClient.getSequence(signer)
         const chainId = await signingClient.getChainId()

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -402,6 +402,7 @@ export class PocketBlockchain {
     return await SigningStargateClient.createWithSigner(comet, wallet, {
       registry,
       gasPrice: this.gasPrice,
+      broadcastTimeoutMs: 3 * 60 * 1000,
     })
   }
 }

--- a/packages/ui/src/components/DataTable/Pagination.tsx
+++ b/packages/ui/src/components/DataTable/Pagination.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuTrigger,
 } from "@igniter/ui/components/dropdown-menu";
 import { CheckSmallIcon } from "@igniter/ui/assets";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface PaginationProps {
   totalPages: number;
@@ -20,8 +21,20 @@ export default function Pagination({
   onPageChange,
   disabled,
 }: PaginationProps) {
+  const canPrev = currentPage > 0 && !disabled
+  const canNext = currentPage < totalPages - 1 && !disabled
+
   return (
-    <div className="flex items-center justify-end space-x-2 py-4">
+    <div className="flex items-center justify-end space-x-1 py-4">
+      <button
+        className="flex items-center justify-center p-2 bg-(--input-bg) border rounded-lg hover:bg-secondary disabled:opacity-50 disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground transition-colors"
+        disabled={!canPrev}
+        onClick={() => onPageChange(currentPage - 1)}
+        aria-label="Previous page"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+
       <DropdownMenu>
         <DropdownMenuTrigger disabled={totalPages <= 1 || disabled}>
           <div className="flex items-center gap-2 p-2">
@@ -30,7 +43,7 @@ export default function Pagination({
             </span>
           </div>
         </DropdownMenuTrigger>
-        <DropdownMenuContent side="top">
+        <DropdownMenuContent side="top" className="max-h-60 overflow-y-auto">
           {Array.from({ length: totalPages }, (_, i) => (
             <DropdownMenuItem
               key={i}
@@ -43,6 +56,15 @@ export default function Pagination({
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <button
+        className="flex items-center justify-center p-2 bg-(--input-bg) border rounded-lg hover:bg-secondary disabled:opacity-50 disabled:pointer-events-none disabled:bg-muted disabled:text-muted-foreground transition-colors"
+        disabled={!canNext}
+        onClick={() => onPageChange(currentPage + 1)}
+        aria-label="Next page"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
     </div>
   );
 }

--- a/packages/ui/src/components/DataTable/index.tsx
+++ b/packages/ui/src/components/DataTable/index.tsx
@@ -87,18 +87,17 @@ export default function DataTable<TData extends object, TValue>({
       desc: defaultSort.direction === "desc",
     }] : []
   );
-  const initialFilters = React.useMemo(() => {
-    return filters.flatMap((filterGroup) =>
+
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
+    filters.flatMap((filterGroup) =>
       filterGroup.items.flat()
         .filter((f) => f.isDefault && f.value !== '')
         .map((f) => ({ id: String(f.column), value: f.value }))
     )
-  }, [])
-
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    initialFilters
   );
   const [globalFilter, setGlobalFilter] = React.useState('')
+  const [searchInput, setSearchInput] = React.useState('')
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const globalFilterFn = React.useMemo(() => {
     if (!searchableColumns?.length) return undefined
@@ -212,8 +211,13 @@ export default function DataTable<TData extends object, TValue>({
           <input
             type="text"
             placeholder={searchPlaceholder}
-            value={globalFilter}
-            onChange={(e) => setGlobalFilter(e.target.value)}
+            value={searchInput}
+            onChange={(e) => {
+              const value = e.target.value
+              setSearchInput(value)
+              if (debounceRef.current) clearTimeout(debounceRef.current)
+              debounceRef.current = setTimeout(() => setGlobalFilter(value), 300)
+            }}
             disabled={isLoading || isError}
             className="h-9 w-full sm:max-w-sm md:max-w-md rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[color:--color-blue-1] disabled:opacity-50"
           />

--- a/packages/ui/src/components/DataTable/index.tsx
+++ b/packages/ui/src/components/DataTable/index.tsx
@@ -60,6 +60,9 @@ export interface DataTableProps<TData extends object, TValue> {
   csvFilename?: string
   refetch?: () => void,
   columnVisibility?: Record<string, boolean>
+  /** Column keys to search across with the global search input */
+  searchableColumns?: (keyof TData)[]
+  searchPlaceholder?: string
 }
 
 export default function DataTable<TData extends object, TValue>({
@@ -73,6 +76,8 @@ export default function DataTable<TData extends object, TValue>({
   refetch,
   csvFilename,
   columnVisibility,
+  searchableColumns,
+  searchPlaceholder = 'Search...',
 }: DataTableProps<TData, TValue>) {
   const defaultSort = sorts.flat().find((sort) => sort.isDefault);
 
@@ -82,9 +87,34 @@ export default function DataTable<TData extends object, TValue>({
       desc: defaultSort.direction === "desc",
     }] : []
   );
+  const initialFilters = React.useMemo(() => {
+    return filters.flatMap((filterGroup) =>
+      filterGroup.items.flat()
+        .filter((f) => f.isDefault && f.value !== '')
+        .map((f) => ({ id: String(f.column), value: f.value }))
+    )
+  }, [])
+
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
+    initialFilters
   );
+  const [globalFilter, setGlobalFilter] = React.useState('')
+
+  const globalFilterFn = React.useMemo(() => {
+    if (!searchableColumns?.length) return undefined
+    return (row: any, _columnId: string, filterValue: string) => {
+      if (!filterValue) return true
+      const q = filterValue.toLowerCase()
+      return searchableColumns.some((col) => {
+        const val = row.getValue(String(col))
+        if (val == null) return false
+        if (typeof val === 'object' && 'name' in val) {
+          return String(val.name).toLowerCase().includes(q)
+        }
+        return String(val).toLowerCase().includes(q)
+      })
+    }
+  }, [searchableColumns])
 
   const table = useReactTable({
     data,
@@ -95,6 +125,8 @@ export default function DataTable<TData extends object, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn,
     autoResetPageIndex: true,
     initialState: {
       pagination: {
@@ -106,6 +138,7 @@ export default function DataTable<TData extends object, TValue>({
     state: {
       columnFilters,
       sorting,
+      globalFilter,
     },
   });
 
@@ -174,8 +207,18 @@ export default function DataTable<TData extends object, TValue>({
 
   return (
     <div>
-      <div className="flex items-center justify-end space-x-2 pb-6">
-        <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2 pb-6">
+        {searchableColumns?.length ? (
+          <input
+            type="text"
+            placeholder={searchPlaceholder}
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            disabled={isLoading || isError}
+            className="h-9 w-full sm:max-w-sm md:max-w-md rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[color:--color-blue-1] disabled:opacity-50"
+          />
+        ) : <div />}
+        <div className="flex items-center gap-2 flex-wrap">
           {csvFilename && (
             <ExportButton
               columns={columns}

--- a/packages/ui/src/components/PieChart/PieChart.tsx
+++ b/packages/ui/src/components/PieChart/PieChart.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import React, { useCallback, useMemo, useRef } from 'react'
+import { Pie } from 'react-chartjs-2'
+import type { Chart as ChartJS, ChartData, ChartOptions } from 'chart.js'
+import { PIE_CHART_TOP_ITEMS, PIE_COLORS, PIE_OTHERS_COLOR } from './constants'
+
+export interface PieChartItem {
+  id: string
+  value: number
+  percent: number
+}
+
+export interface DistributionPieChartProps {
+  data: PieChartItem[]
+  label?: string
+  topItems?: number
+  className?: string
+  /** 'right' (default) places the legend beside the chart; 'bottom' places it below in a multi-column grid */
+  legendPosition?: 'right' | 'bottom'
+  /** Pie chart canvas size in pixels (default 160) */
+  size?: number
+}
+
+function groupItems(data: PieChartItem[], topItems: number): { items: PieChartItem[]; othersItems: PieChartItem[] } {
+  const sorted = [...data].sort((a, b) => b.value - a.value)
+  const top = sorted.slice(0, topItems)
+  const rest = sorted.slice(topItems)
+
+  if (rest.length > 0) {
+    const othersValue = rest.reduce((sum, item) => sum + item.value, 0)
+    const othersPercent = rest.reduce((sum, item) => sum + item.percent, 0)
+    top.push({ id: 'Others', value: othersValue, percent: othersPercent })
+  }
+
+  return { items: top, othersItems: rest }
+}
+
+function getColors(items: PieChartItem[]): string[] {
+  return items.map((item, i) =>
+    item.id === 'Others'
+      ? PIE_OTHERS_COLOR
+      : (PIE_COLORS[i % PIE_COLORS.length] ?? PIE_OTHERS_COLOR)
+  )
+}
+
+/** Convert a hex color to rgba with the given alpha */
+function withAlpha(color: string, alpha: number): string {
+  // Handle hex colors (#RRGGBB)
+  if (color.startsWith('#')) {
+    const r = parseInt(color.slice(1, 3), 16)
+    const g = parseInt(color.slice(3, 5), 16)
+    const b = parseInt(color.slice(5, 7), 16)
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`
+  }
+  return color
+}
+
+export default function DistributionPieChart({
+  data,
+  label,
+  topItems = PIE_CHART_TOP_ITEMS,
+  className,
+  legendPosition = 'right',
+  size = 160,
+}: DistributionPieChartProps) {
+  const chartRef = useRef<ChartJS<'pie'>>(null)
+  const { items, othersItems } = useMemo(() => groupItems(data, topItems), [data, topItems])
+  const colors = useMemo(() => getColors(items), [items])
+
+  const chartOptions: ChartOptions<'pie'> = useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: true,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        displayColors: false,
+        callbacks: {
+          label: (context) => {
+            const value = context.raw as number
+            if (context.label === 'Others' && othersItems.length > 0) {
+              return [
+                ...othersItems.map(
+                  (item) => `  ${item.id}: ${item.value.toLocaleString()}`
+                ),
+                `  Total: ${value.toLocaleString()}`,
+              ]
+            }
+            return ` ${value.toLocaleString()}`
+          },
+        },
+      },
+    },
+  }), [othersItems])
+
+  const handleLegendClick = useCallback((index: number) => {
+    const chart = chartRef.current
+    if (!chart) return
+
+    const meta = chart.getDatasetMeta(0)
+    const element = meta.data[index]
+    if (!element) return
+
+    chart.tooltip?.setActiveElements(
+      [{ datasetIndex: 0, index }],
+      { x: element.x, y: element.y },
+    )
+    chart.update()
+  }, [])
+
+  const chartData: ChartData<'pie'> = useMemo(
+    () => ({
+      labels: items.map((item) => item.id),
+      datasets: [
+        {
+          data: items.map((item) => item.value),
+          backgroundColor: colors,
+          borderColor: colors.map((c) => withAlpha(c, 0.4)),
+          borderWidth: 2,
+        },
+      ],
+    }),
+    [items, colors],
+  )
+
+  if (!data.length) return null
+
+  const legend = (
+    <div
+      className={
+        legendPosition === 'bottom'
+          ? 'grid grid-cols-2 gap-x-3 gap-y-1.5'
+          : 'flex flex-col gap-1.5 min-w-0'
+      }
+    >
+      {items.map((item, index) => (
+        <div
+          key={item.id}
+          className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+          onClick={() => handleLegendClick(index)}
+        >
+          <span
+            className="inline-flex items-center justify-center rounded-sm px-1.5 py-0.5 text-[11px] font-bold text-white shrink-0 min-w-[42px]"
+            style={{ backgroundColor: colors[index] }}
+          >
+            {item.percent.toFixed(1)}%
+          </span>
+          <span className="text-sm truncate text-foreground">
+            {item.id}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+
+  return (
+    <div className={`flex flex-col gap-3 ${className ?? ''}`}>
+      {label && (
+        <p className="text-sm font-medium text-muted-foreground text-center">{label}</p>
+      )}
+      {legendPosition === 'bottom' ? (
+        <>
+          <div className="shrink-0 mx-auto" style={{ width: size, height: size }}>
+            <Pie ref={chartRef} data={chartData} options={chartOptions} />
+          </div>
+          {legend}
+        </>
+      ) : (
+        <div className="flex flex-row items-center gap-6">
+          <div className="shrink-0" style={{ width: size, height: size }}>
+            <Pie ref={chartRef} data={chartData} options={chartOptions} />
+          </div>
+          {legend}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/components/PieChart/constants.ts
+++ b/packages/ui/src/components/PieChart/constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Maximum number of slices shown in pie charts before grouping the rest as "Others".
+ * Override via NEXT_PUBLIC_PIE_CHART_TOP_ITEMS env var.
+ */
+export const PIE_CHART_TOP_ITEMS: number =
+  Number(process.env.NEXT_PUBLIC_PIE_CHART_TOP_ITEMS) || 5
+
+/**
+ * Pie chart color palette — designed for dark backgrounds (#0a0e13 / #1c2532).
+ * Slots 0–4 match the app's --chart-1 through --chart-5 CSS variables.
+ * Slots 5–6 are complementary extended hues.
+ */
+export const PIE_COLORS = [
+  '#3b82f6', // blue-500
+  '#14b8a6', // teal-500
+  '#a855f7', // purple-500
+  '#06b6d4', // cyan-500
+  '#6366f1', // indigo-500
+  '#f59e0b', // amber-500
+  '#f43f5e', // rose-500
+  '#10b981', // emerald-500
+  '#0ea5e9', // sky-500
+  '#d946ef', // fuchsia-500
+  '#84cc16', // lime-500
+  '#f97316', // orange-500
+  '#8b5cf6', // violet-500
+] as const
+
+/** Color used for the "Others" slice — muted slate. */
+export const PIE_OTHERS_COLOR = '#64748b' // slate-500

--- a/packages/ui/src/components/PieChart/index.ts
+++ b/packages/ui/src/components/PieChart/index.ts
@@ -1,0 +1,3 @@
+export { default as DistributionPieChart } from './PieChart'
+export type { PieChartItem, DistributionPieChartProps } from './PieChart'
+export { PIE_CHART_TOP_ITEMS, PIE_COLORS, PIE_OTHERS_COLOR } from './constants'

--- a/packages/ui/src/components/RewardsByAddresses/RewardsByAddressChart.tsx
+++ b/packages/ui/src/components/RewardsByAddresses/RewardsByAddressChart.tsx
@@ -5,7 +5,8 @@ import {
 } from './operations'
 import { useChartType } from '../BaseLineBarChart/ChartType'
 import { useDataContext } from '../../context/data'
-import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useApolloClient } from '@apollo/client'
 import ErrorRetry  from '../ErrorRetry'
 import NoData from '../NoData'
 import BaseLineBarChart from '../BaseLineBarChart/BaseLineBarChart'
@@ -17,10 +18,12 @@ import ItemsSelector from './ItemsSelector'
 import { clsx } from 'clsx'
 import { useGroupAll } from './GroupAllSwitch'
 import { amountToPokt, getShortAddress, toCompactFormat, toCurrencyFormat } from '../../lib/utils'
-import useFetchOnBlock, { DocumentNodeData, ExtractVariables } from '../../hooks/useFetchOnNewBlock'
+import { DocumentNodeData, ExtractVariables } from '../../hooks/useFetchOnNewBlock'
 import { ContentLoader } from './Loader'
 import { rewardsByAddressAndTimeGroupByDateDocument } from '@igniter/graphql/rewards'
 import { useSelectedTime } from './TimeSelector'
+import { useHeightContext } from '../../context/Height/height'
+import { batchArray } from '../../lib/batch'
 
 export interface RewardItem extends LineBarItem {
   totalAmount: number
@@ -46,25 +49,79 @@ export default function RewardsByAddressChart({
   const {chartType} = useChartType()
   const {setData, data} = useDataContext<RewardItem>()
   const {selectedTime} = useSelectedTime()
+  const client = useApolloClient()
+  const { currentHeight, currentTime, firstHeight } = useHeightContext()
   const lastVariables = useRef<ExtractVariables<typeof rewardsByAddressAndTimeGroupByDateDocument>>(initialVariables)
 
-  const variables = useCallback((_: number, timestamp: string) => {
-    return lastVariables.current = rewardsByAddressAndTimeGroupByDateVariables(
-      addresses,
-      supplierAddresses,
-      timestamp,
-      selectedTime,
-    )
-  }, [addresses, supplierAddresses, selectedTime])
+  type RewardsData = DocumentNodeData<typeof rewardsByAddressAndTimeGroupByDateDocument>
+  const [rawData, setRawData] = useState<RewardsData | null>(initialData)
+  const [error, setError] = useState(initialError)
+  const [isLoading, setIsLoading] = useState(false)
+  const firstRenderRef = useRef(true)
+  const lastSelectedTimeRef = useRef(selectedTime)
 
-  const { data: rawData, error, refetch, isLoading } = useFetchOnBlock({
-    query: rewardsByAddressAndTimeGroupByDateDocument,
-    variables,
-    initialResult: initialData,
-    initialError,
-    skip: !addresses.length,
-    updateOnNewSession: true,
-  })
+  const fetchBatched = useCallback(async () => {
+    if (!addresses.length) return
+
+    setIsLoading(true)
+    try {
+      const batches = batchArray(supplierAddresses)
+      const results = await Promise.all(
+        batches.map((batch) => {
+          const vars = rewardsByAddressAndTimeGroupByDateVariables(
+            addresses,
+            batch,
+            currentTime,
+            selectedTime,
+          )
+          lastVariables.current = vars
+          return client.query({
+            query: rewardsByAddressAndTimeGroupByDateDocument,
+            variables: vars,
+            fetchPolicy: 'network-only',
+          })
+        }),
+      )
+
+      const aggregated = results.reduce(
+        (acc, { data: d }) => {
+          if (!acc) return d
+          const accRewards = Array.isArray(acc.rewards) ? acc.rewards : []
+          const dRewards = Array.isArray(d.rewards) ? d.rewards : []
+          return { ...d, rewards: [...accRewards, ...dRewards] }
+        },
+        null as RewardsData | null,
+      )
+
+      setRawData(aggregated)
+      setError(false)
+    } catch {
+      setError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [client, addresses, supplierAddresses, currentTime, selectedTime])
+
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false
+      return
+    }
+
+    if (!addresses.length) return
+
+    // Refetch on new session or when selectedTime changes
+    const timeChanged = lastSelectedTimeRef.current !== selectedTime
+    lastSelectedTimeRef.current = selectedTime
+
+    if (
+      timeChanged ||
+      currentHeight !== firstHeight
+    ) {
+      fetchBatched()
+    }
+    // eslint-disable-next-line
+  }, [currentHeight, selectedTime])
 
   const {groupAll: groupAllAddresses} = useGroupAll()
 
@@ -212,7 +269,7 @@ export default function RewardsByAddressChart({
     content = (
       <div className={'mt-[-10px] flex w-full grow'}>
         <ErrorRetry
-          onRetry={refetch}
+          onRetry={fetchBatched}
         />
       </div>
     )

--- a/packages/ui/src/components/RewardsByAddresses/ServerRewardsByAddresses.tsx
+++ b/packages/ui/src/components/RewardsByAddresses/ServerRewardsByAddresses.tsx
@@ -14,6 +14,7 @@ import { getLatestBlock } from '../../api/blocks'
 import { getServerApolloClient } from '../../lib/graphql/server'
 import { getValidTime, Time } from '../../lib/dates'
 import { SelectedTimeProvider } from './TimeSelector'
+import { batchArray } from '../../lib/batch'
 
 interface RewardsByAddressesProps {
   addresses: Array<string>
@@ -44,21 +45,41 @@ export default async function ServerRewardsByAddresses({
       chartType = cookiesAwaited?.get(chartTypeCookieKey)?.value === 'bar' ? 'bar' : 'line'
 
       const latestBlock = await getLatestBlock(graphQlUrl)
+      const client = getServerApolloClient(graphQlUrl)
+      const batches = batchArray(supplierAddresses)
 
+      // Use first batch's variables as the canonical variables for client-side refresh
       variables = rewardsByAddressAndTimeGroupByDateVariables(
         addresses,
-        supplierAddresses,
+        batches[0] ?? [],
         latestBlock.timestamp,
         timeSelected,
       )
 
-      const response = await getServerApolloClient(graphQlUrl)
-        .query({
-          query: rewardsByAddressAndTimeGroupByDateDocument,
-          variables,
-        })
+      const results = await Promise.all(
+        batches.map((batch) =>
+          client.query({
+            query: rewardsByAddressAndTimeGroupByDateDocument,
+            variables: rewardsByAddressAndTimeGroupByDateVariables(
+              addresses,
+              batch,
+              latestBlock.timestamp,
+              timeSelected,
+            ),
+          }),
+        ),
+      )
 
-      data = response.data
+      // Aggregate: concatenate the rewards JSON arrays from each batch
+      data = results.reduce(
+        (acc, { data: d }) => {
+          if (!acc) return d
+          const accRewards = Array.isArray(acc.rewards) ? acc.rewards : []
+          const dRewards = Array.isArray(d.rewards) ? d.rewards : []
+          return { ...d, rewards: [...accRewards, ...dRewards] }
+        },
+        null as typeof results[0]['data'] | null,
+      )
     } catch {
       error = true
     }

--- a/packages/ui/src/components/RewardsSummary/ServerSummary.tsx
+++ b/packages/ui/src/components/RewardsSummary/ServerSummary.tsx
@@ -3,6 +3,7 @@ import Summary from './Summary'
 import { getLatestBlock } from '../../api/blocks'
 import { getServerApolloClient } from '../../lib/graphql/server'
 import { summaryDocument } from '@igniter/graphql/rewards'
+import { batchArray } from '../../lib/batch'
 
 interface ServerSummaryProps {
   addresses: Array<string>
@@ -24,18 +25,51 @@ export default async function ServerSummary({
   if (addresses.length) {
     try {
       const latestBlock = await getLatestBlock(graphQlUrl)
+      const client = getServerApolloClient(graphQlUrl)
+      const batches = batchArray(supplierAddresses)
 
-      const response = await getServerApolloClient(graphQlUrl).query({
-        query: summaryDocument,
-        variables: summaryVariables(
-          isOwners,
-          addresses,
-          supplierAddresses,
-          latestBlock.timestamp
-        )
-      })
+      const results = await Promise.all(
+        batches.map((batch) =>
+          client.query({
+            query: summaryDocument,
+            variables: summaryVariables(
+              isOwners,
+              addresses,
+              batch,
+              latestBlock.timestamp,
+            ),
+          }),
+        ),
+      )
 
-      data = response.data
+      // Aggregate results across batches
+      data = results.reduce(
+        (acc, { data: d }) => {
+          if (!acc) return d
+          return {
+            ...d,
+            suppliers: {
+              ...d.suppliers,
+              totalCount:
+                (acc.suppliers?.totalCount ?? 0) +
+                (d.suppliers?.totalCount ?? 0),
+              aggregates: {
+                ...d.suppliers?.aggregates,
+                sum: {
+                  stakeAmount:
+                    Number(acc.suppliers?.aggregates?.sum?.stakeAmount ?? 0) +
+                    Number(d.suppliers?.aggregates?.sum?.stakeAmount ?? 0),
+                },
+              },
+            },
+            last24h:
+              Number(acc.last24h ?? 0) + Number(d.last24h ?? 0),
+            last48h:
+              Number(acc.last48h ?? 0) + Number(d.last48h ?? 0),
+          }
+        },
+        null as typeof results[0]['data'] | null,
+      )
     } catch {
       error = true
     }

--- a/packages/ui/src/components/RewardsSummary/Summary.tsx
+++ b/packages/ui/src/components/RewardsSummary/Summary.tsx
@@ -1,16 +1,48 @@
 'use client'
 
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useApolloClient } from '@apollo/client'
 import ErrorRetry from '../ErrorRetry'
 import FourCard from '../FourCards/FourCard'
 import { combineByIndex } from '../FourCards/utils'
 import { labels } from './constants'
 import NoData from '../NoData'
 import { amountToPokt, toCurrencyFormat } from '../../lib/utils'
-import useFetchOnBlock, { DocumentNodeData } from '../../hooks/useFetchOnNewBlock'
+import { DocumentNodeData } from '../../hooks/useFetchOnNewBlock'
+import { useHeightContext } from '../../context/Height/height'
 import { summaryDocument } from '@igniter/graphql/rewards'
 import { summaryVariables } from './operations'
+import { batchArray } from '../../lib/batch'
 import SummaryLoader from './Loader'
+
+type SummaryData = DocumentNodeData<typeof summaryDocument>
+
+function aggregateSummaryResults(results: SummaryData[]): SummaryData {
+  return results.reduce((acc, d) => {
+    if (!acc) return d
+    return {
+      ...d,
+      suppliers: {
+        ...d.suppliers,
+        totalCount:
+          (acc.suppliers?.totalCount ?? 0) +
+          (d.suppliers?.totalCount ?? 0),
+        aggregates: {
+          ...d.suppliers?.aggregates,
+          sum: {
+            stakeAmount:
+              Number(acc.suppliers?.aggregates?.sum?.stakeAmount ?? 0) +
+              Number(d.suppliers?.aggregates?.sum?.stakeAmount ?? 0),
+          },
+        },
+      },
+      last24h:
+        Number(acc.last24h ?? 0) + Number(d.last24h ?? 0),
+      last48h:
+        Number(acc.last48h ?? 0) + Number(d.last48h ?? 0),
+    }
+  }) as SummaryData
+}
 
 function Value({value}: {value: string}) {
   return (
@@ -37,26 +69,62 @@ export default function Summary({
   initialError,
   initialData
 }: SummaryProps) {
-  const variables = useCallback((_: number, currentTime: string) => {
-    return summaryVariables(isOwners, addresses, supplierAddresses, currentTime)
-  }, [isOwners, addresses, supplierAddresses])
+  const client = useApolloClient()
+  const { currentHeight, currentTime, firstHeight } = useHeightContext()
+  const [data, setData] = useState<SummaryData | null>(initialData)
+  const [error, setError] = useState(initialError)
+  const [isLoading, setIsLoading] = useState(false)
+  const firstRenderRef = useRef(true)
+  const lastValueRef = useRef<SummaryData | null>(initialData)
 
-  const { data, error, refetch, isLoading } = useFetchOnBlock({
-    query: summaryDocument,
-    variables,
-    initialResult: initialData,
-    initialError,
-    skip: !addresses.length,
-    updateOnNewSession: true,
-  })
+  const fetchBatched = useCallback(async () => {
+    if (!addresses.length) return
 
-  if (isLoading) {
+    setIsLoading(true)
+    try {
+      const batches = batchArray(supplierAddresses)
+      const results = await Promise.all(
+        batches.map((batch) =>
+          client.query({
+            query: summaryDocument,
+            variables: summaryVariables(isOwners, addresses, batch, currentTime),
+            fetchPolicy: 'network-only',
+          }),
+        ),
+      )
+
+      const aggregated = aggregateSummaryResults(results.map((r) => r.data))
+      lastValueRef.current = aggregated
+      setData(aggregated)
+      setError(false)
+    } catch {
+      setError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [client, isOwners, addresses, supplierAddresses, currentTime])
+
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false
+      return
+    }
+
+    if (!addresses.length) return
+
+    if (currentHeight !== firstHeight) {
+      fetchBatched()
+    }
+    // eslint-disable-next-line
+  }, [currentHeight])
+
+  if (isLoading && !lastValueRef.current) {
     return <SummaryLoader />
-  } else if (error) {
+  } else if (error && !lastValueRef.current) {
     return (
       <div className={"bg-[color:--main-background] pt-3 pb-1 gap-1 rounded-lg border border-[color:--divider] base-shadow"}>
         <ErrorRetry
-          onRetry={refetch}
+          onRetry={fetchBatched}
           errorMessage={'Oops. There was an error loading the summary data.'}
         />
       </div>

--- a/packages/ui/src/lib/batch.ts
+++ b/packages/ui/src/lib/batch.ts
@@ -1,0 +1,15 @@
+const SUPPLIER_BATCH_SIZE = 200
+
+/**
+ * Split an array into batches to avoid oversized GraphQL requests (413 errors).
+ * Returns the original array wrapped in a single-element array if it's small enough.
+ */
+export function batchArray<T>(items: T[], batchSize = SUPPLIER_BATCH_SIZE): T[][] {
+  if (items.length <= batchSize) return [items]
+
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += batchSize) {
+    batches.push(items.slice(i, i + batchSize))
+  }
+  return batches
+}


### PR DESCRIPTION
# Middleman UX improvements and remediation retry

## Summary

- **Provider Breakdown**: New overview section with sortable table, pie charts (stake distribution & rewards), CSV export. Uses `useQuery` with `refetch` for error retry. Only renders for multi-provider users via lightweight `COUNT DISTINCT` query to avoid skeleton flash.
- **Services Overview & Provider Stats**: New supplier page sections with loading/error states and retry buttons.
- **PieChart component**: Reusable pie chart with interactive legend clicks, "Others" tooltip breakdown, configurable size and legend position.
- **DataTable improvements**: Global search input, prev/next pagination buttons, default filter support (`isDefault`), responsive toolbar with `flex-wrap`.
- **GraphQL batching**: Server-side and client-side request batching (batch size 200) across Summary, RewardsByAddressChart, and ProviderBreakdown to handle large supplier sets.
- **Sequence mismatch retry**: Retry logic in `remediateSupplier` for Cosmos SDK account sequence mismatch errors — parses expected sequence from error and retries `stakeSupplier` with explicit `SignerData`.
- **Timeout increases**: Higher timeouts for broadcast and supplier remediation workflows.
- **Bug fix**: Corrected supplier stats API variable name (`domains` → `pDomains`).

## Changes

### Middleman App (`apps/middleman`)

- `actions/Nodes.ts` — Added `GetProviderBreakdown` (server action with batched GraphQL) and `GetProviderCount` (lightweight distinct count)
- `app/overview/page.tsx` — Added client-side `ProviderBreakdown` component
- `app/overview/ProviderBreakdown.tsx` — **New** — Client component with `useQuery`, loading/error/retry states, sortable table, pie charts, CSV export
- `app/(lists)/nodes/ChainOverview.tsx` — **New** — Services overview with loading/error states
- `app/(lists)/nodes/ProviderStats.tsx` — **New** — Provider stats with loading/error states
- `app/(lists)/nodes/page.tsx` — Integrated new sections
- `app/(lists)/nodes/table/columns.tsx` — Default filter (Staked), added Unstaked filter, new sort options (Stake Amount, Balance, Created At)
- `app/(lists)/nodes/table/index.tsx` — Added search by address/owner/provider
- `app/unstake/page.tsx` — Use `selectedOwnerAddress` instead of `connectedIdentity`
- `lib/dal/nodes.ts` — Added `getProviderCountByUser` (COUNT DISTINCT query)

### Provider Workflows (`apps/provider-workflows`)

- `activities/index.ts` — Sequence mismatch detection and retry with expected sequence in `remediateSupplier`; fixed `domains` → `pDomains`
- `workflows/SupplierRemediation.ts` — Increased timeout
- `workflows/SupplierRemediationRange.ts` — Increased timeout

### Pocket Package (`packages/pocket`)

- `index.ts` — Added `parseExpectedSequence`, `isSequenceMismatchError` utilities; added `explicitSequence` parameter to `stakeSupplier` with manual sign + broadcast flow

### UI Package (`packages/ui`)

- `components/DataTable/index.tsx` — Global search input, responsive toolbar, initial filter support
- `components/DataTable/Pagination.tsx` — Prev/next page buttons
- `components/PieChart/` — **New** — Reusable pie chart component with interactive legend and tooltip breakdown
- `components/RewardsSummary/ServerSummary.tsx` — Server-side batching
- `components/RewardsSummary/Summary.tsx` — Client-side batched refetch
- `components/RewardsByAddresses/ServerRewardsByAddresses.tsx` — Server-side batching
- `components/RewardsByAddresses/RewardsByAddressChart.tsx` — Client-side batched refetch
- `lib/batch.ts` — **New** — Array batching utility for GraphQL requests
