### PR TITLE
Run docker builds only after quality checks pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         run: pnpm turbo test
 
   docker-build:
+    needs: quality
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Add `needs: quality` to the `docker-build` job in CI
- Docker builds now wait for lint, build, type-check, and tests to pass before starting
- Saves runner time when quality checks fail

## Test plan

- [ ] CI pipeline runs quality first, docker-build jobs start only after quality succeeds