### PR TITLE
Fix text contrast in middleman gradient-border status pills

### DIFF
--- a/apps/middleman/src/app/app/import-suppliers/components/ImportSuccessStep.tsx
+++ b/apps/middleman/src/app/app/import-suppliers/components/ImportSuccessStep.tsx
@@ -38,11 +38,11 @@ export function ImportSuccessStep({
 
       <div className="relative flex h-[64px] gradient-border-green">
         <div className="absolute inset-0 flex flex-row items-center m-[0.5px] bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between">
-          <span className="text-[20px] text-[var(--text-tertiary)]">
+          <span className="text-[20px] text-white">
             Imported
           </span>
           <span className="flex flex-row items-center gap-2">
-            <span className="font-mono text-[20px] text-[var(--text-primary)]">
+            <span className="font-mono text-[20px] text-white">
               {importedSuppliers.length} supplier
               {importedSuppliers.length !== 1 ? 's' : ''}
             </span>

--- a/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
@@ -212,14 +212,14 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, selectedAdd
 
             <div className="relative flex h-[64px] min-h-[64px] gradient-border-slate">
                 <div className={`absolute inset-0 flex flex-row items-center m-[0.5px] bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between`}>
-                    <span className="text-[20px] text-[var(--text-tertiary)]">
+                    <span className="text-[20px] text-white">
                         Stake
                     </span>
                     <span className="flex flex-row items-center gap-2">
-                        <span className="font-mono text-[20px] text-[var(--text-primary)]">
+                        <span className="font-mono text-[20px] text-white">
                             {toCurrencyFormat(amount, 2, 2)}
                         </span>
-                        <span className="font-mono text-[20px] text-[var(--text-tertiary)]">
+                        <span className="font-mono text-[20px] text-white/60">
                             $POKT
                         </span>
                     </span>

--- a/apps/middleman/src/app/app/stake/components/StakeSuccessStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/StakeSuccessStep/index.tsx
@@ -74,11 +74,11 @@ export function StakeSuccessStep({amount, selectedOffer, selectedAddressGroupId,
                     <div className="relative flex h-[64px] gradient-border-green">
                         <div
                             className={`absolute inset-0 flex flex-row items-center m-[0.5px] bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between`}>
-                        <span className="text-[20px] text-[var(--text-tertiary)]">
+                        <span className="text-[20px] text-white">
                             Stake
                         </span>
                             <span className="flex flex-row items-center gap-2">
-                            <span className="font-mono text-[20px] text-[var(--text-primary)]">
+                            <span className="font-mono text-[20px] text-white">
                               <Amount value={amount} />
                             </span>
                         </span>

--- a/apps/middleman/src/app/app/unstake/components/ReviewStep/index.tsx
+++ b/apps/middleman/src/app/app/unstake/components/ReviewStep/index.tsx
@@ -141,7 +141,7 @@ export function ReviewStep({
 
       <div className="relative flex h-[64px] min-h-[64px] gradient-border-slate">
         <div className="absolute inset-0 flex flex-row items-center m-[0.5px] bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between">
-          <span className="text-[20px] text-[var(--text-tertiary)]">
+          <span className="text-[20px] text-white">
             Unstake
           </span>
           <span className="flex flex-row items-center gap-2">
@@ -149,10 +149,10 @@ export function ReviewStep({
               <Skeleton className="w-[100px] h-6 bg-bg-elevated" />
             ) : (
               <>
-                <span className="font-mono text-[20px] text-[var(--text-primary)]">
+                <span className="font-mono text-[20px] text-white">
                   {toCurrencyFormat(totalStakeAmount / 1e6, 2, 2)}
                 </span>
-                <span className="font-mono text-[20px] text-[var(--text-tertiary)]">
+                <span className="font-mono text-[20px] text-white/60">
                   $POKT
                 </span>
               </>

--- a/apps/middleman/src/app/app/unstake/components/UnstakeSuccessStep/index.tsx
+++ b/apps/middleman/src/app/app/unstake/components/UnstakeSuccessStep/index.tsx
@@ -53,14 +53,14 @@ export function UnstakeSuccessStep({ nodeCount, totalStakeAmount, transaction, o
           <div className="relative flex h-[64px] gradient-border-green">
             <div
               className={`absolute inset-0 flex flex-row items-center m-[0.5px] bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between`}>
-              <span className="text-[20px] text-[var(--text-tertiary)]">
+              <span className="text-[20px] text-white">
                 Unstake
               </span>
               <span className="flex flex-row items-center gap-2">
-                <span className="font-mono text-[20px] text-[var(--text-primary)]">
+                <span className="font-mono text-[20px] text-white">
                   {toCurrencyFormat(totalStakeAmount / 1e6, 2, 2)}
                 </span>
-                <span className="font-mono text-[20px] text-[var(--text-tertiary)]">
+                <span className="font-mono text-[20px] text-white/60">
                   $POKT
                 </span>
               </span>

--- a/apps/middleman/src/app/detail/NodeDetail.tsx
+++ b/apps/middleman/src/app/detail/NodeDetail.tsx
@@ -258,11 +258,11 @@ export default function NodeDetail({
         }
       >
         <div className={`absolute inset-0 flex flex-row items-center bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between`}>
-          <span className="text-[20px] text-text-tertiary">
+          <span className="text-[20px] text-white">
             {status.slice(0, 1).toUpperCase() + status.slice(1)}
           </span>
           <div className="flex flex-row items-center gap-2">
-            <p className="font-mono !text-[20px]">
+            <p className="font-mono !text-[20px] text-white">
               <Amount value={amountToPokt(stakeAmount)} />
             </p>
           </div>

--- a/apps/middleman/src/app/detail/TransactionDetail.tsx
+++ b/apps/middleman/src/app/detail/TransactionDetail.tsx
@@ -469,11 +469,11 @@ export default function TransactionDetail({
         }
       >
         <div className={`absolute inset-0 flex flex-row items-center bg-[var(--background)] rounded-[8px] p-[18px_25px] justify-between`}>
-          <span className="text-[20px] text-text-tertiary">
+          <span className="text-[20px] text-white">
             {type === TransactionType.OperationalFunds ? 'Amount' : type}
           </span>
           <div className="flex flex-row items-center gap-2">
-            <p className="font-mono !text-[20px]">
+            <p className="font-mono !text-[20px] text-white">
               <Amount value={totalValue} maxFractionDigits={0} minimumFractionDigits={0} />
             </p>
           </div>


### PR DESCRIPTION
## Summary

- White text on all gradient-border status pills (green, orange, purple, slate)
- Fixes poor contrast: dark text was unreadable on colored gradient backgrounds
- Affects 7 views: node detail, transaction detail, stake review/success, unstake review/success, import success

## Test plan

- [ ] Visual check on node detail (Staked — orange pill)
- [ ] Visual check on unstake success (Scheduled — green pill)
- [ ] Visual check on transaction detail (all pill variants)