### PR TITLE
Fix staging ingress TLS secret name

### DIFF
--- a/k8s/apps/middleman/overlays/staging/ingress.yaml
+++ b/k8s/apps/middleman/overlays/staging/ingress.yaml
@@ -19,4 +19,4 @@ spec:
   tls:
     - hosts:
         - staking-dev.pocket.network
-      secretName: staking-dev-pocket-tls
+      secretName: staking-pocket-tls


### PR DESCRIPTION
## Summary

Fix staging ingress to use `staking-pocket-tls` instead of `staking-dev-pocket-tls`. The cert now covers both domains (staking.pocket.network + staking-dev.pocket.network) as SANs, reflected to both namespaces.

## Test plan

- [ ] CI passes
- [ ] After merge: ArgoCD syncs staging ingress with correct TLS secret
- [ ] staking-dev.pocket.network loads with valid TLS
