### PR TITLE
Use disposable release branch for PRs to main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -110,12 +110,16 @@ jobs:
           git commit -m "chore(deploy): update staging image to $IMAGE_TAG"
           git push
 
-      - name: Create or update PR to main
+      - name: Create or update release PR to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if a PR from staging to main already exists
-          EXISTING_PR=$(gh pr list --base main --head staging --json number --jq '.[0].number' 2>/dev/null || echo "")
+          # Create/update release branch from staging
+          git checkout -B release
+          git push --force origin release
+
+          # Check if a PR from release to main already exists
+          EXISTING_PR=$(gh pr list --base main --head release --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           PR_BODY="## Staging Release
 
@@ -129,14 +133,14 @@ jobs:
 
           if [ -n "$EXISTING_PR" ]; then
             gh pr edit "$EXISTING_PR" \
-              --title "Release: staging → main ($IMAGE_TAG)" \
+              --title "Release: staging ($IMAGE_TAG)" \
               --body "$PR_BODY"
             echo "Updated existing PR #$EXISTING_PR"
           else
             gh pr create \
               --base main \
-              --head staging \
-              --title "Release: staging → main ($IMAGE_TAG)" \
+              --head release \
+              --title "Release: staging ($IMAGE_TAG)" \
               --body "$PR_BODY"
-            echo "Created new PR from staging to main"
+            echo "Created new PR from release to main"
           fi

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -5,23 +5,24 @@ This document describes the complete development, staging, and production releas
 ## Overview
 
 ```
-Feature Branch ──PR──> staging ──PR──> main
-                         │                │
-                    Deploy Staging    Deploy Production
-                    (SHA tags)        (semver tags)
-                         │                │
-                         ▼                ▼
-                   staking-dev.       staking.
-                   pocket.network     pocket.network
+Feature Branch ──PR──> staging ──creates──> release ──PR──> main
+                         │                                    │
+                    Deploy Staging                     Deploy Production
+                    (SHA tags)                         (semver tags)
+                         │                                    │
+                         ▼                                    ▼
+                   staking-dev.                          staking.
+                   pocket.network                        pocket.network
 ```
 
 ## Branches
 
-| Branch | Purpose | Protected |
+| Branch | Purpose | Lifecycle |
 |--------|---------|-----------|
-| `main` | Production-ready code. Deploys to mainnet. | Yes — requires PR + approval |
-| `staging` | Pre-production validation. Deploys to staging. | Yes — requires PR + approval |
-| `feat/*`, `fix/*` | Development branches. Target `staging`. | No |
+| `main` | Production-ready code. Deploys to mainnet. | Long-lived, protected |
+| `staging` | Pre-production validation. Deploys to staging. | Long-lived, protected. Rebased on main after each release |
+| `release` | Disposable branch for release PRs to main. | Created by staging deploy, deleted on merge |
+| `feat/*`, `fix/*` | Development branches. Target `staging`. | Short-lived |
 
 ## Environments
 
@@ -129,17 +130,19 @@ Feature Branch ──PR──> staging ──PR──> main
 3. PR merged to staging with label "release"
    - deploy-staging builds + pushes images with SHA tag
    - Staging overlay updated automatically
-   - PR staging → main auto-created
+   - Creates "release" branch from staging
+   - PR release → main auto-created
 
 4. Team validates on staking-dev.pocket.network
 
-5. Add label "release:patch" (or minor/major) to the staging → main PR
-   - prepare-release computes version, updates mainnet overlays
+5. Add label "release:patch" (or minor/major) to the release → main PR
+   - prepare-release computes version, updates mainnet overlays on release branch
    - PR title updated to "Release v0.6.1"
 
 6. Team reviews version in PR, approves
 
 7. PR merged to main
+   - "release" branch auto-deleted by GitHub (disposable)
    - deploy-production builds + pushes images with semver
    - Git tag v0.6.1 created
    - GitHub Release created
@@ -152,8 +155,8 @@ Feature Branch ──PR──> staging ──PR──> main
 k8s/apps/
 ├── middleman/
 │   ├── base/                          # Shared base (dev + prod)
-│   ├── dev/                           # Tilt local dev patches
 │   └── overlays/
+│       ├── dev/                       # Tilt local dev patches
 │       ├── mainnet/                   # Production overlay
 │       │   ├── config.json            # ArgoCD app config
 │       │   ├── kustomization.yaml     # Image tag managed by CI
@@ -166,8 +169,8 @@ k8s/apps/
 │           └── patches/               # ConfigMap, Secrets (1password)
 └── middleman-workflows/
     ├── base/
-    ├── dev/
     └── overlays/
+        ├── dev/
         └── mainnet/                   # Production only (no staging)
             ├── config.json
             ├── kustomization.yaml     # Image tag managed by CI


### PR DESCRIPTION
## Summary

Fix: GitHub's auto-delete-on-merge was deleting the `staging` branch when the release PR merged, breaking ArgoCD's staging ApplicationSet.

**Solution:** staging deploy now creates a disposable `release` branch from staging. The PR is `release` → `main` instead of `staging` → `main`. When merged, GitHub deletes `release` (disposable) while `staging` stays alive.

## Changes

- `deploy-staging.yml`: creates `release` branch from staging, PR from `release` → `main`
- `docs/guides/cicd.md`: updated branch strategy, overlay structure (dev/ → overlays/dev/), flow diagram

## Test plan

- [ ] CI passes
- [ ] After merge + staging deploy: release branch created, PR release→main opened
