### PR TITLE
Add prepare-release workflow for pre-merge version resolution

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       bump_type:
-        description: "Version bump type"
+        description: "Version bump type (only for manual trigger)"
         required: true
         type: choice
         options:
@@ -59,38 +59,32 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine version
-        id: version
         run: |
-          # Get latest semver tag
-          LATEST_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | head -1)
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v0.0.0"
-          fi
-          echo "Latest tag: $LATEST_TAG"
-          VERSION=${LATEST_TAG#v}
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-
-          # Determine bump type from label or workflow_dispatch input
-          BUMP_TYPE=""
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BUMP_TYPE="${{ inputs.bump_type }}"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'release:major') }}; then
-            BUMP_TYPE="major"
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'release:minor') }}; then
-            BUMP_TYPE="minor"
+            # Manual trigger: compute version from latest tag + input
+            LATEST_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | head -1)
+            if [ -z "$LATEST_TAG" ]; then LATEST_TAG="v0.0.0"; fi
+            VERSION=${LATEST_TAG#v}
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+            case "${{ inputs.bump_type }}" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              patch) PATCH=$((PATCH + 1)) ;;
+            esac
+
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+            # Update overlays since prepare-release didn't run
+            sed -i 's/newTag: ".*"/newTag: "'"$NEW_VERSION"'"/' k8s/apps/middleman/overlays/mainnet/kustomization.yaml
+            sed -i 's/newTag: ".*"/newTag: "'"$NEW_VERSION"'"/' k8s/apps/middleman-workflows/overlays/mainnet/kustomization.yaml
           else
-            BUMP_TYPE="patch"
+            # PR merge: version already set by prepare-release workflow
+            NEW_VERSION=$(grep 'newTag:' k8s/apps/middleman/overlays/mainnet/kustomization.yaml | head -1 | sed 's/.*newTag: "\(.*\)"/\1/')
           fi
 
-          case "$BUMP_TYPE" in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH + 1)) ;;
-          esac
-
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          echo "New version: v$NEW_VERSION (bump: $BUMP_TYPE)"
+          echo "Deploying version: v$NEW_VERSION"
 
       - name: Prune all apps
         run: |
@@ -146,19 +140,18 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Update production overlays
-        run: |
-          sed -i 's/newTag: ".*"/newTag: "'"$NEW_VERSION"'"/' k8s/apps/middleman/overlays/mainnet/kustomization.yaml
-          sed -i 's/newTag: ".*"/newTag: "'"$NEW_VERSION"'"/' k8s/apps/middleman-workflows/overlays/mainnet/kustomization.yaml
-
-      - name: Commit, tag, and push
+      - name: Commit overlay changes and tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Only needed for workflow_dispatch (PR merge already has overlays updated)
           git add k8s/apps/middleman/overlays/mainnet/kustomization.yaml \
                   k8s/apps/middleman-workflows/overlays/mainnet/kustomization.yaml
-          git diff --staged --quiet && echo "No changes to commit" && exit 0
-          git commit -m "chore(deploy): release v${NEW_VERSION} [skip ci]"
+          if ! git diff --staged --quiet; then
+            git commit -m "chore(deploy): release v${NEW_VERSION} [skip ci]"
+          fi
+
           git tag "v${NEW_VERSION}"
           git push origin main --tags
 
@@ -166,7 +159,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DOCKER_IMAGES="## 🐳 Docker Images
+          PREV_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | sed -n '2p')
+
+          DOCKER_IMAGES="## Docker Images
 
           **Provider Application:**
           - Provider: \`ghcr.io/pokt-network/provider:${NEW_VERSION}\`
@@ -176,13 +171,19 @@ jobs:
           - Middleman: \`ghcr.io/pokt-network/middleman:${NEW_VERSION}\`
           - Middleman Workflows: \`ghcr.io/pokt-network/middleman-workflows:${NEW_VERSION}\`"
 
-          gh release create "v${NEW_VERSION}" \
-            --title "v${NEW_VERSION}" \
-            --generate-notes \
-            --notes-start-tag "$(git tag -l 'v*.*.*' --sort=-v:refname | sed -n '2p')" \
-            --latest
+          if [ -n "$PREV_TAG" ]; then
+            gh release create "v${NEW_VERSION}" \
+              --title "v${NEW_VERSION}" \
+              --generate-notes \
+              --notes-start-tag "$PREV_TAG" \
+              --latest
+          else
+            gh release create "v${NEW_VERSION}" \
+              --title "v${NEW_VERSION}" \
+              --generate-notes \
+              --latest
+          fi
 
-          # Append docker images section to the auto-generated notes
           EXISTING_BODY=$(gh release view "v${NEW_VERSION}" --json body --jq '.body')
           gh release edit "v${NEW_VERSION}" \
             --notes "${EXISTING_BODY}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,90 @@
+name: Prepare Release
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'release:patch') ||
+      contains(github.event.pull_request.labels.*.name, 'release:minor') ||
+      contains(github.event.pull_request.labels.*.name, 'release:major')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version
+        id: version
+        run: |
+          LATEST_TAG=$(git tag -l 'v*.*.*' --sort=-v:refname | head -1)
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+          fi
+          echo "Latest tag: $LATEST_TAG"
+
+          VERSION=${LATEST_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          # Priority: major > minor > patch
+          if ${{ contains(github.event.pull_request.labels.*.name, 'release:major') }}; then
+            MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'release:minor') }}; then
+            MINOR=$((MINOR + 1)); PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "New version: v$NEW_VERSION"
+
+      - name: Update mainnet overlays
+        run: |
+          sed -i 's/newTag: ".*"/newTag: "'"$NEW_VERSION"'"/' k8s/apps/middleman/overlays/mainnet/kustomization.yaml
+          sed -i 's/newTag: ".*"/newTag: "'"$NEW_VERSION"'"/' k8s/apps/middleman-workflows/overlays/mainnet/kustomization.yaml
+
+      - name: Commit overlay changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add k8s/apps/middleman/overlays/mainnet/kustomization.yaml \
+                  k8s/apps/middleman-workflows/overlays/mainnet/kustomization.yaml
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore(release): prepare v${NEW_VERSION} mainnet overlays [skip ci]"
+          git push
+
+      - name: Update PR title and body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --title "Release v${NEW_VERSION}" \
+            --body "$(cat <<EOF
+          ## Release v${NEW_VERSION}
+
+          **Version bump:** \`${{ github.event.label.name }}\`
+          **Previous version:** $(git tag -l 'v*.*.*' --sort=-v:refname | head -1)
+
+          ### Mainnet overlays updated
+          - \`k8s/apps/middleman/overlays/mainnet/kustomization.yaml\` → \`${NEW_VERSION}\`
+          - \`k8s/apps/middleman-workflows/overlays/mainnet/kustomization.yaml\` → \`${NEW_VERSION}\`
+
+          ### What happens on merge
+          1. Build + push all 4 images tagged \`${NEW_VERSION}\` + \`latest\`
+          2. Create git tag \`v${NEW_VERSION}\`
+          3. Create GitHub Release with auto-generated notes
+
+          ---
+          *Auto-prepared by prepare-release workflow*
+          EOF
+          )"


### PR DESCRIPTION
## Summary

- **New `prepare-release.yml`**: when a `release:*` label is added to a PR targeting main, this workflow:
  1. Computes next version from latest tag + label (major > minor > patch)
  2. Updates mainnet overlay kustomization files with the version
  3. Commits to the PR branch (staging)
  4. Updates PR title/body with version details

- **Updated `deploy-production.yml`**: on PR merge, reads version from overlay (already set by prepare-release) instead of computing post-merge. `workflow_dispatch` still computes version for manual triggers.

## Why

The reviewer should see the exact version that will be deployed **before** approving the merge. No surprises post-merge, no direct commits to main.

## Test plan

- [ ] CI passes
- [ ] After merge: add `release:patch` label to a staging→main PR, verify overlay is updated with correct version
- [ ] Merge the release PR, verify images are built with that version + tag + GitHub Release created
