### PR TITLE
Move branch-gate to standalone workflow

### DIFF
--- a/.github/workflows/branch-gate.yml
+++ b/.github/workflows/branch-gate.yml
@@ -1,0 +1,16 @@
+name: Branch Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  branch-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only release branch can target main
+        if: github.head_ref != 'release'
+        run: |
+          echo "::error::PRs to main must come from the 'release' branch, not '${{ github.head_ref }}'."
+          echo "Flow: feature → staging → release → main"
+          exit 1


### PR DESCRIPTION
## Summary

- Extract `branch-gate` from `ci.yml` into its own workflow (`branch-gate.yml`)
- `branch-gate.yml` triggers on all PRs to `main` without `paths-ignore`
- Fixes: release PR to main was blocked because CI skipped entirely when only overlay files changed, causing `branch-gate` check to never report

## Test plan

- [ ] Release PR to main shows `branch-gate` check as passing
- [ ] CI workflow still runs quality + docker-build on regular PRs