### PR TITLE
Add branch-gate check: only release branch can target main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,17 @@ permissions:
   packages: read
 
 jobs:
+  branch-gate:
+    if: github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only release branch can target main
+        if: github.head_ref != 'release'
+        run: |
+          echo "::error::PRs to main must come from the 'release' branch, not '${{ github.head_ref }}'."
+          echo "Flow: feature → staging → release → main"
+          exit 1
+
   quality:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds a `branch-gate` CI job that blocks PRs to main from any branch other than `release`. This is enforced as a required status check in the main ruleset.

Also configured GitHub rulesets:
- **main**: added `required_status_checks` for `branch-gate`
- **staging**: new ruleset with same protections as main (linear history, approval, squash only)
- **long-live-dev**: deleted (obsolete `develop` branch)

## Test plan

- [ ] CI passes
- [ ] PR from feature branch to main → branch-gate fails, merge blocked
- [ ] PR from release to main → branch-gate passes
