### PR TITLE
Fix false-positive success in remediateSupplier

### DIFF
--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -302,26 +302,17 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
 
     if (!key) {
       log.warn('remediateSupplier: Key not found', {params})
-      return {
-        success: false,
-        message: 'Key not found'
-      }
+      throw ApplicationFailure.nonRetryable('Key not found', 'not_found')
     }
 
     if (!key.addressGroup) {
       log.warn('remediateSupplier: Address Group not found', {params})
-      return {
-        success: false,
-        message: 'Key address group not found'
-      }
+      throw ApplicationFailure.nonRetryable('Key address group not found', 'not_found')
     }
 
     if (!supplier) {
       log.warn('remediateSupplier: Supplier not found', {params})
-      return {
-        success: false,
-        message: 'Supplier not found'
-      }
+      throw ApplicationFailure.retryable('Supplier not found', 'not_found')
     }
 
     if (key.remediationHistory?.length === 0) {
@@ -406,11 +397,10 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
             params,
             error: e,
           })
-          return {
-            success: false,
-            message: 'Failed while updating the supplier status.',
-            keyUpdate: update,
-          }
+          throw ApplicationFailure.retryable(
+            `Failed while updating the supplier status for ${params.address}.`,
+            'db_update_failed',
+          )
         }
 
         return { success: true, message: 'Supplier already configured; remediation cleared.' }
@@ -446,10 +436,10 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
         supportedServicesCount: supportedServices.length,
         addressGroup: key.addressGroup?.id ?? 'unknown',
       })
-      return {
-        success: false,
-        message: 'Refusing to stake with empty services config.',
-      }
+      throw ApplicationFailure.nonRetryable(
+        `Refusing to stake with empty services config for ${params.address}.`,
+        'empty_services',
+      )
     }
 
     log.debug('remediateSupplier: Executing stake transaction', {
@@ -581,20 +571,25 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
       log.debug('remediateSupplier: Update Supplier done!', { params })
     } catch (e) {
       log.warn('remediateSupplier: Update Supplier failed!', { params, error: e })
-      return {
-        success: false,
-        message: 'Failed while updating the supplier status.',
-        keyUpdate: update,
-        stakeTxResult: txResult,
-      }
+      throw ApplicationFailure.retryable(
+        `Failed while updating the supplier status for ${params.address}. Key state: ${update.state}. Stake tx success: ${txResult.success}, message: ${txResult.message}`,
+        'db_update_failed',
+      )
+    }
+
+    if (!txResult.success) {
+      log.warn('remediateSupplier: Stake transaction failed', { params, txResult })
+      throw ApplicationFailure.nonRetryable(
+        `Remediation transaction failed for ${params.address}. Key state: ${update.state}. Tx code: ${txResult.code}, message: ${txResult.message}`,
+        'stake_tx_failed',
+      )
     }
 
     log.info('remediateSupplier: Execution finished', { params })
 
     return {
-      success: txResult.success,
-      message: txResult.success ? 'Remediation completed successfully.' : 'Remediation transaction failed.',
-      stakeTxResult: txResult,
+      success: true,
+      message: 'Remediation completed successfully.',
     }
   }
 })

--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -26,6 +26,16 @@ export type ProcessSupplierParams = {
   height: number;
 }
 
+export type UpsertSupplierStatusResult = {
+  state: KeyState;
+  remediationReasons: RemediationHistoryEntryReason[];
+  prev?: {
+    state?: KeyState;
+    remediationReasons?: RemediationHistoryEntryReason[];
+  };
+  supplier?: Supplier;
+}
+
 export type RemediateSupplierParams = ProcessSupplierParams & {
   reasons: RemediationHistoryEntryReason[];
 }
@@ -69,7 +79,7 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
    * Upserts the supplier status into the database.
    * @param params ProcessSupplierParams
    */
-  async upsertSupplierStatus(params: ProcessSupplierParams): Promise<boolean> {
+  async upsertSupplierStatus(params: ProcessSupplierParams): Promise<UpsertSupplierStatusResult> {
     log.info('upsertSupplierStatus: Querying for keys, settings, balance and supplier', {params})
     const [key, settings, balance, supplier]: [KeyWithGroup, ApplicationSettings, number, Supplier] = await Promise.all([
       dal.keys.loadKey(params.address),
@@ -81,6 +91,9 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
     if (!key) {
       throw new ApplicationFailure('key not found', 'not_found', true)
     }
+
+    const prevState = key.state
+    const prevRemediationReasons = (key.remediationHistory ?? []).map((rh) => rh.reason)
 
     const loggerContext = {
       key: key.address,
@@ -279,7 +292,33 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
     log.debug('Updating supplier', { params, update })
     await dal.keys.updateKey(params.address, update, params.height)
     log.info('Update Supplier done!', {params})
-    return true
+
+    const currentState = update.state ?? prevState
+    const currentRemediationReasons = (update.remediationHistory ?? key.remediationHistory ?? []).map((rh) => rh.reason)
+
+    const result: UpsertSupplierStatusResult = {
+      state: currentState,
+      remediationReasons: currentRemediationReasons,
+    }
+
+    const prevDiff: UpsertSupplierStatusResult['prev'] = {}
+    if (prevState !== currentState) {
+      prevDiff.state = prevState
+    }
+
+    const addedReasons = currentRemediationReasons.filter((r) => !prevRemediationReasons.includes(r))
+    const removedReasons = prevRemediationReasons.filter((r) => !currentRemediationReasons.includes(r))
+    if (addedReasons.length || removedReasons.length) {
+      prevDiff.remediationReasons = prevRemediationReasons
+    }
+
+    if (Object.keys(prevDiff).length) {
+      result.prev = prevDiff
+    }
+
+    result.supplier = supplier
+
+    return result
   },
 
   /**


### PR DESCRIPTION
The `remediateSupplier` activity was returning `{ success: false, ... }` objects on failure instead of throwing errors. Because Temporal only retries activities that **throw**, these failures were silently treated as successful completions — no retries, no workflow-level error tracking.

This PR replaces all `{ success: false }` returns with appropriate `ApplicationFailure` throws:

- **Non-retryable** (`ApplicationFailure.nonRetryable`) for data/config issues that won't resolve on retry:
    - Key not found
    - Address group not found
    - Empty services config
    - Stake transaction failed (already persisted as `RemediationFailed` in DB)

- **Retryable** (`ApplicationFailure.retryable`) for transient errors that may succeed on retry:
    - Supplier not found (timing issue, may appear on next attempt)
    - DB update failures (clearing OwnerInitialStake or post-stake update)

Error messages now include the supplier address, key state, and transaction result details for observability.