### PR TITLE
Fix fetch of providers supplier stats

### DIFF
--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -86,7 +86,11 @@ function extractDomainsForAddressGroup(ag: AddressGroupsJson[number]): string[] 
       }
     }
   }
-  return Array.from(domains)
+
+  return Array.from(domains).map((d) => {
+    const parts = d.split('.')
+    return parts.length > 2 ? parts.slice(-2).join('.') : d
+  })
 }
 
 export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain, providerService: ProviderService) => ({


### PR DESCRIPTION
Fix supplier stats query returning zeros by normalizing extracted domains to their second-level form (e.g. rm02.kalorius.tech → kalorius.tech, to.stakenodes.org → stakenodes.org) to match how the indexer stores them.