### PR TITLE
Split remediation schedules, UI controls, auto-bootstrap, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ node_modules
 # Local env files
 apps/provider/.env
 .env
+
+# Bootstrap config files (dev uses local copies of *.example.json)
+**/bootstrap.json
+!**/bootstrap.example.json
 .env.local
 .env.development.local
 .env.test.local

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -87,11 +87,46 @@ The `.env.sample` already points to these file paths by default. You can alterna
 | `PROVIDER_JSON` | Inline JSON array of providers (consumed by Middleman) |
 | `PROVIDER_JSON_FILE` | Path to a provider JSON file (consumed by Middleman) |
 
+### Auto-bootstrap (optional)
+
+By default, both apps require completing a setup wizard on first launch. For faster dev iterations, you can skip the wizard by providing a bootstrap config file.
+
+1. Copy the example config and adjust values:
+
+```bash
+# Provider
+cp k8s/apps/provider/overlays/dev/bootstrap.example.json \
+   k8s/apps/provider/overlays/dev/bootstrap.json
+
+# Middleman
+cp k8s/apps/middleman/overlays/dev/bootstrap.example.json \
+   k8s/apps/middleman/overlays/dev/bootstrap.json
+```
+
+2. Add the bootstrap paths to your `.env`:
+
+```bash
+PROVIDER_BOOTSTRAP_CONFIG_PATH=../overlays/dev/bootstrap.json
+MIDDLEMAN_BOOTSTRAP_CONFIG_PATH=../overlays/dev/bootstrap.json
+```
+
+When these variables are set, Tilt injects an init container that seeds the database before the app starts. The seed script:
+- Is **idempotent** — if the app is already bootstrapped, it skips
+- Fetches **minimum stake** and **current height** from the Pocket API at runtime (not hardcoded)
+- Fetches **delegators** (for Provider) and **providers** (for Middleman) from the governance CDN
+- Derives the **app identity** (compressed public key) from the `APP_IDENTITY` private key
+
+The `bootstrap.json` files are gitignored. The `.example.json` files are committed as templates.
+
+> **Important:** The governance files (`k8s/tools/governance/providers.json` and `delegators.json`) must be configured first — the bootstrap seed fetches from them via the governance nginx CDN.
+
 ### Other variables
 
 | Variable | Description |
 |----------|-------------|
-| `MINIMUM_STAKE_BUFFER` | Buffer in uPOKT removed from minimum stake to allow operation after slashes (default: `500000000`) |
+| `MINIMUM_STAKE_BUFFER` | Buffer in uPOKT added to on-chain minimum stake (default: `500000000`) |
+| `PROVIDER_BOOTSTRAP_CONFIG_PATH` | Path to provider bootstrap JSON (relative to Tiltfile). Enables auto-bootstrap when set |
+| `MIDDLEMAN_BOOTSTRAP_CONFIG_PATH` | Path to middleman bootstrap JSON (relative to Tiltfile). Enables auto-bootstrap when set |
 
 ---
 

--- a/apps/middleman/src/app/admin/setup/blockchainFrom.tsx
+++ b/apps/middleman/src/app/admin/setup/blockchainFrom.tsx
@@ -204,16 +204,17 @@ const FormComponent: React.FC<FormProps> = ({ defaultValues, goNext }) => {
               control={form.control}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Shannon API URL</FormLabel>
+                  <FormLabel>Pocket API URL</FormLabel>
                   <FormControl>
                     <Input
                       {...field}
-                      placeholder="https://your-shannon-rpc.example.com"
+                      placeholder="https://your-pocket-api.example.com"
                     />
                   </FormControl>
                   <FormDescription>
-                    A public RPC or gateway URL for the Pocket Network. This is used to auto-detect
-                    the network and minimum stake. The network (chain ID) cannot be changed after setup.
+                    The Cosmos SDK REST API of your Pocket Network node (port <code>1317</code>).
+                    <strong> Do not use the Tendermint RPC</strong> (port <code>26657</code>).
+                    This auto-detects your network and minimum stake. The chain ID is locked after setup.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/apps/middleman/src/db/bootstrap-seed.ts
+++ b/apps/middleman/src/db/bootstrap-seed.ts
@@ -1,0 +1,205 @@
+import { eq } from 'drizzle-orm'
+import * as fs from 'fs'
+import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing'
+import * as schema from '@igniter/db/middleman/schema'
+import { UserRole, ProviderFee } from '@igniter/db/middleman/enums'
+import { setup } from '@igniter/db/connection'
+import { getLogger } from '@igniter/logger'
+
+const { usersTable, applicationSettingsTable, providersTable } = schema
+
+interface BootstrapConfig {
+  settings: {
+    name: string
+    supportEmail?: string
+    ownerEmail: string
+    fee: number
+    delegatorRewardsAddress: string
+    privacyPolicy?: string
+    rpcUrl: string
+    indexerApiUrl: string
+    chainId: string
+  }
+}
+
+interface CdnProvider {
+  name: string
+  identity: string
+  identityHistory?: string[]
+  url: string
+}
+
+async function main() {
+  const configPath = process.env.BOOTSTRAP_CONFIG_PATH
+  if (!configPath) {
+    console.log('[bootstrap-seed] BOOTSTRAP_CONFIG_PATH not set, skipping.')
+    process.exit(0)
+  }
+
+  if (!fs.existsSync(configPath)) {
+    console.log(`[bootstrap-seed] Config file not found at ${configPath}, skipping.`)
+    process.exit(0)
+  }
+
+  const ownerIdentity = process.env.OWNER_IDENTITY
+  if (!ownerIdentity) {
+    console.error('[bootstrap-seed] OWNER_IDENTITY is required.')
+    process.exit(1)
+  }
+
+  const ownerEmail = process.env.OWNER_EMAIL
+  const appIdentityPrivateKey = process.env.APP_IDENTITY
+  if (!appIdentityPrivateKey) {
+    console.error('[bootstrap-seed] APP_IDENTITY is required.')
+    process.exit(1)
+  }
+
+  // Derive compressed public key from APP_IDENTITY private key
+  const privateKeyBytes = Buffer.from(appIdentityPrivateKey, 'hex')
+  const wallet = await DirectSecp256k1Wallet.fromKey(privateKeyBytes)
+  const [account] = await wallet.getAccounts()
+  if (!account) {
+    console.error('[bootstrap-seed] Failed to derive public key from APP_IDENTITY.')
+    process.exit(1)
+  }
+  const appIdentity = Buffer.from(account.pubkey).toString('hex')
+
+  const logger = getLogger()
+  const { db, disconnect } = setup({ schema, logger })
+
+  try {
+    // Check if already bootstrapped
+    const existing = await db
+      .select({ isBootstrapped: applicationSettingsTable.isBootstrapped })
+      .from(applicationSettingsTable)
+      .limit(1)
+
+    if (existing.length > 0 && existing[0].isBootstrapped) {
+      console.log('[bootstrap-seed] Already bootstrapped, skipping.')
+      process.exit(0)
+    }
+
+    const config: BootstrapConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+    console.log('[bootstrap-seed] Starting bootstrap...')
+
+    // Step 0: Fetch blockchain params from RPC (minimumStake + current height)
+    const rpcBase = config.settings.rpcUrl.replace(/\/$/, '')
+    const stakeBuffer = parseInt(process.env.MINIMUM_STAKE_BUFFER || '0', 10)
+    let minimumStake = 0
+    let updatedAtHeight = '0'
+
+    try {
+      const supplierParamsUrl = `${rpcBase}/pokt-network/poktroll/supplier/params`
+      console.log(`[bootstrap-seed] Fetching minimum stake from ${supplierParamsUrl}...`)
+      const paramsResponse = await fetch(supplierParamsUrl)
+      if (!paramsResponse.ok) throw new Error(`Supplier params: HTTP ${paramsResponse.status}`)
+      const paramsData = await paramsResponse.json()
+      const rawAmount = parseFloat(paramsData.params.min_stake.amount)
+      minimumStake = (rawAmount + stakeBuffer) / 1e6
+      console.log(`[bootstrap-seed] Minimum stake: ${minimumStake} POKT (raw: ${rawAmount}, buffer: ${stakeBuffer})`)
+
+      const statusUrl = `${rpcBase}/cosmos/base/node/v1beta1/status`
+      console.log(`[bootstrap-seed] Fetching current height from ${statusUrl}...`)
+      const statusResponse = await fetch(statusUrl)
+      if (!statusResponse.ok) throw new Error(`Node status: HTTP ${statusResponse.status}`)
+      const statusData = await statusResponse.json()
+      updatedAtHeight = statusData.height
+      console.log(`[bootstrap-seed] Current height: ${updatedAtHeight}`)
+    } catch (err) {
+      console.error('[bootstrap-seed] Failed to fetch blockchain params:', err)
+      process.exit(1)
+    }
+
+    // Step 1: Create owner user
+    const resolvedOwnerEmail = config.settings.ownerEmail || ownerEmail || ''
+    await db
+      .insert(usersTable)
+      .values({
+        identity: ownerIdentity,
+        email: resolvedOwnerEmail,
+        role: UserRole.Owner,
+      })
+      .onConflictDoNothing({ target: usersTable.identity })
+
+    console.log('[bootstrap-seed] Owner user created.')
+
+    // Step 2: Insert application settings (not yet bootstrapped)
+    if (existing.length === 0) {
+      await db.insert(applicationSettingsTable).values({
+        name: config.settings.name,
+        appIdentity,
+        supportEmail: config.settings.supportEmail ?? resolvedOwnerEmail,
+        ownerEmail: resolvedOwnerEmail,
+        ownerIdentity,
+        fee: config.settings.fee,
+        minimumStake,
+        isBootstrapped: false,
+        chainId: config.settings.chainId,
+        delegatorRewardsAddress: config.settings.delegatorRewardsAddress,
+        rpcUrl: config.settings.rpcUrl,
+        indexerApiUrl: config.settings.indexerApiUrl,
+        updatedAtHeight,
+        privacyPolicy: config.settings.privacyPolicy ?? null,
+        createdBy: ownerIdentity,
+        updatedBy: ownerIdentity,
+      })
+    }
+
+    console.log('[bootstrap-seed] Application settings created.')
+
+    // Step 3: Fetch providers from CDN and insert them
+    const providersCdnUrl = process.env.PROVIDERS_CDN_URL
+    if (providersCdnUrl) {
+      const resolvedUrl = providersCdnUrl.replace('{chainId}', config.settings.chainId)
+      console.log(`[bootstrap-seed] Fetching providers from ${resolvedUrl}...`)
+      try {
+        const response = await fetch(resolvedUrl)
+        if (!response.ok) {
+          console.warn(`[bootstrap-seed] Failed to fetch providers (${response.status}), skipping.`)
+        } else {
+          const cdnProviders: CdnProvider[] = await response.json()
+          for (const provider of cdnProviders) {
+            await db
+              .insert(providersTable)
+              .values({
+                name: provider.name,
+                identity: provider.identity,
+                url: provider.url,
+                enabled: true,
+                visible: true,
+                fee: 0,
+                feeType: ProviderFee.UpTo,
+                minimumStake: 0,
+                operationalFunds: 5,
+                allowPublicStaking: false,
+                createdBy: ownerIdentity,
+                updatedBy: ownerIdentity,
+              })
+              .onConflictDoNothing({ target: providersTable.identity })
+
+            console.log(`[bootstrap-seed] Provider "${provider.name}" created.`)
+          }
+        }
+      } catch (err) {
+        console.warn('[bootstrap-seed] Error fetching providers, skipping:', err)
+      }
+    } else {
+      console.log('[bootstrap-seed] PROVIDERS_CDN_URL not set, skipping providers.')
+    }
+
+    // Step 4: Mark as bootstrapped
+    await db
+      .update(applicationSettingsTable)
+      .set({ isBootstrapped: true, updatedBy: ownerIdentity })
+      .where(eq(applicationSettingsTable.isBootstrapped, false))
+
+    console.log('[bootstrap-seed] Bootstrap complete!')
+  } catch (error) {
+    console.error('[bootstrap-seed] Error:', error)
+    process.exit(1)
+  } finally {
+    await disconnect()
+  }
+}
+
+main()

--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -136,6 +136,11 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
           // means the key is imported and is already staked, let's set it to the owner address
           update.ownerAddress = supplier.ownerAddress
         }
+
+        // Backfill for legacy keys with empty owner address
+        if (!key.ownerAddress && supplier.ownerAddress) {
+          update.ownerAddress = supplier.ownerAddress
+        }
       }
 
       log.debug('remediateSupplier: Checking if is owner initial stake remediation needed', {

--- a/apps/provider-workflows/src/bootstrap.ts
+++ b/apps/provider-workflows/src/bootstrap.ts
@@ -12,26 +12,34 @@ import { RemediationHistoryEntryReason } from "@igniter/db/provider/enums"
 enum ScheduledWorkflowType {
   SupplierStatus = 'SupplierStatus',
   SupplierRemediation = 'SupplierRemediation',
+  SupplierInitialStake = 'SupplierInitialStake',
 }
 
 const ScheduledWorkflowConfig: Record<
   ScheduledWorkflowType,
-  { interval: string; args: any[]; envVar: string }
+  { workflowType: string; interval: string; args: any[]; envVar: string }
 > = {
   [ScheduledWorkflowType.SupplierStatus]: {
+    workflowType: 'SupplierStatus',
     interval: '2m',
     args: [],
     envVar: 'SCHEDULE_SUPPLIER_STATUS_INTERVAL',
   },
   [ScheduledWorkflowType.SupplierRemediation]: {
+    workflowType: 'SupplierRemediation',
     interval: '10s',
     args: [{
-      reasons: [
-        RemediationHistoryEntryReason.OwnerInitialStake,
-        RemediationHistoryEntryReason.ServiceMismatch,
-      ]
+      reasons: [RemediationHistoryEntryReason.ServiceMismatch]
     }],
     envVar: 'SCHEDULE_SUPPLIER_REMEDIATION_INTERVAL',
+  },
+  [ScheduledWorkflowType.SupplierInitialStake]: {
+    workflowType: 'SupplierRemediation',
+    interval: '10s',
+    args: [{
+      reasons: [RemediationHistoryEntryReason.OwnerInitialStake]
+    }],
+    envVar: 'SCHEDULE_SUPPLIER_INITIAL_STAKE_INTERVAL',
   },
 }
 
@@ -89,7 +97,7 @@ async function bootstrapScheduledWorkflows(client: Client, config: TemporalConfi
     try {
       const desc = await handle.describe()
 
-      const currentArgs = (desc as any).action.args || []
+      const currentArgs = desc.action.args ?? []
       const currentIntervalMs = desc.spec.intervals?.[0]?.every
       const desiredIntervalMs = parseDurationToMs(interval)
 
@@ -122,7 +130,7 @@ async function bootstrapScheduledWorkflows(client: Client, config: TemporalConfi
         await client.schedule.create({
           action: {
             type: 'startWorkflow',
-            workflowType,
+            workflowType: wfConfig.workflowType,
             taskQueue: config.taskQueue!,
             args: wfConfig.args,
           },

--- a/apps/provider-workflows/src/workflows/SupplierRemediation.ts
+++ b/apps/provider-workflows/src/workflows/SupplierRemediation.ts
@@ -55,6 +55,11 @@ export async function SupplierRemediation(input: SupplierRemediationInput): Prom
     getKeysMinAndMax(),
   ])
 
+  if (minId == null || maxId == null) {
+    log.info('SupplierRemediation: No keys found, nothing to remediate.')
+    return { height, minId: 0, maxId: 0 }
+  }
+
   const loggerContext = {
     height,
     minId,

--- a/apps/provider-workflows/src/workflows/SupplierStatus.ts
+++ b/apps/provider-workflows/src/workflows/SupplierStatus.ts
@@ -59,6 +59,11 @@ export async function SupplierStatus(): Promise<{ height: number, minId: number,
     getKeysMinAndMax(),
   ])
 
+  if (minId == null || maxId == null) {
+    log.info('SupplierStatus: No keys found, nothing to check.')
+    return { height, minId: 0, maxId: 0 }
+  }
+
   const loggerContext = {
     height,
     minId,

--- a/apps/provider/src/actions/Keys.ts
+++ b/apps/provider/src/actions/Keys.ts
@@ -95,7 +95,7 @@ export async function UpdateKeysState(ids: number[], state: KeyState): Promise<A
   })
 }
 
-export async function MarkKeysForRemediation(): Promise<ActionResult<void>> {
+export async function ClearKeysRemediation(): Promise<ActionResult<void>> {
   return withRequireOwner(async () => {
     await updateKeysStateWhereCurrentStateIn([
       KeyState.AttentionNeeded,

--- a/apps/provider/src/actions/Remediation.ts
+++ b/apps/provider/src/actions/Remediation.ts
@@ -1,0 +1,120 @@
+'use server'
+
+import { z } from 'zod'
+import {
+  type ActionResult,
+  withRequireOwner,
+} from '@/lib/utils/actionUtils'
+import {
+  listStakedKeysWithDetails,
+  listKeysByAddresses,
+  batchUpdateRemediationHistory,
+} from '@/lib/dal/keys'
+import { getExpectedServicesFromKey } from '@igniter/domain/provider/utils'
+import { CompareSupplierServiceConfigHandler } from '@igniter/domain/provider/operations'
+import { RemediationHistoryEntryReason } from '@igniter/db/provider/enums'
+import type { RemediationHistoryEntry } from '@igniter/db/provider/schema'
+import { TriggerRemediationSchedule } from '@/actions/Schedules'
+
+interface RemediationReasonDetail {
+  count: number
+  addresses: string[]
+  label: string
+}
+
+export interface RemediationSummary {
+  total: number
+  byReason: Record<string, RemediationReasonDetail>
+}
+
+export async function EvaluateRemediationNeeds(): Promise<ActionResult<RemediationSummary>> {
+  return withRequireOwner(async () => {
+    const keys = await listStakedKeysWithDetails()
+
+    const comparer = new CompareSupplierServiceConfigHandler()
+    const mismatchAddresses: string[] = []
+
+    for (const key of keys) {
+      // Only evaluate keys that have services synced from chain and have an address group
+      if (!key.services || key.services.length === 0 || !key.addressGroup) {
+        continue
+      }
+
+      const expectedServices = getExpectedServicesFromKey(key)
+
+      if (expectedServices.length === 0) {
+        continue
+      }
+
+      const result = comparer.execute({
+        serviceConfigSetA: key.services,
+        serviceConfigSetB: expectedServices,
+      })
+
+      if (!result.isEqual) {
+        mismatchAddresses.push(key.address)
+      }
+    }
+
+    const summary: RemediationSummary = {
+      total: mismatchAddresses.length,
+      byReason: {},
+    }
+
+    if (mismatchAddresses.length > 0) {
+      summary.byReason[RemediationHistoryEntryReason.ServiceMismatch] = {
+        count: mismatchAddresses.length,
+        addresses: mismatchAddresses,
+        label: 'Service Mismatch',
+      }
+    }
+
+    return summary
+  })
+}
+
+const addressesSchema = z.array(
+  z.string().min(1).regex(/^pokt1[a-z0-9]{38,43}$/, 'Must be a valid POKT bech32 address'),
+).min(1, 'At least one address is required')
+
+export async function RequestRemediation(addresses: string[]): Promise<ActionResult<void>> {
+  return withRequireOwner(async () => {
+    const validatedAddresses = addressesSchema.parse(addresses)
+
+    const keys = await listKeysByAddresses(validatedAddresses)
+
+    if (keys.length === 0) {
+      throw new Error('No keys found for the provided addresses')
+    }
+
+    const updates: Array<{ address: string; remediationHistory: RemediationHistoryEntry[] }> = []
+
+    for (const key of keys) {
+      const entry: RemediationHistoryEntry = {
+        message: 'Service mismatch detected — remediation requested by operator',
+        reason: RemediationHistoryEntryReason.ServiceMismatch,
+        timestamp: Date.now(),
+      }
+
+      const history = [...(key.remediationHistory ?? [])]
+      const existingIndex = history.findIndex((item) => item.reason === entry.reason)
+
+      if (existingIndex !== -1) {
+        history[existingIndex] = entry
+      } else {
+        history.push(entry)
+        history.sort((a, b) => b.timestamp - a.timestamp)
+      }
+
+      updates.push({
+        address: key.address,
+        remediationHistory: history,
+      })
+    }
+
+    await batchUpdateRemediationHistory(updates)
+
+    // Trigger the SupplierRemediation schedule
+    await TriggerRemediationSchedule()
+  })
+}

--- a/apps/provider/src/actions/Schedules.ts
+++ b/apps/provider/src/actions/Schedules.ts
@@ -1,0 +1,38 @@
+'use server'
+
+import {
+  type ActionResult,
+  withRequireOwner,
+} from '@/lib/utils/actionUtils'
+import { getTemporalClient } from '@/lib/temporal'
+
+const REMEDIATION_SCHEDULE_ID = 'SupplierRemediation-scheduled'
+
+export async function GetRemediationScheduleStatus(): Promise<ActionResult<{ paused: boolean }>> {
+  return withRequireOwner(async () => {
+    const client = getTemporalClient()
+    const handle = client.schedule.getHandle(REMEDIATION_SCHEDULE_ID)
+    const desc = await handle.describe()
+    return { paused: desc.state.paused }
+  })
+}
+
+export async function ToggleRemediationSchedule(paused: boolean): Promise<ActionResult<void>> {
+  return withRequireOwner(async () => {
+    const client = getTemporalClient()
+    const handle = client.schedule.getHandle(REMEDIATION_SCHEDULE_ID)
+    if (paused) {
+      await handle.pause()
+    } else {
+      await handle.unpause()
+    }
+  })
+}
+
+export async function TriggerRemediationSchedule(): Promise<ActionResult<void>> {
+  return withRequireOwner(async () => {
+    const client = getTemporalClient()
+    const handle = client.schedule.getHandle(REMEDIATION_SCHEDULE_ID)
+    await handle.trigger()
+  })
+}

--- a/apps/provider/src/app/admin/(internal)/keys/AutoStakeToggle.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/AutoStakeToggle.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import React from 'react'
+import { Button } from '@igniter/ui/components/button'
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
+import { useRouter } from 'next/navigation'
+import { GetRemediationScheduleStatus, ToggleRemediationSchedule } from '@/actions/Schedules'
+
+export default function AutoStakeToggle() {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [paused, setPaused] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    GetRemediationScheduleStatus().then((result) => {
+      if (cancelled) return
+      if (result.success) {
+        setPaused(result.data.paused)
+      } else {
+        setError(result.error.message)
+      }
+    }).catch((e) => {
+      if (cancelled) return
+      setError(e instanceof Error ? e.message : 'Failed to fetch schedule status')
+    }).finally(() => {
+      if (!cancelled) setIsLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [])
+
+  const onClick = () => setOpen(true)
+
+  const onClose = () => {
+    if (!isSubmitting) setOpen(false)
+  }
+
+  const handleConfirm = async () => {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const result = await ToggleRemediationSchedule(!paused)
+      if (!result.success) {
+        setError(result.error.message)
+        return
+      }
+      setPaused(!paused)
+      setOpen(false)
+      router.refresh()
+    } catch (e) {
+      console.error('Failed to toggle remediation schedule', e)
+      setError(e instanceof Error ? e.message : 'Failed to toggle schedule. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Button className={'h-8'} variant={'outline'} disabled>
+        Auto Stake: …
+      </Button>
+    )
+  }
+
+  return (
+    <>
+      <Button className={'h-8'} variant={'outline'} onClick={onClick} disabled={isSubmitting}>
+        Auto Stake: {paused ? 'OFF' : 'ON'}
+      </Button>
+
+      <ConfirmationDialog
+        title={paused ? 'Enable Auto Stake' : 'Disable Auto Stake'}
+        open={open}
+        onClose={onClose}
+        footerActions={(
+          <>
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={isSubmitting} type="button">
+              Cancel
+            </Button>
+            <Button onClick={handleConfirm} disabled={isSubmitting}>
+              {isSubmitting ? 'Confirming…' : 'Confirm'}
+            </Button>
+          </>
+        )}
+      >
+        {error && (
+          <div className="px-4 py-2 text-[12px] text-red-400 bg-bg-root">
+            {error}
+          </div>
+        )}
+        <div className="py-3 text-[14px] text-text-secondary">
+          {paused ? (
+            <>
+              This will <span className="font-semibold">resume</span> the automatic remediation schedule. The system will automatically re-stake suppliers with service mismatches on the configured interval.
+            </>
+          ) : (
+            <>
+              This will <span className="font-semibold">pause</span> the automatic remediation schedule. Suppliers with service mismatches will no longer be automatically re-staked until you re-enable this.
+            </>
+          )}
+        </div>
+      </ConfirmationDialog>
+    </>
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/ClearRemediationButton.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/ClearRemediationButton.tsx
@@ -4,9 +4,9 @@ import React from 'react'
 import { Button } from '@igniter/ui/components/button'
 import { ConfirmationDialog } from '@/components/ConfirmationDialog'
 import { useRouter } from 'next/navigation'
-import { MarkKeysForRemediation } from '@/actions/Keys'
+import { ClearKeysRemediation } from '@/actions/Keys'
 
-export default function MarkForRemediationButton() {
+export default function ClearRemediationButton() {
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
@@ -22,11 +22,11 @@ export default function MarkForRemediationButton() {
     setError(null)
     setIsSubmitting(true)
     try {
-      await MarkKeysForRemediation()
+      await ClearKeysRemediation()
       setOpen(false)
       router.refresh()
     } catch (e) {
-      console.error('Failed to mark keys for remediation', e)
+      console.error('Failed to clear remediation state', e)
       setError(e instanceof Error ? e.message : 'Failed to update keys state. Please try again.')
     } finally {
       setIsSubmitting(false)
@@ -36,11 +36,11 @@ export default function MarkForRemediationButton() {
   return (
     <>
       <Button className={'h-8'} variant={'outline'} onClick={onClick} disabled={isSubmitting}>
-        Mark for remediation
+        Clear remediation
       </Button>
 
       <ConfirmationDialog
-        title="Mark for remediation"
+        title="Clear remediation"
         open={open}
         onClose={onClose}
         footerActions={(
@@ -60,7 +60,7 @@ export default function MarkForRemediationButton() {
           </div>
         )}
         <div className="py-3 text-[14px] text-text-secondary">
-          This will set all keys with state <span className="font-semibold">AttentionNeeded</span> or <span className="font-semibold">RemediationFailed</span> back to <span className="font-semibold">Staked</span>. The system will re-evaluate and try to remediate where possible.
+          This will reset all keys with state <span className="font-semibold">AttentionNeeded</span> or <span className="font-semibold">RemediationFailed</span> back to <span className="font-semibold">Staked</span>. The system will re-evaluate them on the next status check.
         </div>
       </ConfirmationDialog>
     </>

--- a/apps/provider/src/app/admin/(internal)/keys/RequestRemediationButton.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/RequestRemediationButton.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import React from 'react'
+import { Button } from '@igniter/ui/components/button'
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
+import { useRouter } from 'next/navigation'
+import {
+  EvaluateRemediationNeeds,
+  RequestRemediation,
+  type RemediationSummary,
+} from '@/actions/Remediation'
+
+type State = 'idle' | 'evaluating' | 'summary' | 'confirming' | 'done' | 'error'
+
+export default function RequestRemediationButton() {
+  const router = useRouter()
+  const [state, setState] = React.useState<State>('idle')
+  const [open, setOpen] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [summary, setSummary] = React.useState<RemediationSummary | null>(null)
+
+  const handleClick = async () => {
+    setError(null)
+    setSummary(null)
+    setOpen(true)
+    setState('evaluating')
+
+    try {
+      const result = await EvaluateRemediationNeeds()
+      if (!result.success) {
+        setError(result.error.message)
+        setState('error')
+        return
+      }
+      setSummary(result.data)
+      setState('summary')
+    } catch (e) {
+      console.error('Failed to evaluate remediation needs', e)
+      setError(e instanceof Error ? e.message : 'Failed to evaluate remediation needs.')
+      setState('error')
+    }
+  }
+
+  const handleConfirm = async () => {
+    if (!summary) return
+
+    const allAddresses = Object.values(summary.byReason).flatMap((r) => r.addresses)
+    if (allAddresses.length === 0) return
+
+    setError(null)
+    setState('confirming')
+
+    try {
+      const result = await RequestRemediation(allAddresses)
+      if (!result.success) {
+        setError(result.error.message)
+        setState('error')
+        return
+      }
+      setState('done')
+      setOpen(false)
+      router.refresh()
+    } catch (e) {
+      console.error('Failed to request remediation', e)
+      setError(e instanceof Error ? e.message : 'Failed to request remediation.')
+      setState('error')
+    }
+  }
+
+  const handleClose = () => {
+    if (state === 'evaluating' || state === 'confirming') return
+    setOpen(false)
+    setState('idle')
+    setError(null)
+    setSummary(null)
+  }
+
+  const isLoading = state === 'evaluating' || state === 'confirming'
+  const hasResults = summary && summary.total > 0
+  const noResults = summary && summary.total === 0
+
+  return (
+    <>
+      <Button
+        className={'h-8'}
+        variant={'outline'}
+        onClick={handleClick}
+        disabled={state === 'evaluating' || state === 'confirming'}
+      >
+        Request Remediation
+      </Button>
+
+      <ConfirmationDialog
+        title="Request Remediation"
+        open={open}
+        onClose={handleClose}
+        footerActions={(
+          <>
+            {noResults && (
+              <Button variant="outline" onClick={handleClose} type="button">
+                Close
+              </Button>
+            )}
+            {(hasResults || state === 'error') && (
+              <>
+                <Button
+                  variant="outline"
+                  onClick={handleClose}
+                  disabled={isLoading}
+                  type="button"
+                >
+                  Cancel
+                </Button>
+                {hasResults && (
+                  <Button onClick={handleConfirm} disabled={isLoading}>
+                    {state === 'confirming' ? 'Requesting...' : 'Confirm'}
+                  </Button>
+                )}
+              </>
+            )}
+          </>
+        )}
+      >
+        {error && (
+          <div className="px-4 py-2 text-[12px] text-red-400 bg-bg-root">
+            {error}
+          </div>
+        )}
+
+        {state === 'evaluating' && (
+          <div className="py-3 text-[14px] text-text-secondary">
+            Evaluating supplier configurations...
+          </div>
+        )}
+
+        {noResults && (
+          <div className="py-3 text-[14px] text-text-secondary">
+            All suppliers are up to date. No remediation needed.
+          </div>
+        )}
+
+        {hasResults && (
+          <div className="py-3 text-[14px] text-text-secondary">
+            <p className="font-semibold mb-2">Evaluation Results:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              {Object.values(summary.byReason).map((reason) => (
+                <li key={reason.label}>
+                  {reason.count} supplier{reason.count !== 1 ? 's' : ''} {reason.count !== 1 ? 'have' : 'has'} {reason.label}
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3">
+              Total: <span className="font-semibold">{summary.total}</span> supplier{summary.total !== 1 ? 's' : ''} need{summary.total === 1 ? 's' : ''} remediation.
+            </p>
+            <p className="mt-2 text-[12px] text-text-tertiary">
+              Would you like to proceed? This will mark them for remediation and trigger the remediation workflow.
+            </p>
+          </div>
+        )}
+      </ConfirmationDialog>
+    </>
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/page.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/page.tsx
@@ -4,7 +4,9 @@ import KeysTable from '@/app/admin/(internal)/keys/table'
 import { Button } from '@igniter/ui/components/button'
 import Link from 'next/link'
 import { GetAppName } from '@/actions/ApplicationSettings'
-import MarkForRemediationButton from '@/app/admin/(internal)/keys/MarkForRemediationButton'
+import ClearRemediationButton from '@/app/admin/(internal)/keys/ClearRemediationButton'
+import AutoStakeToggle from '@/app/admin/(internal)/keys/AutoStakeToggle'
+import RequestRemediationButton from '@/app/admin/(internal)/keys/RequestRemediationButton'
 
 export const dynamic = "force-dynamic";
 
@@ -32,7 +34,9 @@ export default async function AddressesPage() {
               Export
             </Button>
           </Link>
-          <MarkForRemediationButton />
+          <ClearRemediationButton />
+          <RequestRemediationButton />
+          <AutoStakeToggle />
         </div>
         <KeysTable />
       </div>

--- a/apps/provider/src/app/admin/(internal)/settings/Form.tsx
+++ b/apps/provider/src/app/admin/(internal)/settings/Form.tsx
@@ -82,7 +82,7 @@ export default function SettingsForm() {
       rpcUrl: settings?.rpcUrl || '',
       indexerApiUrl: settings?.indexerApiUrl || '',
       chainId: settings?.chainId || '',
-      minimumStake: settings?.minimumStake,
+      minimumStake: settings?.minimumStake ?? 0,
       appIdentity: settings?.appIdentity || '',
       updatedAtHeight: settings?.updatedAtHeight || '',
     },
@@ -298,7 +298,7 @@ pokt1def456ghi789jkl012mno345pqr678stu901vwx`}
                         render={({ field }) => (
                           <FormItem>
                             <FormLabel className="text-text-secondary">
-                              Node API URL
+                              Pocket API URL
                               {isValidatingRpc && <LoaderIcon className="inline-block animate-spin ml-2 h-3 w-3" />}
                             </FormLabel>
                             <FormControl>

--- a/apps/provider/src/app/admin/details/KeyDetail/RemediationHistoryList.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/RemediationHistoryList.tsx
@@ -136,7 +136,7 @@ export function RemediationHistoryList({ entries, keyId, keyState }: { entries: 
       setShowConfirm(false)
       router.refresh()
     } catch (e) {
-      console.error('Failed to mark for remediation', e)
+      console.error('Failed to clear remediation state', e)
       setError(e instanceof Error ? e.message : 'Failed to update key state. Please try again.')
     } finally {
       setIsSubmitting(false)
@@ -147,12 +147,12 @@ export function RemediationHistoryList({ entries, keyId, keyState }: { entries: 
     <div className="flex flex-col gap-2">
       {[KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(keyState) && (
         <ActionButton onClick={onRequestRemediation} disabled={isSubmitting}>
-          Mark for remediation
+          Clear remediation
         </ActionButton>
       )}
 
       <ConfirmationDialog
-        title="Mark for remediation"
+        title="Clear remediation"
         open={showConfirm}
         onClose={() => { if (!isSubmitting) setShowConfirm(false) }}
         footerActions={(
@@ -172,7 +172,7 @@ export function RemediationHistoryList({ entries, keyId, keyState }: { entries: 
           </div>
         )}
         <div className="py-3 text-[14px] text-text-secondary">
-          This will set the key state back to <span className="font-semibold">Staked</span>. Prompting the system to re-evaluate it.
+          This will reset the key state back to <span className="font-semibold">Staked</span>. The system will re-evaluate it on the next status check.
         </div>
       </ConfirmationDialog>
 

--- a/apps/provider/src/app/admin/setup/ConfigureBlockChain/index.tsx
+++ b/apps/provider/src/app/admin/setup/ConfigureBlockChain/index.tsx
@@ -249,11 +249,11 @@ const FormComponent: React.FC<FormProps> = ({ defaultValues, goNext }) => {
               control={form.control}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Node API URL</FormLabel>
+                  <FormLabel>Pocket API URL</FormLabel>
                   <FormControl>
                     <Input
                       {...field}
-                      placeholder="https://your-shannon-node-api.example.com"
+                      placeholder="https://your-pocket-api.example.com"
                     />
                   </FormControl>
                   <FormDescription>

--- a/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
+++ b/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
@@ -358,7 +358,7 @@ export function AddOrUpdateServiceDialog({
 
               {!serviceOnChain && hasLoadServiceError && (
                 <div className="text-sm text-center py-4 px-3 rounded-md" style={{ background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.2)', color: '#f87171' }}>
-                  Failed to load services from chain. Check your Node API URL.
+                  Failed to load services from chain. Check your Pocket API URL.
                 </div>
               )}
 

--- a/apps/provider/src/db/bootstrap-seed.ts
+++ b/apps/provider/src/db/bootstrap-seed.ts
@@ -1,0 +1,356 @@
+import * as schema from '@igniter/db/provider/schema'
+import { UserRole } from '@igniter/db/provider/enums'
+import { eq } from 'drizzle-orm'
+import * as fs from 'fs'
+import * as path from 'path'
+import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing'
+import { setup } from '@igniter/db/connection'
+import { getLogger } from '@igniter/logger'
+
+const {
+  usersTable,
+  applicationSettingsTable,
+  regionsTable,
+  relayMinersTable,
+  servicesTable,
+  addressGroupTable,
+  addressGroupServicesTable,
+  delegatorsTable,
+} = schema
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface BootstrapConfig {
+  settings: {
+    name: string
+    supportEmail?: string
+    rpcUrl: string
+    indexerApiUrl: string
+    chainId: string
+    rewardAddresses?: string[]
+    initialOperationalFunds?: number
+    minimumOperationalFunds?: number
+  }
+  regions: Array<{ displayName: string; urlValue: string }>
+  relayMiners: Array<{
+    name: string
+    identity: string
+    regionName: string
+    domain: string
+  }>
+  services: Array<{
+    serviceId: string
+    name: string
+    ownerAddress?: string
+    computeUnits?: number
+    revSharePercentage?: number
+    endpoints: Array<{
+      url: string
+      rpcType: number
+      configs?: Array<{ key: string; value: string }>
+    }>
+  }>
+  addressGroups: Array<{
+    name: string
+    relayMinerName: string
+    private?: boolean
+    linkedAddresses?: string[]
+    services: Array<{
+      serviceId: string
+      addSupplierShare?: boolean
+      supplierShare?: number
+      revShare?: Array<{ address: string; share: number }>
+    }>
+  }>
+}
+
+interface CdnDelegator {
+  name: string
+  identity: string
+  identityHistory?: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const configPath = process.env.BOOTSTRAP_CONFIG_PATH
+  if (!configPath) {
+    console.log('[bootstrap-seed] BOOTSTRAP_CONFIG_PATH not set, skipping.')
+    process.exit(0)
+  }
+
+  const resolvedPath = path.resolve(configPath)
+  if (!fs.existsSync(resolvedPath)) {
+    console.log(`[bootstrap-seed] Config file not found at ${resolvedPath}, skipping.`)
+    process.exit(0)
+  }
+
+  const ownerIdentity = process.env.OWNER_IDENTITY
+  if (!ownerIdentity) {
+    console.error('[bootstrap-seed] OWNER_IDENTITY is required.')
+    process.exit(1)
+  }
+
+  const ownerEmail = process.env.OWNER_EMAIL || undefined
+
+  const appIdentityPrivateKey = process.env.APP_IDENTITY
+  if (!appIdentityPrivateKey) {
+    console.error('[bootstrap-seed] APP_IDENTITY is required.')
+    process.exit(1)
+  }
+
+  // Derive compressed public key from APP_IDENTITY private key
+  const privateKeyBytes = Buffer.from(appIdentityPrivateKey, 'hex')
+  const wallet = await DirectSecp256k1Wallet.fromKey(privateKeyBytes)
+  const [account] = await wallet.getAccounts()
+  if (!account) {
+    console.error('[bootstrap-seed] Failed to derive public key from APP_IDENTITY.')
+    process.exit(1)
+  }
+  const appIdentity = Buffer.from(account.pubkey).toString('hex')
+
+  // Connect to DB
+  const logger = getLogger()
+  const { db, disconnect } = setup({ schema, logger })
+
+  try {
+    // Check if already bootstrapped
+    const existingSettings = await db
+      .select()
+      .from(applicationSettingsTable)
+      .limit(1)
+
+    if (existingSettings.length > 0 && existingSettings[0]!.isBootstrapped) {
+      console.log('[bootstrap-seed] Already bootstrapped, skipping.')
+      await disconnect()
+      process.exit(0)
+    }
+
+    // Read config
+    const rawConfig = fs.readFileSync(resolvedPath, 'utf-8')
+    const config: BootstrapConfig = JSON.parse(rawConfig)
+
+    console.log('[bootstrap-seed] Starting bootstrap...')
+
+    // 0. Fetch blockchain params from RPC (minimumStake + current height)
+    const rpcBase = config.settings.rpcUrl.replace(/\/$/, '')
+    const stakeBuffer = parseInt(process.env.MINIMUM_STAKE_BUFFER || '0', 10)
+    let minimumStake = 0
+    let updatedAtHeight = '0'
+
+    try {
+      // Fetch minimum stake
+      const supplierParamsUrl = `${rpcBase}/pokt-network/poktroll/supplier/params`
+      console.log(`[bootstrap-seed] Fetching minimum stake from ${supplierParamsUrl}...`)
+      const paramsResponse = await fetch(supplierParamsUrl)
+      if (!paramsResponse.ok) throw new Error(`Supplier params: HTTP ${paramsResponse.status}`)
+      const paramsData = await paramsResponse.json()
+      const rawAmount = parseFloat(paramsData.params.min_stake.amount)
+      minimumStake = (rawAmount + stakeBuffer) / 1e6
+      console.log(`[bootstrap-seed] Minimum stake: ${minimumStake} POKT (raw: ${rawAmount}, buffer: ${stakeBuffer})`)
+
+      // Fetch current height
+      const statusUrl = `${rpcBase}/cosmos/base/node/v1beta1/status`
+      console.log(`[bootstrap-seed] Fetching current height from ${statusUrl}...`)
+      const statusResponse = await fetch(statusUrl)
+      if (!statusResponse.ok) throw new Error(`Node status: HTTP ${statusResponse.status}`)
+      const statusData = await statusResponse.json()
+      updatedAtHeight = statusData.height
+      console.log(`[bootstrap-seed] Current height: ${updatedAtHeight}`)
+    } catch (err) {
+      console.error('[bootstrap-seed] Failed to fetch blockchain params:', err)
+      process.exit(1)
+    }
+
+    // 1. Create owner user
+    console.log('[bootstrap-seed] Creating owner user...')
+    await db
+      .insert(usersTable)
+      .values({
+        identity: ownerIdentity,
+        email: ownerEmail,
+        role: UserRole.Owner,
+      })
+      .onConflictDoNothing()
+
+    // 2. Create application settings
+    console.log('[bootstrap-seed] Creating application settings...')
+    await db.insert(applicationSettingsTable).values({
+      name: config.settings.name,
+      appIdentity,
+      supportEmail: config.settings.supportEmail,
+      ownerIdentity: ownerIdentity,
+      ownerEmail: ownerEmail,
+      chainId: config.settings.chainId as any,
+      minimumStake,
+      initialOperationalFunds: config.settings.initialOperationalFunds,
+      minimumOperationalFunds: config.settings.minimumOperationalFunds,
+      isBootstrapped: false, // will set to true at the end
+      rpcUrl: config.settings.rpcUrl,
+      indexerApiUrl: config.settings.indexerApiUrl,
+      updatedAtHeight,
+      rewardAddresses: config.settings.rewardAddresses ?? [],
+      createdBy: ownerIdentity,
+      updatedBy: ownerIdentity,
+    })
+
+    // 3. Create regions
+    console.log('[bootstrap-seed] Creating regions...')
+    const regionNameToId: Record<string, number> = {}
+    for (const region of config.regions) {
+      const [inserted] = await db
+        .insert(regionsTable)
+        .values({
+          displayName: region.displayName,
+          urlValue: region.urlValue,
+          createdBy: ownerIdentity,
+          updatedBy: ownerIdentity,
+        })
+        .returning({ id: regionsTable.id })
+
+      regionNameToId[region.displayName] = inserted!.id
+      console.log(`[bootstrap-seed]   Region "${region.displayName}" -> id ${inserted!.id}`)
+    }
+
+    // 4. Create relay miners
+    console.log('[bootstrap-seed] Creating relay miners...')
+    const relayMinerNameToId: Record<string, number> = {}
+    for (const rm of config.relayMiners) {
+      const regionId = regionNameToId[rm.regionName]
+      if (regionId === undefined) {
+        throw new Error(
+          `[bootstrap-seed] Relay miner "${rm.name}" references unknown region "${rm.regionName}". ` +
+          `Available regions: ${Object.keys(regionNameToId).join(', ')}`,
+        )
+      }
+
+      const [inserted] = await db
+        .insert(relayMinersTable)
+        .values({
+          name: rm.name,
+          identity: rm.identity,
+          regionId,
+          domain: rm.domain,
+          createdBy: ownerIdentity,
+          updatedBy: ownerIdentity,
+        })
+        .returning({ id: relayMinersTable.id })
+
+      relayMinerNameToId[rm.name] = inserted!.id
+      console.log(`[bootstrap-seed]   Relay miner "${rm.name}" -> id ${inserted!.id}`)
+    }
+
+    // 5. Create services
+    console.log('[bootstrap-seed] Creating services...')
+    for (const svc of config.services) {
+      await db.insert(servicesTable).values({
+        serviceId: svc.serviceId,
+        name: svc.name,
+        ownerAddress: svc.ownerAddress ?? ownerIdentity,
+        computeUnits: svc.computeUnits ?? 1,
+        revSharePercentage: svc.revSharePercentage,
+        endpoints: svc.endpoints.map((ep) => ({
+          url: ep.url,
+          rpcType: ep.rpcType,
+        })),
+        createdBy: ownerIdentity,
+        updatedBy: ownerIdentity,
+      })
+      console.log(`[bootstrap-seed]   Service "${svc.serviceId}" created`)
+    }
+
+    // 6. Create address groups
+    console.log('[bootstrap-seed] Creating address groups...')
+    for (const ag of config.addressGroups) {
+      const relayMinerId = relayMinerNameToId[ag.relayMinerName]
+      if (relayMinerId === undefined) {
+        throw new Error(
+          `[bootstrap-seed] Address group "${ag.name}" references unknown relay miner "${ag.relayMinerName}". ` +
+          `Available relay miners: ${Object.keys(relayMinerNameToId).join(', ')}`,
+        )
+      }
+
+      const [insertedAg] = await db
+        .insert(addressGroupTable)
+        .values({
+          name: ag.name,
+          relayMinerId,
+          private: ag.private ?? false,
+          linkedAddresses: ag.linkedAddresses ?? [],
+          createdBy: ownerIdentity,
+          updatedBy: ownerIdentity,
+        })
+        .returning({ id: addressGroupTable.id })
+
+      console.log(`[bootstrap-seed]   Address group "${ag.name}" -> id ${insertedAg!.id}`)
+
+      // 7. Create address group services
+      if (ag.services && ag.services.length > 0) {
+        for (const agSvc of ag.services) {
+          await db.insert(addressGroupServicesTable).values({
+            addressGroupId: insertedAg!.id,
+            serviceId: agSvc.serviceId,
+            addSupplierShare: agSvc.addSupplierShare ?? false,
+            supplierShare: agSvc.supplierShare ?? 0,
+            revShare: agSvc.revShare ?? [],
+          })
+          console.log(`[bootstrap-seed]     Linked service "${agSvc.serviceId}" to address group "${ag.name}"`)
+        }
+      }
+    }
+
+    // 8. Fetch delegators from CDN and create them
+    const delegatorsCdnUrl = process.env.DELEGATORS_CDN_URL
+    if (delegatorsCdnUrl) {
+      const resolvedUrl = delegatorsCdnUrl.replace('{chainId}', config.settings.chainId)
+      console.log(`[bootstrap-seed] Fetching delegators from ${resolvedUrl}...`)
+      try {
+        const response = await fetch(resolvedUrl)
+        if (!response.ok) {
+          console.warn(`[bootstrap-seed] Failed to fetch delegators (${response.status}), skipping.`)
+        } else {
+          const cdnDelegators: CdnDelegator[] = await response.json()
+          for (const del of cdnDelegators) {
+            await db
+              .insert(delegatorsTable)
+              .values({
+                name: del.name,
+                identity: del.identity,
+                enabled: true,
+                createdBy: ownerIdentity,
+                updatedBy: ownerIdentity,
+              })
+              .onConflictDoNothing()
+            console.log(`[bootstrap-seed]   Delegator "${del.name}" created`)
+          }
+        }
+      } catch (err) {
+        console.warn('[bootstrap-seed] Error fetching delegators, skipping:', err)
+      }
+    } else {
+      console.log('[bootstrap-seed] DELEGATORS_CDN_URL not set, skipping delegators.')
+    }
+
+    // 9. Set isBootstrapped = true
+    console.log('[bootstrap-seed] Setting isBootstrapped = true...')
+    await db
+      .update(applicationSettingsTable)
+      .set({ isBootstrapped: true, updatedBy: ownerIdentity })
+      .where(eq(applicationSettingsTable.ownerIdentity, ownerIdentity))
+
+    console.log('[bootstrap-seed] Bootstrap complete!')
+  } catch (error) {
+    console.error('[bootstrap-seed] Bootstrap failed:', error)
+    await disconnect()
+    process.exit(1)
+  }
+
+  await disconnect()
+  process.exit(0)
+}
+
+main()

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -1,6 +1,7 @@
 import type {
   InsertKey,
-  Key, KeyWithRelations,
+  Key, KeyWithRelations, KeyWithGroup,
+  RemediationHistoryEntry,
 } from '@igniter/db/provider/schema'
 import * as schema from '@igniter/db/provider/schema'
 import { getDbClient } from '@/db'
@@ -11,6 +12,7 @@ import {
   count,
   eq,
   inArray,
+  sql,
 } from 'drizzle-orm'
 import { NodePgQueryResultHKT } from 'drizzle-orm/node-postgres'
 
@@ -274,4 +276,132 @@ export async function updateKeysStateWhereCurrentStateIn(currentStates: KeyState
       state: newState,
     })
     .where(inArray(keysTable.state, currentStates))
+}
+
+/**
+ * Lists all keys in `Staked` state with deep address group relations,
+ * including addressGroupServices (with service and endpoints),
+ * and relayMiner (with region).
+ *
+ * This mirrors the deep loading pattern from the workflow DAL's `loadKey` function.
+ */
+export async function listStakedKeysWithDetails(): Promise<KeyWithGroup[]> {
+  const dbClient = getDbClient()
+  return dbClient.db.query.keysTable.findMany({
+    where: eq(keysTable.state, KeyState.Staked),
+    with: {
+      addressGroup: {
+        with: {
+          relayMiner: {
+            columns: {
+              id: true,
+              name: true,
+              identity: true,
+              regionId: true,
+              domain: true,
+              createdAt: true,
+              updatedAt: true,
+              createdBy: true,
+              updatedBy: true,
+            },
+            with: {
+              region: true,
+            },
+          },
+          addressGroupServices: {
+            with: {
+              service: {
+                columns: {
+                  name: true,
+                  endpoints: true,
+                },
+              },
+            },
+          },
+        },
+        extras: {
+          keysCount: sql<number>`
+            CAST(
+              (
+                SELECT COUNT(*)
+                FROM ${keysTable}
+                WHERE ${keysTable}."address_group_id" = ${schema.addressGroupTable.id}
+              ) AS INTEGER
+            )
+          `.as('keys_count'),
+        },
+      },
+    },
+  })
+}
+
+/**
+ * Batch update remediationHistory for multiple keys by address.
+ */
+export async function batchUpdateRemediationHistory(
+  updates: Array<{ address: string; remediationHistory: RemediationHistoryEntry[] }>,
+): Promise<void> {
+  const dbClient = getDbClient()
+  await Promise.all(
+    updates.map((update) =>
+      dbClient.db
+        .update(keysTable)
+        .set({ remediationHistory: update.remediationHistory })
+        .where(eq(keysTable.address, update.address)),
+    ),
+  )
+}
+
+/**
+ * Load keys by addresses with deep address group relations.
+ */
+export async function listKeysByAddresses(addresses: string[]): Promise<KeyWithGroup[]> {
+  if (addresses.length === 0) return []
+  const dbClient = getDbClient()
+  return dbClient.db.query.keysTable.findMany({
+    where: inArray(keysTable.address, addresses),
+    with: {
+      addressGroup: {
+        with: {
+          relayMiner: {
+            columns: {
+              id: true,
+              name: true,
+              identity: true,
+              regionId: true,
+              domain: true,
+              createdAt: true,
+              updatedAt: true,
+              createdBy: true,
+              updatedBy: true,
+            },
+            with: {
+              region: true,
+            },
+          },
+          addressGroupServices: {
+            with: {
+              service: {
+                columns: {
+                  name: true,
+                  endpoints: true,
+                },
+              },
+            },
+          },
+        },
+        extras: {
+          keysCount: sql<number>`
+            CAST(
+              (
+                SELECT COUNT(*)
+                FROM ${keysTable}
+                WHERE ${keysTable}."address_group_id" = ${schema.addressGroupTable.id}
+              ) AS INTEGER
+            )
+          `.as('keys_count'),
+        },
+      },
+    },
+  })
 }

--- a/apps/provider/src/lib/temporal.ts
+++ b/apps/provider/src/lib/temporal.ts
@@ -15,8 +15,8 @@ function makeClient(): Client {
 
 export function getTemporalConfig() {
   return {
-    namespace: process.env.TEMPORAL_NAMESPACE || "middleman",
-    taskQueue: process.env.TEMPORAL_TASK_QUEUE || "middleman-operations",
+    namespace: process.env.TEMPORAL_NAMESPACE || "provider",
+    taskQueue: process.env.TEMPORAL_TASK_QUEUE || "provider-operations",
   };
 }
 

--- a/docs/guides/provider/bootstrap.md
+++ b/docs/guides/provider/bootstrap.md
@@ -22,7 +22,7 @@ Connect the Provider to the Pocket Network by entering the REST API URL of a Poc
 | Field | Description |
 |-------|-------------|
 | **App Identity** | Your provider's public identifier, derived from the `APP_IDENTITY` private key in your environment. Read-only — displayed for reference. Verify that this matches the address you registered in the [governance PR](https://github.com/pokt-network/pocket-network-genesis/pulls). |
-| **Shannon API URL** | The REST API endpoint of a Pocket Network node (e.g., `https://sauron-api.beta.infra.pocket.network`). This is the Cosmos SDK REST interface, typically served on port `1317` for self-hosted nodes. Required. After entering a valid URL, the app fetches chain parameters automatically. |
+| **Pocket API URL** | The REST API endpoint of a Pocket Network node (e.g., `https://sauron-api.beta.infra.pocket.network`). This is the Cosmos SDK REST interface, typically served on port `1317` for self-hosted nodes. Do not use the Tendermint RPC (port `26657`). Required. After entering a valid URL, the app fetches chain parameters automatically. |
 | **Network** | The chain ID detected from the API (e.g., `pocket-beta`). Read-only — auto-populated. Cannot be changed after bootstrap. |
 | **Network Minimum Stake** | The minimum stake required on-chain, in uPOKT. Read-only — auto-populated from the API. |
 | **Indexer API URL** | URL of the blockchain indexer, used to retrieve reward data. Required. The app validates that the indexer's network matches the detected chain ID. Available indexers: `https://api.poktscan.com` (mainnet) and `https://beta-api.poktscan.com` (beta). |

--- a/docs/guides/provider/key-inventory.md
+++ b/docs/guides/provider/key-inventory.md
@@ -44,7 +44,7 @@
    | **Unstaked** | No longer staked — available for export or re-use. |
    | **Stake Failed** | Staking transaction failed. Operator action required. |
    | **Missing Stake** | Expected stake not found after 24 hours. Investigate with the owner/staker. |
-   | **Remediation Failed** | Auto-remediation did not work. Use Mark for Remediation to retry. |
+   | **Remediation Failed** | Auto-remediation did not work. Use Clear Remediation to retry. |
    | **Attention Needed** | System cannot auto-resolve this. Review the key details and take action. |
 
    > Keys progress through states automatically as staking operations proceed. See the [Key Management reference](../../reference/provider/key-management.md) for the full lifecycle diagram and all 11 state definitions.

--- a/docs/reference/provider/key-management.md
+++ b/docs/reference/provider/key-management.md
@@ -67,7 +67,11 @@ These states will not resolve automatically. Check the key detail view for remed
 - **Remediation Failed** — Automatic remediation did not work. Review the remediation history and retry manually.
 - **Attention Needed** — The system detected a condition it cannot resolve. Review the details and take manual action.
 
-To trigger a remediation retry for `RemediationFailed` or `AttentionNeeded` keys, use the **Mark for Remediation** button on the Keys page.
+The Keys page provides three actions for managing remediation:
+
+- **Clear Remediation** — Resets all `RemediationFailed` or `AttentionNeeded` keys back to `Staked`. The system will re-evaluate them on the next status check.
+- **Request Remediation** — Evaluates all staked suppliers for service mismatches and presents a summary. If you confirm, the system marks affected keys for remediation and triggers the remediation workflow immediately.
+- **Auto Stake** toggle — Controls whether the automatic remediation schedule is active. When paused, the system detects issues but does not auto-remediate — you must use Request Remediation to trigger fixes manually. The initial stake workflow (for new suppliers without services) always runs regardless of this toggle.
 
 ---
 
@@ -171,7 +175,7 @@ All 11 key states from the `KeyState` enum, with display names and operator guid
 | `unstaking` | Unstaking | No | Unstake transaction submitted. Resolves automatically. |
 | `unstaked` | Unstaked | No | Key is no longer staked. Available for export or re-use. |
 | `missing_stake` | Missing Stake | **Yes** | Expected stake not found after 24 hours. Investigate with the owner/staker. |
-| `remediation_failed` | Remediation Failed | **Yes** | Auto-remediation failed. Review remediation history, then use Mark for Remediation. |
+| `remediation_failed` | Remediation Failed | **Yes** | Auto-remediation failed. Review remediation history, then use Clear Remediation. |
 | `attention_needed` | Attention Needed | **Yes** | System cannot auto-resolve. Review key details and take manual action. |
 
 ### Transient vs. Stable States

--- a/k8s/apps/middleman-workflows/Tiltfile
+++ b/k8s/apps/middleman-workflows/Tiltfile
@@ -3,14 +3,7 @@ custom_build(
     command='./k8s/docker/build.sh middleman-workflows',
     dir='../../../',
     deps=['../../../apps/middleman-workflows', '../../../packages'],
-    ignore=[
-      'node_modules',
-      '**/node_modules',
-      'packages/**/node_modules',
-      'apps/**/node_modules',
-      'apps/**/dist',
-      'packages/**/dist'
-    ],
+    ignore=['node_modules', '**/node_modules', '**/dist', '**/*.test.ts', '**/__fixtures__'],
     live_update=[
       sync('../../../apps/middleman-workflows', '/app/apps/middleman-workflows'),
       sync('../../../packages', '/app/packages'),

--- a/k8s/apps/middleman/Tiltfile
+++ b/k8s/apps/middleman/Tiltfile
@@ -42,6 +42,45 @@ for o in objects:
     o['stringData']['APP_IDENTITY'] = APP_IDENTITY
     break
 
+# Auto-bootstrap: if MIDDLEMAN_BOOTSTRAP_CONFIG_PATH points to a local JSON file,
+# read it, create a ConfigMap, mount it in an init container, and seed the DB.
+BOOTSTRAP_LOCAL_PATH=os.getenv('MIDDLEMAN_BOOTSTRAP_CONFIG_PATH', '')
+
+if BOOTSTRAP_LOCAL_PATH != '':
+  bootstrap_content = read_file(BOOTSTRAP_LOCAL_PATH)
+  bootstrap_configmap = {
+    'apiVersion': 'v1',
+    'kind': 'ConfigMap',
+    'metadata': {'name': 'middleman-bootstrap-config'},
+    'data': {'bootstrap.json': str(bootstrap_content)},
+  }
+  objects.append(bootstrap_configmap)
+
+  for o in objects:
+    if o['kind'] == 'Deployment' and o['metadata']['name'] == 'middleman':
+      init_containers = o['spec']['template']['spec'].get('initContainers', [])
+      init_containers.append({
+        'name': 'db-bootstrap-seed',
+        'image': 'localhost:5001/middleman',
+        'workingDir': '/app',
+        'command': ['sh', '-c', 'pnpm exec turbo run build --filter=@igniter/db && cd apps/middleman && pnpm exec tsx src/db/bootstrap-seed.ts'],
+        'env': [{'name': 'BOOTSTRAP_CONFIG_PATH', 'value': '/bootstrap/bootstrap.json'}],
+        'envFrom': [
+          {'configMapRef': {'name': 'middleman-config'}},
+          {'secretRef': {'name': 'middleman-secrets'}},
+          {'secretRef': {'name': 'postgres-middleman-connection'}},
+        ],
+        'volumeMounts': [{'name': 'bootstrap-config', 'mountPath': '/bootstrap', 'readOnly': True}],
+      })
+      o['spec']['template']['spec']['initContainers'] = init_containers
+      volumes = o['spec']['template']['spec'].get('volumes', [])
+      volumes.append({
+        'name': 'bootstrap-config',
+        'configMap': {'name': 'middleman-bootstrap-config'},
+      })
+      o['spec']['template']['spec']['volumes'] = volumes
+      break
+
 # encode it after replace env vars
 k8s_yaml(encode_yaml_stream(objects), allow_duplicates=False)
 

--- a/k8s/apps/middleman/Tiltfile
+++ b/k8s/apps/middleman/Tiltfile
@@ -3,7 +3,7 @@ custom_build(
     command='./k8s/docker/build.sh middleman',
     dir='../../../',
     deps=['../../../apps/middleman', '../../../packages'],
-    ignore=['node_modules', '**/node_modules', 'packages/**/node_modules', 'apps/**/node_modules', 'apps/**/node_modules/dist', 'packages/**/dist'],
+    ignore=['node_modules', '**/node_modules', '**/dist', '**/*.test.ts', '**/__fixtures__'],
     live_update=[
       sync('../../../apps/middleman', '/app/apps/middleman'),
       sync('../../../packages', '/app/packages'),

--- a/k8s/apps/middleman/overlays/dev/bootstrap.example.json
+++ b/k8s/apps/middleman/overlays/dev/bootstrap.example.json
@@ -1,0 +1,11 @@
+{
+  "settings": {
+    "name": "Igniter Middleman (Dev)",
+    "ownerEmail": "dev@igniter.local",
+    "fee": 0,
+    "delegatorRewardsAddress": "pokt10d79e5fyglwt9clgrvtwmy6jqj8a9nh8ntp00c",
+    "rpcUrl": "https://sauron-api.beta.infra.pocket.network",
+    "indexerApiUrl": "https://beta-api.poktscan.com/",
+    "chainId": "pocket-lego-testnet"
+  }
+}

--- a/k8s/apps/provider-workflows/Tiltfile
+++ b/k8s/apps/provider-workflows/Tiltfile
@@ -3,14 +3,7 @@ custom_build(
     command='./k8s/docker/build.sh provider-workflows',
     dir='../../../',
     deps=['../../../apps/provider-workflows', '../../../packages'],
-    ignore=[
-      'node_modules',
-      '**/node_modules',
-      'packages/**/node_modules',
-      'apps/**/node_modules',
-      'apps/**/dist',
-      'packages/**/dist'
-    ],
+    ignore=['node_modules', '**/node_modules', '**/dist', '**/*.test.ts', '**/__fixtures__'],
     live_update=[
       sync('../../../apps/provider-workflows', '/app/apps/provider-workflows'),
       sync('../../../packages', '/app/packages'),

--- a/k8s/apps/provider/Tiltfile
+++ b/k8s/apps/provider/Tiltfile
@@ -3,7 +3,7 @@ custom_build(
     command='./k8s/docker/build.sh provider',
     dir='../../../',
     deps=['../../../apps/provider', '../../../packages'],
-    ignore=['node_modules', '**/node_modules', 'packages/**/node_modules', 'apps/**/node_modules',  'apps/**/node_modules/dist', 'packages/**/dist'],
+    ignore=['node_modules', '**/node_modules', '**/dist', '**/*.test.ts', '**/__fixtures__'],
     live_update=[
       sync('../../../apps/provider', '/app/apps/provider'),
       sync('../../../packages', '/app/packages'),

--- a/k8s/apps/provider/Tiltfile
+++ b/k8s/apps/provider/Tiltfile
@@ -42,6 +42,45 @@ for o in objects:
     o['stringData']['APP_IDENTITY'] = APP_IDENTITY
     break
 
+# Auto-bootstrap: if PROVIDER_BOOTSTRAP_CONFIG_PATH points to a local JSON file,
+# read it, create a ConfigMap, mount it in an init container, and seed the DB.
+BOOTSTRAP_LOCAL_PATH=os.getenv('PROVIDER_BOOTSTRAP_CONFIG_PATH', '')
+
+if BOOTSTRAP_LOCAL_PATH != '':
+  bootstrap_content = read_file(BOOTSTRAP_LOCAL_PATH)
+  bootstrap_configmap = {
+    'apiVersion': 'v1',
+    'kind': 'ConfigMap',
+    'metadata': {'name': 'provider-bootstrap-config'},
+    'data': {'bootstrap.json': str(bootstrap_content)},
+  }
+  objects.append(bootstrap_configmap)
+
+  for o in objects:
+    if o['kind'] == 'Deployment' and o['metadata']['name'] == 'provider':
+      init_containers = o['spec']['template']['spec'].get('initContainers', [])
+      init_containers.append({
+        'name': 'db-bootstrap-seed',
+        'image': 'localhost:5001/provider',
+        'workingDir': '/app',
+        'command': ['sh', '-c', 'pnpm exec turbo run build --filter=@igniter/db && cd apps/provider && pnpm exec tsx src/db/bootstrap-seed.ts'],
+        'env': [{'name': 'BOOTSTRAP_CONFIG_PATH', 'value': '/bootstrap/bootstrap.json'}],
+        'envFrom': [
+          {'configMapRef': {'name': 'provider-config'}},
+          {'secretRef': {'name': 'provider-secrets'}},
+          {'secretRef': {'name': 'postgres-provider-connection'}},
+        ],
+        'volumeMounts': [{'name': 'bootstrap-config', 'mountPath': '/bootstrap', 'readOnly': True}],
+      })
+      o['spec']['template']['spec']['initContainers'] = init_containers
+      volumes = o['spec']['template']['spec'].get('volumes', [])
+      volumes.append({
+        'name': 'bootstrap-config',
+        'configMap': {'name': 'provider-bootstrap-config'},
+      })
+      o['spec']['template']['spec']['volumes'] = volumes
+      break
+
 # encode it after replace env vars
 k8s_yaml(encode_yaml_stream(objects), allow_duplicates=False)
 

--- a/k8s/apps/provider/overlays/dev/bootstrap.example.json
+++ b/k8s/apps/provider/overlays/dev/bootstrap.example.json
@@ -1,0 +1,54 @@
+{
+  "settings": {
+    "name": "Igniter Provider (Dev)",
+    "rpcUrl": "https://sauron-api.beta.infra.pocket.network",
+    "indexerApiUrl": "https://beta-api.poktscan.com/",
+    "chainId": "pocket-lego-testnet",
+    "rewardAddresses": [],
+    "initialOperationalFunds": 5,
+    "minimumOperationalFunds": 2
+  },
+  "regions": [
+    {
+      "displayName": "US East",
+      "urlValue": "us-east"
+    }
+  ],
+  "relayMiners": [
+    {
+      "name": "RM 01",
+      "identity": "rm-01",
+      "regionName": "US East",
+      "domain": "relay.dev.example.com"
+    }
+  ],
+  "services": [
+    {
+      "serviceId": "pnf-anvil",
+      "name": "Anvil (PNF)",
+      "ownerAddress": "",
+      "computeUnits": 1,
+      "endpoints": [
+        {
+          "url": "",
+          "rpcType": 3
+        }
+      ]
+    }
+  ],
+  "addressGroups": [
+    {
+      "name": "Default Group",
+      "relayMinerName": "RM 01",
+      "private": false,
+      "services": [
+        {
+          "serviceId": "pnf-anvil",
+          "addSupplierShare": false,
+          "supplierShare": 0,
+          "revShare": []
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "build:middleman-workflows:docker": "./k8s/docker/build.sh middleman-workflows",
     "build:provider-workflows:docker": "./k8s/docker/build.sh provider-workflows",
     "build:provider:docker": "./k8s/docker/build.sh provider",
-    "create-cluster": "./k8s/docker/cluster.sh"
+    "middleman:seed": "pnpm exec tsx apps/middleman/src/db/bootstrap-seed.ts",
+    "create-cluster": "./k8s/docker/cluster.sh",
+    "provider:seed": "pnpm exec tsx apps/provider/src/db/bootstrap-seed.ts"
   },
   "workspaces": [
     "apps/*",

--- a/packages/domain/jest.config.ts
+++ b/packages/domain/jest.config.ts
@@ -11,6 +11,7 @@ const config: Config = {
         '^@igniter/pocket/proto/(.*)$': '<rootDir>/../pocket/src/proto/generated/$1',
         '^@igniter/pocket/(.*)$': '<rootDir>/../pocket/src/$1',
         '^@igniter/pocket$': '<rootDir>/../pocket/src/index.ts',
+        '^@igniter/db/provider/enums$': '<rootDir>/../db/src/provider/schema/enums',
         '^@igniter/db/(.*)$': '<rootDir>/../db/src/$1',
         '^@igniter/logger$': '<rootDir>/../logger/src/index.ts',
         '^@pocket/(.*)$': '<rootDir>/../pocket/src/$1',

--- a/packages/domain/src/provider/operations/suppliers/CompareSupplierServiceConfig/CompareSupplierServiceConfigHandler.test.ts
+++ b/packages/domain/src/provider/operations/suppliers/CompareSupplierServiceConfig/CompareSupplierServiceConfigHandler.test.ts
@@ -6,6 +6,16 @@ import type {
     SupplierEndpoint,
     ConfigOption,
 } from '@igniter/pocket';
+import { RPCType } from '@igniter/pocket/proto/pocket/shared/service';
+import {
+    matchingSupplierAndKey,
+    mismatchedSupplierAndKey,
+    pristineSupplier,
+    OWNER_ADDRESS,
+    PROVIDER_ADDRESS,
+    DELEGATOR_ADDRESS,
+} from '@igniter/domain/provider/utils/__fixtures__/supplier-data';
+import { getExpectedServicesFromKey } from '@igniter/domain/provider/utils/suppliers';
 
 const rs = (address: string): ServiceRevenueShare => ({ address });
 const co = (key: number, value: string): ConfigOption => ({ key, value });
@@ -75,5 +85,101 @@ describe('CompareSupplierServiceConfigHandler', () => {
 
         expect(result.isEqual).toBe(false);
         expect(result.diff.length).toBeGreaterThan(0);
+    });
+});
+
+// ── Fixture-based comparison tests ──────────────────────────────────────
+describe('CompareSupplierServiceConfigHandler with fixtures', () => {
+    let handler: CompareSupplierServiceConfigHandler;
+
+    beforeAll(() => {
+        handler = new CompareSupplierServiceConfigHandler();
+    });
+
+    it('returns isEqual true when supplier services match expected from key', () => {
+        const expected = getExpectedServicesFromKey(matchingSupplierAndKey.key);
+        const actual = matchingSupplierAndKey.supplier.services;
+
+        const result = handler.execute({
+            serviceConfigSetA: expected,
+            serviceConfigSetB: actual,
+        });
+
+        expect(result.isEqual).toBe(true);
+        expect(result.diff).toEqual([]);
+    });
+
+    it('returns isEqual false when supplier services differ from expected', () => {
+        const expected = getExpectedServicesFromKey(mismatchedSupplierAndKey.key);
+        const actual = mismatchedSupplierAndKey.supplier.services;
+
+        const result = handler.execute({
+            serviceConfigSetA: expected,
+            serviceConfigSetB: actual,
+        });
+
+        expect(result.isEqual).toBe(false);
+        expect(result.diff.length).toBeGreaterThan(0);
+    });
+
+    it('returns isEqual true when services are in different order but semantically equal', () => {
+        const expected = getExpectedServicesFromKey(matchingSupplierAndKey.key);
+        // Reverse the order of services
+        const actual = [...matchingSupplierAndKey.supplier.services].reverse();
+
+        const result = handler.execute({
+            serviceConfigSetA: expected,
+            serviceConfigSetB: actual,
+        });
+
+        expect(result.isEqual).toBe(true);
+    });
+
+    it('returns isEqual false when comparing empty services against populated', () => {
+        const expected = getExpectedServicesFromKey(matchingSupplierAndKey.key);
+
+        const result = handler.execute({
+            serviceConfigSetA: expected,
+            serviceConfigSetB: pristineSupplier.services,
+        });
+
+        expect(result.isEqual).toBe(false);
+        expect(result.diff.length).toBeGreaterThan(0);
+    });
+
+    it('returns isEqual true when both sides are empty', () => {
+        const result = handler.execute({
+            serviceConfigSetA: [],
+            serviceConfigSetB: [],
+        });
+
+        expect(result.isEqual).toBe(true);
+        expect(result.diff).toEqual([]);
+    });
+
+    it('returns isEqual true when revShare entries are in different order', () => {
+        const serviceA: SupplierServiceConfig[] = [{
+            serviceId: 'anvil',
+            endpoints: [{ url: 'https://test.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+            revShare: [
+                { address: OWNER_ADDRESS, revSharePercentage: 80 },
+                { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+            ],
+        }];
+        const serviceB: SupplierServiceConfig[] = [{
+            serviceId: 'anvil',
+            endpoints: [{ url: 'https://test.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+            revShare: [
+                { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+                { address: OWNER_ADDRESS, revSharePercentage: 80 },
+            ],
+        }];
+
+        const result = handler.execute({
+            serviceConfigSetA: serviceA,
+            serviceConfigSetB: serviceB,
+        });
+
+        expect(result.isEqual).toBe(true);
     });
 });

--- a/packages/domain/src/provider/utils/__fixtures__/supplier-data.ts
+++ b/packages/domain/src/provider/utils/__fixtures__/supplier-data.ts
@@ -8,7 +8,7 @@ import type { Supplier, ServiceConfigUpdate } from '@igniter/pocket/proto/pocket
 import type { SupplierServiceConfig } from '@igniter/pocket/proto/pocket/shared/service';
 import { RPCType } from '@igniter/pocket/proto/pocket/shared/service';
 import type { KeyWithGroup } from '@igniter/db/provider/schema';
-import { KeyState } from '@igniter/db/provider/schema/enums';
+import { KeyState } from '@igniter/db/provider/enums';
 
 // ---------------------------------------------------------------------------
 // Shared addresses

--- a/packages/domain/src/provider/utils/__fixtures__/supplier-data.ts
+++ b/packages/domain/src/provider/utils/__fixtures__/supplier-data.ts
@@ -1,0 +1,457 @@
+/**
+ * Realistic test fixtures for supplier service comparison tests.
+ *
+ * These fixtures use actual types from the proto-generated code and DB schema
+ * to catch comparison bugs like the re-staking loop (see findings-supplier-restaking-loop.md).
+ */
+import type { Supplier, ServiceConfigUpdate } from '@igniter/pocket/proto/pocket/shared/supplier';
+import type { SupplierServiceConfig } from '@igniter/pocket/proto/pocket/shared/service';
+import { RPCType } from '@igniter/pocket/proto/pocket/shared/service';
+import type { KeyWithGroup } from '@igniter/db/provider/schema';
+import { KeyState } from '@igniter/db/provider/schema/enums';
+
+// ---------------------------------------------------------------------------
+// Shared addresses
+// ---------------------------------------------------------------------------
+const OWNER_ADDRESS = 'pokt1owner7x9f3hqz5p8kn4d0e2c6wm7a1b9r3t5y8';
+const OPERATOR_ADDRESS = 'pokt1oper8k2g4jd6h7m9w1c3f5n0b6v4r8q2s7t1e';
+const DELEGATOR_ADDRESS = 'pokt1dele3a5c7m2n8x4k1p9f6b0v3r7w5q8s2t6y';
+const PROVIDER_ADDRESS = 'pokt1prov4b6d8n3m9y1k2p7f5c0v6r8w4q1s3t5e';
+
+// ---------------------------------------------------------------------------
+// Helpers — build complete sub-objects without partial casts
+// ---------------------------------------------------------------------------
+
+function makeServiceConfig(
+  serviceId: string,
+  endpoints: SupplierServiceConfig['endpoints'],
+  revShare: SupplierServiceConfig['revShare'],
+): SupplierServiceConfig {
+  return { serviceId, endpoints, revShare };
+}
+
+function makeSupplier(overrides: Partial<Supplier>): Supplier {
+  return {
+    ownerAddress: OWNER_ADDRESS,
+    operatorAddress: OPERATOR_ADDRESS,
+    stake: { denom: 'upokt', amount: '100000000' },
+    services: [],
+    unstakeSessionEndHeight: 0,
+    serviceConfigHistory: [],
+    ...overrides,
+  };
+}
+
+function makeHistoryEntry(
+  service: SupplierServiceConfig,
+  activationHeight: number,
+  deactivationHeight: number,
+): ServiceConfigUpdate {
+  return {
+    operatorAddress: OPERATOR_ADDRESS,
+    service,
+    activationHeight,
+    deactivationHeight,
+  };
+}
+
+/**
+ * Build a KeyWithGroup fixture. Fields not relevant to the test can be
+ * filled with sensible defaults.  We use `as KeyWithGroup` because the
+ * full Key type includes encrypted DB columns (privateKey, etc.) that
+ * are irrelevant to the domain logic under test.
+ */
+function makeKeyWithGroup(overrides: Record<string, unknown>): KeyWithGroup {
+  return {
+    id: 1,
+    address: OPERATOR_ADDRESS,
+    publicKey: 'a'.repeat(66),
+    privateKey: 'encrypted',
+    ownerAddress: OWNER_ADDRESS,
+    state: KeyState.Staked,
+    remediationHistory: [],
+    deliveredAt: null,
+    deliveredTo: null,
+    addressGroupId: 1,
+    delegatorRevSharePercentage: 0,
+    delegatorRewardsAddress: '',
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+    lastUpdatedHeight: 500,
+    stakeOwner: OWNER_ADDRESS,
+    stakeAmountUpokt: 100000000n,
+    balanceUpokt: 50000000n,
+    services: [],
+    addressGroup: {
+      id: 1,
+      name: 'default-group',
+      linkedAddresses: [],
+      private: false,
+      relayMinerId: 1,
+      createdAt: new Date('2025-01-01'),
+      createdBy: 'admin',
+      updatedAt: new Date('2025-01-01'),
+      updatedBy: 'admin',
+      keysCount: 10,
+      addressGroupServices: [],
+      relayMiner: {
+        id: 1,
+        name: 'miner-us-east',
+        identity: 'rm-us-east-01',
+        regionId: 1,
+        domain: 'relay.example.com',
+        createdAt: new Date('2025-01-01'),
+        createdBy: 'admin',
+        updatedAt: new Date('2025-01-01'),
+        updatedBy: 'admin',
+        region: {
+          id: 1,
+          displayName: 'US East',
+          urlValue: 'us-east',
+          createdAt: new Date('2025-01-01'),
+          createdBy: 'admin',
+          updatedAt: new Date('2025-01-01'),
+          updatedBy: 'admin',
+        },
+      },
+    },
+    ...overrides,
+  } as KeyWithGroup;
+}
+
+// ---------------------------------------------------------------------------
+// Shared service configs reused across fixtures
+// ---------------------------------------------------------------------------
+
+/** "anvil" service with a single JSON_RPC endpoint */
+const anvilServiceConfig = makeServiceConfig(
+  'anvil',
+  [{ url: 'https://us-east-rm-us-east-01-anvil-json.relay.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+  [
+    { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+    { address: OWNER_ADDRESS, revSharePercentage: 80 },
+  ],
+);
+
+/** "eth-mainnet" service with JSON_RPC and REST endpoints */
+const ethMainnetServiceConfig = makeServiceConfig(
+  'eth-mainnet',
+  [
+    { url: 'https://us-east-rm-us-east-01-eth-mainnet-json.relay.example.com', rpcType: RPCType.JSON_RPC, configs: [] },
+    { url: 'https://us-east-rm-us-east-01-eth-mainnet-rest.relay.example.com', rpcType: RPCType.REST, configs: [] },
+  ],
+  [
+    { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+    { address: OWNER_ADDRESS, revSharePercentage: 80 },
+  ],
+);
+
+// =========================================================================
+// 1. matchingSupplierAndKey
+// =========================================================================
+/**
+ * A Supplier whose services exactly match what getExpectedServicesFromKey
+ * would produce from the paired KeyWithGroup.
+ *
+ * Services: anvil (JSON_RPC), eth-mainnet (JSON_RPC + REST)
+ * RevShare: provider 20%, owner 80% (no delegator)
+ */
+export const matchingSupplierAndKey = {
+  supplier: makeSupplier({
+    services: [anvilServiceConfig, ethMainnetServiceConfig],
+  }),
+
+  key: makeKeyWithGroup({
+    addressGroup: {
+      id: 1,
+      name: 'default-group',
+      linkedAddresses: [],
+      private: false,
+      relayMinerId: 1,
+      createdAt: new Date('2025-01-01'),
+      createdBy: 'admin',
+      updatedAt: new Date('2025-01-01'),
+      updatedBy: 'admin',
+      keysCount: 10,
+      addressGroupServices: [
+        {
+          addressGroupId: 1,
+          serviceId: 'anvil',
+          addSupplierShare: false,
+          supplierShare: 0,
+          revShare: [{ address: PROVIDER_ADDRESS, share: 20 }],
+          service: {
+            name: 'Anvil',
+            endpoints: [{ url: 'https://{region}-{rm}-{sid}-{protocol}.{domain}', rpcType: RPCType.JSON_RPC }],
+          },
+        },
+        {
+          addressGroupId: 1,
+          serviceId: 'eth-mainnet',
+          addSupplierShare: false,
+          supplierShare: 0,
+          revShare: [{ address: PROVIDER_ADDRESS, share: 20 }],
+          service: {
+            name: 'Ethereum Mainnet',
+            endpoints: [
+              { url: 'https://{region}-{rm}-{sid}-{protocol}.{domain}', rpcType: RPCType.JSON_RPC },
+              { url: 'https://{region}-{rm}-{sid}-{protocol}.{domain}', rpcType: RPCType.REST },
+            ],
+          },
+        },
+      ],
+      relayMiner: {
+        id: 1,
+        name: 'miner-us-east',
+        identity: 'rm-us-east-01',
+        regionId: 1,
+        domain: 'relay.example.com',
+        createdAt: new Date('2025-01-01'),
+        createdBy: 'admin',
+        updatedAt: new Date('2025-01-01'),
+        updatedBy: 'admin',
+        region: {
+          id: 1,
+          displayName: 'US East',
+          urlValue: 'us-east',
+          createdAt: new Date('2025-01-01'),
+          createdBy: 'admin',
+          updatedAt: new Date('2025-01-01'),
+          updatedBy: 'admin',
+        },
+      },
+    },
+  }),
+};
+
+// =========================================================================
+// 2. mismatchedSupplierAndKey
+// =========================================================================
+/**
+ * A Supplier that is missing the "eth-mainnet" service and has a different
+ * endpoint URL for "anvil" compared to what getExpectedServicesFromKey would
+ * produce.
+ */
+export const mismatchedSupplierAndKey = {
+  supplier: makeSupplier({
+    services: [
+      makeServiceConfig(
+        'anvil',
+        [{ url: 'https://old-endpoint.relay.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+        [
+          { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+          { address: OWNER_ADDRESS, revSharePercentage: 80 },
+        ],
+      ),
+      // "eth-mainnet" is missing
+    ],
+  }),
+
+  key: matchingSupplierAndKey.key, // same key expects both services
+};
+
+// =========================================================================
+// 3. pristineSupplier
+// =========================================================================
+/**
+ * OwnerInitialStake case: supplier was just created on-chain but has
+ * zero services and no config history.
+ */
+export const pristineSupplier = makeSupplier({
+  services: [],
+  serviceConfigHistory: [],
+});
+
+// =========================================================================
+// 4. zeroRevShareKey
+// =========================================================================
+/**
+ * PRIMARY CAUSE OF THE RE-STAKING LOOP:
+ * delegatorRevSharePercentage = 0 with a delegatorRewardsAddress set.
+ *
+ * getExpectedServicesFromKey includes the 0% entry in revShare,
+ * but BuildSupplierServiceConfigHandler filters entries with
+ * revSharePercentage === 0.  This mismatch between expected and
+ * actual causes CompareSupplierServiceConfigHandler to report
+ * isEqual: false, triggering a needless re-stake every cycle.
+ */
+export const zeroRevShareKey = makeKeyWithGroup({
+  delegatorRevSharePercentage: 0,
+  delegatorRewardsAddress: DELEGATOR_ADDRESS,
+  addressGroup: {
+    id: 1,
+    name: 'default-group',
+    linkedAddresses: [],
+    private: false,
+    relayMinerId: 1,
+    createdAt: new Date('2025-01-01'),
+    createdBy: 'admin',
+    updatedAt: new Date('2025-01-01'),
+    updatedBy: 'admin',
+    keysCount: 10,
+    addressGroupServices: [
+      {
+        addressGroupId: 1,
+        serviceId: 'anvil',
+        addSupplierShare: false,
+        supplierShare: 0,
+        revShare: [{ address: PROVIDER_ADDRESS, share: 20 }],
+        service: {
+          name: 'Anvil',
+          endpoints: [{ url: 'https://{region}-{rm}-{sid}-{protocol}.{domain}', rpcType: RPCType.JSON_RPC }],
+        },
+      },
+    ],
+    relayMiner: {
+      id: 1,
+      name: 'miner-us-east',
+      identity: 'rm-us-east-01',
+      regionId: 1,
+      domain: 'relay.example.com',
+      createdAt: new Date('2025-01-01'),
+      createdBy: 'admin',
+      updatedAt: new Date('2025-01-01'),
+      updatedBy: 'admin',
+      region: {
+        id: 1,
+        displayName: 'US East',
+        urlValue: 'us-east',
+        createdAt: new Date('2025-01-01'),
+        createdBy: 'admin',
+        updatedAt: new Date('2025-01-01'),
+        updatedBy: 'admin',
+      },
+    },
+  },
+});
+
+// =========================================================================
+// 5. multiGenerationHistory
+// =========================================================================
+/**
+ * Supplier with complex serviceConfigHistory:
+ * - "anvil" activated at height 100, still active (no deactivation)
+ * - "eth-mainnet" activated at height 100, deactivated at height 200
+ * - "eth-mainnet" new config activated at height 200 (replacement)
+ * - "solana-mainnet" pending activation at height 300 (not yet active)
+ *
+ * Current services array contains the currently active configs.
+ */
+const ethMainnetOldConfig = makeServiceConfig(
+  'eth-mainnet',
+  [{ url: 'https://old-eth.relay.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+  [{ address: OWNER_ADDRESS, revSharePercentage: 100 }],
+);
+
+const ethMainnetNewConfig = makeServiceConfig(
+  'eth-mainnet',
+  [{ url: 'https://us-east-rm-us-east-01-eth-mainnet-json.relay.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+  [
+    { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+    { address: OWNER_ADDRESS, revSharePercentage: 80 },
+  ],
+);
+
+const solanaPendingConfig = makeServiceConfig(
+  'solana-mainnet',
+  [{ url: 'https://us-east-rm-us-east-01-solana-mainnet-json.relay.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+  [{ address: OWNER_ADDRESS, revSharePercentage: 100 }],
+);
+
+export const multiGenerationHistory = makeSupplier({
+  services: [anvilServiceConfig, ethMainnetNewConfig],
+  serviceConfigHistory: [
+    // anvil activated at 100, still active
+    makeHistoryEntry(anvilServiceConfig, 100, 0),
+    // old eth-mainnet activated at 100, deactivated at 200
+    makeHistoryEntry(ethMainnetOldConfig, 100, 200),
+    // new eth-mainnet config activated at 200, still active
+    makeHistoryEntry(ethMainnetNewConfig, 200, 0),
+    // solana-mainnet pending activation at 300
+    makeHistoryEntry(solanaPendingConfig, 300, 0),
+  ],
+});
+
+// =========================================================================
+// 6. deactivatedServicesSupplier
+// =========================================================================
+/**
+ * Supplier where "eth-mainnet" is scheduled for deactivation at height 250.
+ * At height 200, this should be excluded from active services.
+ * "anvil" remains active.
+ */
+export const deactivatedServicesSupplier = makeSupplier({
+  services: [anvilServiceConfig, ethMainnetServiceConfig],
+  serviceConfigHistory: [
+    // eth-mainnet is scheduled for deactivation at 250 (> current height)
+    makeHistoryEntry(ethMainnetServiceConfig, 100, 250),
+  ],
+});
+
+// =========================================================================
+// 7. emptyOwnerKey
+// =========================================================================
+/**
+ * A KeyWithGroup where ownerAddress is empty string (legacy key that was
+ * imported before the ownerAddress field was backfilled).
+ * The paired Supplier has a valid ownerAddress on-chain.
+ *
+ * This tests the owner-remainder revShare calculation: when ownerAddress
+ * is empty, the remainder entry should NOT be added.
+ */
+export const emptyOwnerKey = makeKeyWithGroup({
+  ownerAddress: '',
+  addressGroup: {
+    id: 1,
+    name: 'default-group',
+    linkedAddresses: [],
+    private: false,
+    relayMinerId: 1,
+    createdAt: new Date('2025-01-01'),
+    createdBy: 'admin',
+    updatedAt: new Date('2025-01-01'),
+    updatedBy: 'admin',
+    keysCount: 10,
+    addressGroupServices: [
+      {
+        addressGroupId: 1,
+        serviceId: 'anvil',
+        addSupplierShare: false,
+        supplierShare: 0,
+        revShare: [{ address: PROVIDER_ADDRESS, share: 20 }],
+        service: {
+          name: 'Anvil',
+          endpoints: [{ url: 'https://{region}-{rm}-{sid}-{protocol}.{domain}', rpcType: RPCType.JSON_RPC }],
+        },
+      },
+    ],
+    relayMiner: {
+      id: 1,
+      name: 'miner-us-east',
+      identity: 'rm-us-east-01',
+      regionId: 1,
+      domain: 'relay.example.com',
+      createdAt: new Date('2025-01-01'),
+      createdBy: 'admin',
+      updatedAt: new Date('2025-01-01'),
+      updatedBy: 'admin',
+      region: {
+        id: 1,
+        displayName: 'US East',
+        urlValue: 'us-east',
+        createdAt: new Date('2025-01-01'),
+        createdBy: 'admin',
+        updatedAt: new Date('2025-01-01'),
+        updatedBy: 'admin',
+      },
+    },
+  },
+});
+
+// Re-export addresses for use in assertions
+export {
+  OWNER_ADDRESS,
+  OPERATOR_ADDRESS,
+  DELEGATOR_ADDRESS,
+  PROVIDER_ADDRESS,
+};

--- a/packages/domain/src/provider/utils/suppliers.test.ts
+++ b/packages/domain/src/provider/utils/suppliers.test.ts
@@ -8,6 +8,16 @@ import {
   getSupplierActiveServices,
   getExpectedServicesFromKey,
 } from './suppliers';
+import {
+  matchingSupplierAndKey,
+  zeroRevShareKey,
+  multiGenerationHistory,
+  deactivatedServicesSupplier,
+  emptyOwnerKey,
+  OWNER_ADDRESS,
+  PROVIDER_ADDRESS,
+  DELEGATOR_ADDRESS,
+} from './__fixtures__/supplier-data';
 
 // ── getSchemeForRpcType ─────────────────────────────────────────────
 describe('getSchemeForRpcType', () => {
@@ -310,5 +320,119 @@ describe('getExpectedServicesFromKey', () => {
     } as any;
 
     expect(getExpectedServicesFromKey(key)).toEqual([]);
+  });
+});
+
+// ── Fixture-based tests ─────────────────────────────────────────────────
+describe('with realistic fixtures', () => {
+  describe('getSupplierActiveServices', () => {
+    it('returns correct active services for multi-generation history at height 250', () => {
+      // At height 250: anvil active, eth-mainnet (new) active,
+      // solana-mainnet pending (activationHeight 300 > 250)
+      const result = getSupplierActiveServices(multiGenerationHistory, 250);
+      const ids = result.map((s) => s.serviceId).sort();
+
+      // anvil and eth-mainnet are in services[], solana-mainnet is pending activation
+      expect(ids).toEqual(['anvil', 'eth-mainnet', 'solana-mainnet']);
+    });
+
+    it('excludes deactivated services at current height', () => {
+      // deactivatedServicesSupplier has eth-mainnet deactivation at 250
+      // At height 200, deactivationHeight 250 > 200 means it's scheduled for removal
+      const result = getSupplierActiveServices(deactivatedServicesSupplier, 200);
+      const ids = result.map((s) => s.serviceId);
+
+      expect(ids).toContain('anvil');
+      expect(ids).not.toContain('eth-mainnet');
+    });
+
+    it('includes services pending activation from history', () => {
+      // At height 150, solana-mainnet has activationHeight 300 > 150 and deactivationHeight 0
+      const result = getSupplierActiveServices(multiGenerationHistory, 150);
+      const ids = result.map((s) => s.serviceId);
+
+      expect(ids).toContain('solana-mainnet');
+    });
+
+    it('returns empty services for pristine supplier', () => {
+      const pristine: Supplier = {
+        ownerAddress: OWNER_ADDRESS,
+        operatorAddress: 'pokt1oper8k2g4jd6h7m9w1c3f5n0b6v4r8q2s7t1e',
+        stake: { denom: 'upokt', amount: '100000000' },
+        services: [],
+        unstakeSessionEndHeight: 0,
+        serviceConfigHistory: [],
+      };
+
+      const result = getSupplierActiveServices(pristine, 100);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('getExpectedServicesFromKey', () => {
+    it('produces config matching a correctly staked supplier', () => {
+      const expected = getExpectedServicesFromKey(matchingSupplierAndKey.key);
+
+      // Should produce 2 services: anvil and eth-mainnet
+      expect(expected).toHaveLength(2);
+
+      const anvilExpected = expected.find((s) => s.serviceId === 'anvil');
+      const ethExpected = expected.find((s) => s.serviceId === 'eth-mainnet');
+
+      expect(anvilExpected).toBeDefined();
+      expect(ethExpected).toBeDefined();
+
+      // anvil: 1 endpoint (JSON_RPC), revShare: provider 20% + owner 80%
+      expect(anvilExpected!.endpoints).toHaveLength(1);
+      expect(anvilExpected!.endpoints[0]!.rpcType).toBe(RPCType.JSON_RPC);
+      expect(anvilExpected!.revShare).toEqual(
+        expect.arrayContaining([
+          { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+          { address: OWNER_ADDRESS, revSharePercentage: 80 },
+        ]),
+      );
+
+      // eth-mainnet: 2 endpoints (JSON_RPC + REST)
+      expect(ethExpected!.endpoints).toHaveLength(2);
+    });
+
+    it('includes 0% revShare entry when delegatorRewardsAddress is set with 0% share', () => {
+      // This documents the CURRENT behavior of getExpectedServicesFromKey:
+      // it includes the 0% delegator entry. The re-staking loop bug occurs
+      // because BuildSupplierServiceConfigHandler filters these out.
+      const expected = getExpectedServicesFromKey(zeroRevShareKey);
+
+      expect(expected).toHaveLength(1);
+      const svc = expected[0]!;
+
+      // The 0% delegator entry IS included by getExpectedServicesFromKey
+      const delegatorEntry = svc.revShare.find((r) => r.address === DELEGATOR_ADDRESS);
+      expect(delegatorEntry).toBeDefined();
+      expect(delegatorEntry!.revSharePercentage).toBe(0);
+    });
+
+    it('calculates correct owner remainder after filtering when delegator has 0%', () => {
+      const expected = getExpectedServicesFromKey(zeroRevShareKey);
+      const svc = expected[0]!;
+
+      // delegator=0%, provider=20%, total non-owner = 20%
+      // owner should get 80% remainder
+      const ownerEntry = svc.revShare.find((r) => r.address === OWNER_ADDRESS);
+      expect(ownerEntry).toBeDefined();
+      expect(ownerEntry!.revSharePercentage).toBe(80);
+    });
+
+    it('does not add owner remainder when ownerAddress is empty', () => {
+      const expected = getExpectedServicesFromKey(emptyOwnerKey);
+
+      expect(expected).toHaveLength(1);
+      const svc = expected[0]!;
+
+      // ownerAddress is '' so the condition `revShareSum < 100 && key.ownerAddress` is falsy
+      // Only provider revShare should be present
+      expect(svc.revShare).toHaveLength(1);
+      expect(svc.revShare[0]!.address).toBe(PROVIDER_ADDRESS);
+      expect(svc.revShare[0]!.revSharePercentage).toBe(20);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Remediation schedule split**: Separate `SupplierRemediation` (1001 ServiceMismatch, pausable by operator) from `SupplierInitialStake` (1003, always active). Both use the same underlying workflow with different args.
- **Provider UI controls**: Auto Stake toggle (pause/unpause schedule), Request Remediation (two-step evaluate→confirm), renamed "Mark for Remediation" to "Clear Remediation"
- **Workflow fixes**: Owner address backfill for legacy keys, early return when no keys exist, fix Temporal client namespace defaults
- **Auto-bootstrap for dev**: Idempotent seed scripts for provider and middleman. Tilt conditionally injects init container from local JSON config. Fetches minimumStake/height from Pocket API and delegators/providers from governance CDN.
- **Tests**: 14 new tests with realistic fixtures covering service comparison edge cases from the re-staking loop bug
- **Docs & UI consistency**: Unified "Pocket API URL" label, updated DEVELOP.md with auto-bootstrap setup, updated key-management docs with new actions
- **Tilt improvements**: Simplified ignore patterns to prevent local test/build runs from triggering rebuild cycles

## Test plan

- [x] All domain tests pass locally (49 tests, 4 suites)
- [x] Tilt cluster boots cleanly with auto-bootstrap (both apps seed from JSON + governance CDN)
- [x] Provider and provider-workflows running with 0 restarts
- [x] Middleman and middleman-workflows running with 0 restarts
- [x] Bootstrap seed is idempotent (skips on re-deploy)
- [x] Workflows handle empty key set gracefully (no crash)
- [x] Auto Stake toggle pause/unpause works from UI
- [ ] Verify Request Remediation evaluate→confirm flow (needs staked keys — will test with localnet)
- [ ] Verify Clear Remediation button behavior (needs keys in error state)
- [ ] CI passes