### PR TITLE
Address PR #253 review feedback

### DIFF
--- a/apps/provider/src/actions/Remediation.ts
+++ b/apps/provider/src/actions/Remediation.ts
@@ -87,9 +87,25 @@ export async function RequestRemediation(addresses: string[]): Promise<ActionRes
       throw new Error('No keys found for the provided addresses')
     }
 
+    const comparer = new CompareSupplierServiceConfigHandler()
     const updates: Array<{ address: string; remediationHistory: RemediationHistoryEntry[] }> = []
 
     for (const key of keys) {
+      // Only mark keys that actually have a service mismatch
+      if (!key.services || key.services.length === 0 || !key.addressGroup) {
+        continue
+      }
+
+      const expectedServices = getExpectedServicesFromKey(key)
+      if (expectedServices.length === 0) continue
+
+      const comparison = comparer.execute({
+        serviceConfigSetA: key.services,
+        serviceConfigSetB: expectedServices,
+      })
+
+      if (comparison.isEqual) continue
+
       const entry: RemediationHistoryEntry = {
         message: 'Service mismatch detected — remediation requested by operator',
         reason: RemediationHistoryEntryReason.ServiceMismatch,
@@ -110,6 +126,10 @@ export async function RequestRemediation(addresses: string[]): Promise<ActionRes
         address: key.address,
         remediationHistory: history,
       })
+    }
+
+    if (updates.length === 0) {
+      return // No keys actually have mismatches
     }
 
     await batchUpdateRemediationHistory(updates)

--- a/apps/provider/src/app/admin/(internal)/keys/AutoStakeToggle.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/AutoStakeToggle.tsx
@@ -4,33 +4,26 @@ import React from 'react'
 import { Button } from '@igniter/ui/components/button'
 import { ConfirmationDialog } from '@/components/ConfirmationDialog'
 import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
 import { GetRemediationScheduleStatus, ToggleRemediationSchedule } from '@/actions/Schedules'
 
 export default function AutoStakeToggle() {
   const router = useRouter()
   const [open, setOpen] = React.useState(false)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
-  const [isLoading, setIsLoading] = React.useState(true)
-  const [paused, setPaused] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
 
-  React.useEffect(() => {
-    let cancelled = false
-    GetRemediationScheduleStatus().then((result) => {
-      if (cancelled) return
-      if (result.success) {
-        setPaused(result.data.paused)
-      } else {
-        setError(result.error.message)
-      }
-    }).catch((e) => {
-      if (cancelled) return
-      setError(e instanceof Error ? e.message : 'Failed to fetch schedule status')
-    }).finally(() => {
-      if (!cancelled) setIsLoading(false)
-    })
-    return () => { cancelled = true }
-  }, [])
+  const { data, isLoading } = useQuery({
+    queryKey: ['remediation-schedule-status'],
+    queryFn: async () => {
+      const result = await GetRemediationScheduleStatus()
+      if (!result.success) throw new Error(result.error.message)
+      return result.data
+    },
+    refetchInterval: 30000,
+  })
+
+  const paused = data?.paused ?? false
 
   const onClick = () => setOpen(true)
 
@@ -47,7 +40,6 @@ export default function AutoStakeToggle() {
         setError(result.error.message)
         return
       }
-      setPaused(!paused)
       setOpen(false)
       router.refresh()
     } catch (e) {

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -342,14 +342,14 @@ export async function batchUpdateRemediationHistory(
   updates: Array<{ address: string; remediationHistory: RemediationHistoryEntry[] }>,
 ): Promise<void> {
   const dbClient = getDbClient()
-  await Promise.all(
-    updates.map((update) =>
-      dbClient.db
+  await dbClient.db.transaction(async (tx) => {
+    for (const update of updates) {
+      await tx
         .update(keysTable)
         .set({ remediationHistory: update.remediationHistory })
-        .where(eq(keysTable.address, update.address)),
-    ),
-  )
+        .where(eq(keysTable.address, update.address))
+    }
+  })
 }
 
 /**

--- a/packages/domain/src/provider/utils/suppliers.test.ts
+++ b/packages/domain/src/provider/utils/suppliers.test.ts
@@ -396,43 +396,43 @@ describe('with realistic fixtures', () => {
       expect(ethExpected!.endpoints).toHaveLength(2);
     });
 
-    it('includes 0% revShare entry when delegatorRewardsAddress is set with 0% share', () => {
-      // This documents the CURRENT behavior of getExpectedServicesFromKey:
-      // it includes the 0% delegator entry. The re-staking loop bug occurs
-      // because BuildSupplierServiceConfigHandler filters these out.
+    it('filters out 0% revShare entries to match BuildSupplierServiceConfigHandler', () => {
       const expected = getExpectedServicesFromKey(zeroRevShareKey);
 
       expect(expected).toHaveLength(1);
       const svc = expected[0]!;
 
-      // The 0% delegator entry IS included by getExpectedServicesFromKey
+      // 0% delegator entry should be filtered out (fixes re-staking loop bug)
       const delegatorEntry = svc.revShare.find((r) => r.address === DELEGATOR_ADDRESS);
-      expect(delegatorEntry).toBeDefined();
-      expect(delegatorEntry!.revSharePercentage).toBe(0);
+      expect(delegatorEntry).toBeUndefined();
     });
 
-    it('calculates correct owner remainder after filtering when delegator has 0%', () => {
+    it('calculates owner remainder from filtered revShare sum', () => {
       const expected = getExpectedServicesFromKey(zeroRevShareKey);
       const svc = expected[0]!;
 
-      // delegator=0%, provider=20%, total non-owner = 20%
-      // owner should get 80% remainder
+      // delegator=0% (filtered out), provider=20%
+      // owner should get 100 - 20 = 80% remainder
       const ownerEntry = svc.revShare.find((r) => r.address === OWNER_ADDRESS);
       expect(ownerEntry).toBeDefined();
       expect(ownerEntry!.revSharePercentage).toBe(80);
     });
 
-    it('does not add owner remainder when ownerAddress is empty', () => {
+    it('uses stakeOwner as owner address when ownerAddress is empty', () => {
       const expected = getExpectedServicesFromKey(emptyOwnerKey);
 
       expect(expected).toHaveLength(1);
       const svc = expected[0]!;
 
-      // ownerAddress is '' so the condition `revShareSum < 100 && key.ownerAddress` is falsy
-      // Only provider revShare should be present
-      expect(svc.revShare).toHaveLength(1);
-      expect(svc.revShare[0]!.address).toBe(PROVIDER_ADDRESS);
-      expect(svc.revShare[0]!.revSharePercentage).toBe(20);
+      // ownerAddress is '' but stakeOwner has a value — should use stakeOwner
+      // provider=20%, owner (from stakeOwner)=80%
+      expect(svc.revShare).toHaveLength(2);
+      expect(svc.revShare).toEqual(
+        expect.arrayContaining([
+          { address: PROVIDER_ADDRESS, revSharePercentage: 20 },
+          { address: OWNER_ADDRESS, revSharePercentage: 80 },
+        ]),
+      );
     });
   });
 });

--- a/packages/domain/src/provider/utils/suppliers.ts
+++ b/packages/domain/src/provider/utils/suppliers.ts
@@ -3,6 +3,7 @@ import {Supplier, ServiceConfigUpdate} from "@igniter/pocket/proto/pocket/shared
 import {RPCType, SupplierEndpoint, SupplierServiceConfig} from '@igniter/pocket/proto/pocket/shared/service'
 import {PROTOCOL_DEFAULT_URL} from "@igniter/domain/provider/constants";
 import {KeyWithGroup} from "@igniter/db/provider/schema";
+import {RPCTypeMap} from '@igniter/pocket/constants';
 
 export function getSchemeForRpcType(rpcType: RPCType) {
     switch (rpcType) {
@@ -118,14 +119,14 @@ export function getSupplierActiveServices(
 export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierServiceConfig> {
   const expectedServices: Array<SupplierServiceConfig> = []
 
-  for (const addressGroupService of key?.addressGroup?.addressGroupServices || []) {
-    let revShareSum = 0
+  // Use stakeOwner (from chain) as the authoritative owner address,
+  // falling back to ownerAddress (from DB) for backwards compatibility.
+  const ownerAddress = key.stakeOwner || key.ownerAddress
 
+  for (const addressGroupService of key?.addressGroup?.addressGroupServices || []) {
     const revShare: SupplierServiceConfig['revShare'] = []
 
     if (key.delegatorRewardsAddress) {
-      revShareSum += key.delegatorRevSharePercentage ?? 0
-
       revShare.push({
         address: key.delegatorRewardsAddress,
         revSharePercentage: key.delegatorRevSharePercentage ?? 0,
@@ -133,8 +134,6 @@ export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierSer
     }
 
     if (addressGroupService.addSupplierShare) {
-      revShareSum += addressGroupService.supplierShare ?? 0
-
       revShare.push({
         address: key.address,
         revSharePercentage: addressGroupService.supplierShare ?? 0,
@@ -142,17 +141,20 @@ export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierSer
     }
 
     for (const revShareElement of addressGroupService.revShare) {
-      revShareSum += revShareElement.share
-
       revShare.push({
         address: revShareElement.address,
         revSharePercentage: revShareElement.share,
       })
     }
 
-    if (revShareSum < 100 && key.ownerAddress) {
-      revShare.push({
-        address: key.ownerAddress,
+    // Filter out 0% entries to match BuildSupplierServiceConfigHandler behavior
+    const filteredRevShare = revShare.filter(r => r.revSharePercentage > 0)
+
+    // Calculate owner remainder from filtered sum (not pre-filter)
+    const revShareSum = filteredRevShare.reduce((sum, r) => sum + r.revSharePercentage, 0)
+    if (revShareSum < 100 && ownerAddress) {
+      filteredRevShare.push({
+        address: ownerAddress,
         revSharePercentage: 100 - revShareSum,
       })
     }
@@ -166,10 +168,13 @@ export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierSer
           region: key.addressGroup?.relayMiner?.region?.urlValue || '',
           domain: key.addressGroup?.relayMiner?.domain || '',
         }),
-        rpcType: endpoint.rpcType,
+        // Normalize rpcType to numeric to match BuildSupplierServiceConfigHandler
+        rpcType: typeof endpoint.rpcType === 'string'
+          ? (RPCTypeMap[endpoint.rpcType as keyof typeof RPCTypeMap] ?? -1)
+          : endpoint.rpcType,
         configs: []
       })),
-      revShare,
+      revShare: filteredRevShare,
     }
 
     expectedServices.push(newExpectedService)


### PR DESCRIPTION
## Summary

Addresses review comments from @Alann27 on #253 and fixes the root cause of the supplier re-staking loop.

**Review feedback:**
- **AutoStakeToggle**: Replace manual `useEffect` fetch with `useQuery` (30s refetch interval), consistent with other components
- **AutoStakeToggle**: Remove local `setPaused` mutation after toggle — `useQuery` refetch handles state updates
- **Remediation.ts**: `RequestRemediation` now verifies actual service mismatch (via `CompareSupplierServiceConfigHandler`) before marking each key
- **keys.ts**: `batchUpdateRemediationHistory` wrapped in a DB transaction for atomicity

**Fix service comparison divergence (re-staking loop root cause):**
- Filter 0% revShare entries in `getExpectedServicesFromKey` to match `BuildSupplierServiceConfigHandler` behavior (primary cause of false mismatches)
- Normalize `rpcType` to numeric via `RPCTypeMap` (prevents string vs number false mismatch)
- Use `stakeOwner` (from chain) as authoritative owner address, falling back to `ownerAddress` for backwards compatibility
- Update tests to verify new correct behavior

## Test plan

- [x] All domain tests pass (49 tests, 4 suites)
- [ ] Auto Stake toggle loads status and reflects pause/unpause
- [ ] Request Remediation only marks keys with real mismatches
- [ ] No false-positive ServiceMismatch on correctly staked suppliers
- [ ] CI passes