### PR TITLE
feat(keys): enhance filters, export tracking, and key generation

### DIFF
--- a/apps/provider/drizzle/0016_slim_warlock.sql
+++ b/apps/provider/drizzle/0016_slim_warlock.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "keys" ADD COLUMN "exportedAt" timestamp;--> statement-breakpoint
+ALTER TABLE "keys" ADD COLUMN "exportCount" integer DEFAULT 0;

--- a/apps/provider/drizzle/meta/0016_snapshot.json
+++ b/apps/provider/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1340 @@
+{
+  "id": "8da36f45-7bbf-4ef1-ad04-ab117d0e11bf",
+  "prevId": "12ff0e52-4a1e-4e36-a755-963397e6d9bb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.address_group_services": {
+      "name": "address_group_services",
+      "schema": "",
+      "columns": {
+        "address_group_id": {
+          "name": "address_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addSupplierShare": {
+          "name": "addSupplierShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "supplierShare": {
+          "name": "supplierShare",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "revShare": {
+          "name": "revShare",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "address_group_services_address_group_id_address_groups_id_fk": {
+          "name": "address_group_services_address_group_id_address_groups_id_fk",
+          "tableFrom": "address_group_services",
+          "tableTo": "address_groups",
+          "columnsFrom": [
+            "address_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "address_group_services_service_id_services_serviceId_fk": {
+          "name": "address_group_services_service_id_services_serviceId_fk",
+          "tableFrom": "address_group_services",
+          "tableTo": "services",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "columnsTo": [
+            "serviceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "address_group_services_address_group_id_service_id_pk": {
+          "name": "address_group_services_address_group_id_service_id_pk",
+          "columns": [
+            "address_group_id",
+            "service_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_groups": {
+      "name": "address_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "address_groups_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedAddresses": {
+          "name": "linkedAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "relay_miner_id": {
+          "name": "relay_miner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "address_groups_relay_miner_id_relay_miners_id_fk": {
+          "name": "address_groups_relay_miner_id_relay_miners_id_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "relay_miners",
+          "columnsFrom": [
+            "relay_miner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "address_groups_createdBy_users_identity_fk": {
+          "name": "address_groups_createdBy_users_identity_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "address_groups_updatedBy_users_identity_fk": {
+          "name": "address_groups_updatedBy_users_identity_fk",
+          "tableFrom": "address_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_settings": {
+      "name": "application_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "application_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appIdentity": {
+          "name": "appIdentity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supportEmail": {
+          "name": "supportEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerIdentity": {
+          "name": "ownerIdentity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerEmail": {
+          "name": "ownerEmail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "chain_ids",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minimumStake": {
+          "name": "minimumStake",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initialOperationalFunds": {
+          "name": "initialOperationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 5
+        },
+        "minimumOperationalFunds": {
+          "name": "minimumOperationalFunds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 2
+        },
+        "isBootstrapped": {
+          "name": "isBootstrapped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rpcUrl": {
+          "name": "rpcUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "indexerApiUrl": {
+          "name": "indexerApiUrl",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewardAddresses": {
+          "name": "rewardAddresses",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAtHeight": {
+          "name": "updatedAtHeight",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_settings_createdBy_users_identity_fk": {
+          "name": "application_settings_createdBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "application_settings_updatedBy_users_identity_fk": {
+          "name": "application_settings_updatedBy_users_identity_fk",
+          "tableFrom": "application_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delegators": {
+      "name": "delegators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "delegators_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "delegators_createdBy_users_identity_fk": {
+          "name": "delegators_createdBy_users_identity_fk",
+          "tableFrom": "delegators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "delegators_updatedBy_users_identity_fk": {
+          "name": "delegators_updatedBy_users_identity_fk",
+          "tableFrom": "delegators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "delegators_identity_unique": {
+          "name": "delegators_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.import_supplier_requests": {
+      "name": "import_supplier_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "import_supplier_requests_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegatorIdentity": {
+          "name": "delegatorIdentity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "import_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "matchingSupplierAddresses": {
+          "name": "matchingSupplierAddresses",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "delegatorRevSharePercentage": {
+          "name": "delegatorRevSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_supplier_requests_delegatorIdentity_delegators_identity_fk": {
+          "name": "import_supplier_requests_delegatorIdentity_delegators_identity_fk",
+          "tableFrom": "import_supplier_requests",
+          "tableTo": "delegators",
+          "columnsFrom": [
+            "delegatorIdentity"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "import_supplier_requests_nonce_unique": {
+          "name": "import_supplier_requests_nonce_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_identity_unique": {
+          "name": "users_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keys": {
+      "name": "keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "keys_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "address_states",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "remediationHistory": {
+          "name": "remediationHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegator_identity": {
+          "name": "delegator_identity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_group_id": {
+          "name": "address_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegatorRevSharePercentage": {
+          "name": "delegatorRevSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "delegatorRewardsAddress": {
+          "name": "delegatorRewardsAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "lastUpdatedHeight": {
+          "name": "lastUpdatedHeight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "stakeOwner": {
+          "name": "stakeOwner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "stakeAmountUpokt": {
+          "name": "stakeAmountUpokt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "balanceUpokt": {
+          "name": "balanceUpokt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "services": {
+          "name": "services",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "exportedAt": {
+          "name": "exportedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exportCount": {
+          "name": "exportCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keys_delegator_identity_delegators_identity_fk": {
+          "name": "keys_delegator_identity_delegators_identity_fk",
+          "tableFrom": "keys",
+          "tableTo": "delegators",
+          "columnsFrom": [
+            "delegator_identity"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "keys_address_group_id_address_groups_id_fk": {
+          "name": "keys_address_group_id_address_groups_id_fk",
+          "tableFrom": "keys",
+          "tableTo": "address_groups",
+          "columnsFrom": [
+            "address_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "keys_address_unique": {
+          "name": "keys_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        },
+        "keys_publicKey_unique": {
+          "name": "keys_publicKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publicKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "regions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "urlValue": {
+          "name": "urlValue",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "regions_createdBy_users_identity_fk": {
+          "name": "regions_createdBy_users_identity_fk",
+          "tableFrom": "regions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "regions_updatedBy_users_identity_fk": {
+          "name": "regions_updatedBy_users_identity_fk",
+          "tableFrom": "regions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "regions_displayName_unique": {
+          "name": "regions_displayName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "displayName"
+          ]
+        },
+        "regions_urlValue_unique": {
+          "name": "regions_urlValue_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "urlValue"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.relay_miners": {
+      "name": "relay_miners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "relay_miners_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity": {
+          "name": "identity",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "unique_identity_region_idx": {
+          "name": "unique_identity_region_idx",
+          "columns": [
+            {
+              "expression": "identity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "relay_miners_region_id_regions_id_fk": {
+          "name": "relay_miners_region_id_regions_id_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relay_miners_createdBy_users_identity_fk": {
+          "name": "relay_miners_createdBy_users_identity_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relay_miners_updatedBy_users_identity_fk": {
+          "name": "relay_miners_updatedBy_users_identity_fk",
+          "tableFrom": "relay_miners",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "services_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computeUnits": {
+          "name": "computeUnits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revSharePercentage": {
+          "name": "revSharePercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoints": {
+          "name": "endpoints",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "services_createdBy_users_identity_fk": {
+          "name": "services_createdBy_users_identity_fk",
+          "tableFrom": "services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "services_updatedBy_users_identity_fk": {
+          "name": "services_updatedBy_users_identity_fk",
+          "tableFrom": "services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "identity"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "services_serviceId_unique": {
+          "name": "services_serviceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serviceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_endpoints_not_empty": {
+          "name": "check_endpoints_not_empty",
+          "value": "json_array_length(endpoints) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.address_states": {
+      "name": "address_states",
+      "schema": "public",
+      "values": [
+        "imported",
+        "available",
+        "delivered",
+        "staking",
+        "remediation_failed",
+        "attention_needed",
+        "staked",
+        "stake_failed",
+        "unstaking",
+        "unstaked",
+        "missing_stake"
+      ]
+    },
+    "public.chain_ids": {
+      "name": "chain_ids",
+      "schema": "public",
+      "values": [
+        "pocket",
+        "pocket-beta",
+        "pocket-alpha",
+        "pocket-lego-testnet"
+      ]
+    },
+    "public.import_request_status": {
+      "name": "import_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "expired",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.provider_fee": {
+      "name": "provider_fee",
+      "schema": "public",
+      "values": [
+        "up_to",
+        "fixed"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "user",
+        "owner"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider/drizzle/meta/_journal.json
+++ b/apps/provider/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1774674052531,
       "tag": "0015_even_eddie_brock",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1774628547730,
+      "tag": "0016_slim_warlock",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider/src/actions/Keys.ts
+++ b/apps/provider/src/actions/Keys.ts
@@ -115,20 +115,34 @@ export async function ClearKeysRemediation(): Promise<ActionResult<void>> {
   })
 }
 
+const KeyExportFiltersSchema = z.object({
+  addressGroupId: z.number().int().positive().optional(),
+  states: z.array(z.nativeEnum(KeyState)).optional(),
+  ownerAddress: z.string().optional(),
+  delegatorIdentity: z.string().optional(),
+  dateFrom: z.coerce.date().optional(),
+  dateTo: z.coerce.date().optional(),
+  dateField: z.enum(['createdAt', 'deliveredAt']).optional(),
+  exportStatus: z.enum(['not_exported', 'previously_exported', 'all']).optional(),
+})
+
 export async function CountKeysForExport(filters: KeyExportFilters) {
   return withRequireOwner(async () => {
-    return countKeysForExport(filters)
+    const parsed = KeyExportFiltersSchema.parse(filters)
+    return countKeysForExport(parsed)
   })
 }
 
 export async function ExportKeys(filters: KeyExportFilters) {
   return withRequireOwner(async () => {
-    if (filters.addressGroupId !== undefined) {
-      const group = await findAddressGroupById(filters.addressGroupId)
-      if (!group) throw new Error(`Invalid address group id: ${filters.addressGroupId}`)
+    const parsed = KeyExportFiltersSchema.parse(filters)
+
+    if (parsed.addressGroupId !== undefined) {
+      const group = await findAddressGroupById(parsed.addressGroupId)
+      if (!group) throw new Error(`Invalid address group id: ${parsed.addressGroupId}`)
     }
 
-    const keys = await listKeysForExport(filters)
+    const keys = await listKeysForExport(parsed)
     if (keys.length > 0) {
       await markKeysExported(keys.map(k => k.id))
     }

--- a/apps/provider/src/actions/Keys.ts
+++ b/apps/provider/src/actions/Keys.ts
@@ -7,17 +7,23 @@ import { DirectSecp256k1Wallet } from '@cosmjs/proto-signing'
 import {
   countKeys,
   countPrivateKeysByAddressGroup,
+  countKeysForExport,
   insertMany,
+  listDistinctOwnerAddresses,
+  listKeysForExport,
   listKeysWithPk,
   listPrivateKeysByAddressGroup,
+  markKeysExported,
   updateKeysState,
   updateRewardsSettings,
   updateKeysStateWhereCurrentStateIn,
+  type KeyExportFilters,
 } from '@/lib/dal/keys'
 import {
   type ActionResult,
   withRequireOwner,
 } from '@/lib/utils/actionUtils'
+import { findById as findAddressGroupById } from '@/lib/dal/addressGroups'
 
 export async function CountKeys(): Promise<ActionResult<number>> {
   return withRequireOwner(async () => countKeys())
@@ -106,5 +112,75 @@ export async function ClearKeysRemediation(): Promise<ActionResult<void>> {
       KeyState.AttentionNeeded,
       KeyState.RemediationFailed,
     ], KeyState.Staked)
+  })
+}
+
+export async function CountKeysForExport(filters: KeyExportFilters) {
+  return withRequireOwner(async () => {
+    return countKeysForExport(filters)
+  })
+}
+
+export async function ExportKeys(filters: KeyExportFilters) {
+  return withRequireOwner(async () => {
+    if (filters.addressGroupId !== undefined) {
+      const group = await findAddressGroupById(filters.addressGroupId)
+      if (!group) throw new Error(`Invalid address group id: ${filters.addressGroupId}`)
+    }
+
+    const keys = await listKeysForExport(filters)
+    if (keys.length > 0) {
+      await markKeysExported(keys.map(k => k.id))
+    }
+    return keys.map(k => ({ hex: k.privateKey }))
+  })
+}
+
+export async function ListDistinctOwnerAddresses() {
+  return withRequireOwner(async () => {
+    return listDistinctOwnerAddresses()
+  })
+}
+
+export async function GenerateKeys(addressGroupId: number, count: number) {
+  return withRequireOwner(async () => {
+    const parsed = z.object({
+      addressGroupId: z.number().int().positive(),
+      count: z.number().int().min(1).max(10000),
+    }).parse({ addressGroupId, count })
+
+    const group = await findAddressGroupById(parsed.addressGroupId)
+    if (!group) throw new Error(`Invalid address group id: ${parsed.addressGroupId}`)
+
+    const { Random } = await import('@cosmjs/crypto')
+
+    const keysToInsert: InsertKey[] = []
+    const privateKeys: string[] = []
+
+    for (let i = 0; i < parsed.count; i++) {
+      const privateKeyBytes = Random.getBytes(32)
+      const wallet = await DirectSecp256k1Wallet.fromKey(privateKeyBytes, 'pokt')
+      const [account] = await wallet.getAccounts()
+
+      if (!account) {
+        throw new Error('Failed to create account')
+      }
+
+      const privateKeyHex = Buffer.from(privateKeyBytes).toString('hex')
+      privateKeys.push(privateKeyHex)
+
+      keysToInsert.push({
+        publicKey: Buffer.from(account.pubkey).toString('hex'),
+        privateKey: privateKeyHex,
+        address: account.address,
+        addressGroupId: parsed.addressGroupId,
+        state: KeyState.Available,
+        createdAt: new Date(),
+      })
+    }
+
+    await insertMany(keysToInsert)
+
+    return privateKeys.map(pk => ({ hex: pk }))
   })
 }

--- a/apps/provider/src/app/admin/(internal)/keys/KeyActions.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/KeyActions.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Button } from '@igniter/ui/components/button'
+import ImportForm from './import/ImportForm'
+import ExportForm from './export/ExportForm'
+import GenerateForm from './generate/GenerateForm'
+
+export default function KeyActions() {
+  const [activeModal, setActiveModal] = useState<
+    'import' | 'export' | 'generate' | null
+  >(null)
+
+  return (
+    <>
+      <Button onClick={() => setActiveModal('import')}>Import</Button>
+      <Button
+        className="bg-pnf-mint text-gray-900 border-transparent hover:opacity-90"
+        onClick={() => setActiveModal('export')}
+      >
+        Export
+      </Button>
+      <Button
+        className="bg-pnf-mint text-gray-900 border-transparent hover:opacity-90"
+        onClick={() => setActiveModal('generate')}
+      >
+        Generate
+      </Button>
+
+      {activeModal === 'import' && (
+        <ImportForm onClose={() => setActiveModal(null)} />
+      )}
+      {activeModal === 'export' && (
+        <ExportForm onClose={() => setActiveModal(null)} />
+      )}
+      {activeModal === 'generate' && (
+        <GenerateForm onClose={() => setActiveModal(null)} />
+      )}
+    </>
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/export/ExportForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/export/ExportForm.tsx
@@ -1,7 +1,9 @@
 'use client'
-import type {AddressGroupWithDetails} from '@igniter/db/provider/schema'
+import type {AddressGroupWithDetails, Delegator} from '@igniter/db/provider/schema'
+import type {KeyExportFilters} from '@/lib/dal/keys'
 import {useRouter} from 'next/navigation'
 import React, {useEffect, useState} from 'react'
+import {useForm, useWatch} from 'react-hook-form'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@igniter/ui/components/select'
 import OverrideSidebar from '@igniter/ui/components/OverrideSidebar'
 import {ActivityHeader} from '@igniter/ui/components/ActivityHeader'
@@ -9,86 +11,124 @@ import {AbortConfirmationDialog} from '@igniter/ui/components/AbortConfirmationD
 import {Button} from '@igniter/ui/components/button'
 import {LoaderIcon} from '@igniter/ui/assets'
 import {toCurrencyFormat} from '@igniter/ui/lib/utils'
-import {CountKeysByAddressGroupAndState, GetKeysByAddressGroupAndState} from '@/actions/Keys'
-import {KeyStateLabels} from "@/app/admin/(internal)/keys/constants";
-import type {KeyState} from "@igniter/db/provider/enums";
-
-const exportToJson = (jsonData: object, name: string) => {
-  const jsonString = JSON.stringify(jsonData, null, 2);
-
-  const blob = new Blob([jsonString], {type: 'application/json'});
-
-  const url = window.URL.createObjectURL(blob);
-
-  const link = document.createElement('a');
-  link.href = url;
-
-  link.download = name;
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-
-  window.URL.revokeObjectURL(url);
-};
+import {CountKeysForExport, ExportKeys} from '@/actions/Keys'
+import {exportToJson} from '@/app/admin/(internal)/keys/exportUtils'
+import {KeyStateLabels} from "@/app/admin/(internal)/keys/constants"
+import {KeyState} from "@igniter/db/provider/enums"
 
 
 interface ExportFormProps {
   addressesGroup: AddressGroupWithDetails[]
+  delegators: Delegator[]
+  ownerAddresses: string[]
 }
 
-export default function ExportForm({addressesGroup}: ExportFormProps) {
+type ExportStatus = 'not_exported' | 'previously_exported' | 'all'
+
+interface FilterFormValues {
+  addressGroupId: string
+  selectedStates: KeyState[]
+  ownerAddress: string
+  delegatorIdentity: string
+  dateField: 'createdAt' | 'deliveredAt'
+  dateFrom: string
+  dateTo: string
+  exportStatus: ExportStatus
+}
+
+function buildFilters(values: FilterFormValues): KeyExportFilters {
+  const filters: KeyExportFilters = {}
+  if (values.addressGroupId) filters.addressGroupId = Number(values.addressGroupId)
+  if (values.selectedStates.length > 0) filters.states = values.selectedStates
+  if (values.ownerAddress) filters.ownerAddress = values.ownerAddress
+  if (values.delegatorIdentity) filters.delegatorIdentity = values.delegatorIdentity
+  if (values.dateFrom) filters.dateFrom = new Date(values.dateFrom + 'T00:00:00.000Z')
+  if (values.dateTo) {
+    const to = new Date(values.dateTo + 'T23:59:59.999Z')
+    filters.dateTo = to
+  }
+  if (values.dateFrom || values.dateTo) filters.dateField = values.dateField
+  if (values.exportStatus !== 'all') filters.exportStatus = values.exportStatus
+  return filters
+}
+
+export default function ExportForm({addressesGroup, delegators, ownerAddresses}: ExportFormProps) {
   const router = useRouter()
-  const [isRedirecting, setIsRedirecting] = useState<boolean>(false);
+  const [isRedirecting, setIsRedirecting] = useState(false)
   const [isAbortDialogOpen, setAbortDialogOpen] = useState(false)
   const [status, setStatus] = useState<'form' | 'success' | 'loading' | 'error'>('form')
-  const [addressGroup, setAddressGroup] = useState<string>('')
-  const [keyState, setKeyState] = useState<KeyState | undefined>()
   const [keysExported, setKeysExported] = useState(0)
-  const [totalKeysCount, setTotalKeysCount] = useState<number | null>(null);
-  const [isLoadingKeyCount, setIsLoadingKeyCount] = useState(false);
+  const [totalKeysCount, setTotalKeysCount] = useState<number | null>(null)
+  const [isLoadingKeyCount, setIsLoadingKeyCount] = useState(false)
 
-  const fetchTotalKeysCount = async (groupId: string, keyState?: KeyState) => {
-    if (!groupId) return;
+  const {register, setValue, setError, formState: {errors}, control} = useForm<FilterFormValues>({
+    defaultValues: {
+      addressGroupId: '',
+      selectedStates: [],
+      ownerAddress: '',
+      delegatorIdentity: '',
+      dateField: 'createdAt',
+      dateFrom: '',
+      dateTo: '',
+      exportStatus: 'all',
+    },
+  })
 
-    setIsLoadingKeyCount(true);
-    try {
-      const result = await CountKeysByAddressGroupAndState(Number(groupId), keyState);
+  const values = useWatch({control})
 
-      if (!result || !result.success) {
-        throw new Error('Failed to fetch keys count');
+  const addressGroupId = values.addressGroupId ?? ''
+  const selectedStates = values.selectedStates ?? []
+  const ownerAddress = values.ownerAddress ?? ''
+  const delegatorIdentity = values.delegatorIdentity ?? ''
+  const dateField = values.dateField ?? 'createdAt'
+  const dateFrom = values.dateFrom ?? ''
+  const dateTo = values.dateTo ?? ''
+  const exportStatus = values.exportStatus ?? 'all'
+
+  useEffect(() => {
+    const fetchCount = async () => {
+      setIsLoadingKeyCount(true)
+      try {
+        const result = await CountKeysForExport(buildFilters(values as FilterFormValues))
+        if (!result || !result.success) throw new Error('Failed to fetch count')
+        setTotalKeysCount(result.data)
+      } catch {
+        setTotalKeysCount(null)
+      } finally {
+        setIsLoadingKeyCount(false)
       }
-
-      setTotalKeysCount(result.data);
-    } catch (error) {
-      console.error("Failed to fetch keys count:", error);
-      setTotalKeysCount(null);
-    } finally {
-      setIsLoadingKeyCount(false);
     }
-  };
+    fetchCount()
+  }, [addressGroupId, selectedStates, ownerAddress, delegatorIdentity, dateFrom, dateTo, dateField, exportStatus])
+
+  const handleStateToggle = (state: KeyState) => {
+    const next = selectedStates.includes(state)
+      ? selectedStates.filter(s => s !== state)
+      : [...selectedStates, state]
+    setValue('selectedStates', next)
+  }
 
   const exportKeys = async () => {
-    if (!addressGroup || !keyState || status === 'loading') return;
+    if (status === 'loading') return
+
+    if (addressGroupId && !addressesGroup.some(g => g.id === Number(addressGroupId))) {
+      setError('addressGroupId', {message: 'Selected group does not exist'})
+      return
+    }
 
     setStatus('loading')
     try {
-      const result = await GetKeysByAddressGroupAndState(Number(addressGroup), keyState);
+      const filters = buildFilters(values as FilterFormValues)
+      const result = await ExportKeys(filters)
+      if (!result || !result.success) throw new Error('Failed to fetch keys')
 
-      if (!result || !result.success) {
-        throw new Error('Failed to fetch keys');
-      }
+      const privateKeys = result.data
+      const groupName = addressGroupId
+        ? addressesGroup.find(a => a.id === Number(addressGroupId))?.name ?? 'keys'
+        : 'all-groups'
+      const filename = `${groupName}-keys-at-${new Date().toISOString().replace(/[:.]/g, '_')}.json`
 
-      const privateKeys = result.data;
-
-      const filename = `${addressesGroup.find((a) => a.id === parseInt(addressGroup))?.name}-keys-at-${new Date().toISOString().replace(/[:.]/g, '_')}.json`;
-
-      exportToJson(
-        privateKeys.map(({privateKey}) => ({
-          hex: privateKey
-        })),
-        filename,
-      )
+      exportToJson(privateKeys, filename)
       setKeysExported(privateKeys.length)
       setStatus('success')
     } catch {
@@ -96,98 +136,222 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
     }
   }
 
-  useEffect(() => {
-    if (addressGroup) {
-      fetchTotalKeysCount(addressGroup, keyState);
-    } else {
-      setTotalKeysCount(null);
+  const getFilterSummary = (): string => {
+    const parts: string[] = []
+    if (addressGroupId) {
+      const group = addressesGroup.find(a => a.id === Number(addressGroupId))
+      if (group) parts.push(`Group: ${group.name}`)
     }
-  }, [addressGroup, keyState]);
+    if (selectedStates.length > 0) {
+      parts.push(selectedStates.map(s => KeyStateLabels[s]).join(' + '))
+    }
+    if (ownerAddress) {
+      parts.push(`Owner: ${ownerAddress.slice(0, 8)}...`)
+    }
+    if (delegatorIdentity) {
+      const d = delegators.find(d => d.identity === delegatorIdentity)
+      if (d) parts.push(`Delegator: ${d.name}`)
+    }
+    if (dateFrom || dateTo) {
+      const field = dateField === 'createdAt' ? 'Created' : 'Delivered'
+      if (dateFrom && dateTo) parts.push(`${field}: ${dateFrom} to ${dateTo}`)
+      else if (dateFrom) parts.push(`${field} from: ${dateFrom}`)
+      else parts.push(`${field} to: ${dateTo}`)
+    }
+    if (exportStatus === 'not_exported') parts.push('Not yet exported')
+    else if (exportStatus === 'previously_exported') parts.push('Previously exported')
+    return parts.length > 0 ? parts.join(' · ') : 'No filters applied'
+  }
 
-  let content: React.ReactNode;
+  let content: React.ReactNode
 
   if (status === 'form' || status === 'loading') {
     content = (
       <>
-        <Select value={addressGroup} onValueChange={setAddressGroup}>
-          <SelectTrigger className={'w-full'}>
-            <SelectValue placeholder={'Select an address group'}/>
-          </SelectTrigger>
-          <SelectContent>
-            {addressesGroup.map((addressGroup) => (
-              <SelectItem value={addressGroup.id.toString()} key={addressGroup.id.toString()}>
-                {addressGroup.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {/* Address Group */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-text-secondary">Address Group</label>
+          <Select value={addressGroupId} onValueChange={(v) => setValue('addressGroupId', v === '__all__' ? '' : v, {shouldValidate: true})}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="All Groups"/>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">All Groups</SelectItem>
+              {addressesGroup.map(group => (
+                <SelectItem value={group.id.toString()} key={group.id}>
+                  {group.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.addressGroupId && (
+            <p className="text-xs text-red-500">{errors.addressGroupId.message}</p>
+          )}
+        </div>
 
-        <Select
-          disabled={!addressGroup}
-          value={keyState}
-          onValueChange={(value) => setKeyState(value as KeyState)}
-        >
-          <SelectTrigger className={'w-full'}>
-            <SelectValue placeholder={'Select a key state'}/>
-          </SelectTrigger>
-          <SelectContent>
-            {Object.entries(KeyStateLabels).map(([value, label]) => (
-              <SelectItem value={value} key={value}>
-                {label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {/* Key States */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-text-secondary">Key State</label>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(KeyStateLabels).map(([value, label]) => {
+              const state = value as KeyState
+              const isSelected = selectedStates.includes(state)
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => handleStateToggle(state)}
+                  className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                    isSelected
+                      ? 'bg-blue-600 border-blue-600 text-white'
+                      : 'bg-bg-elevated border-border text-text-secondary hover:bg-bg-hover'
+                  }`}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
 
-        {addressGroup && (
-          <div className="p-4 rounded-md bg-bg-elevated">
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Name</span>
-                <span className="text-sm">
-          {addressesGroup.find(group => group.id.toString() === addressGroup)?.name}
-        </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Visibility</span>
-                <span className="text-sm">
-          {addressesGroup.find(group => group.id.toString() === addressGroup)?.private ? 'Private' : 'Public'}
-                </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium text-text-secondary">Keys to Export:</span>
-                    <span className="text-sm">
-              {isLoadingKeyCount ? (
-                <div className="flex items-center justify-center px-4">
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-500"></div>
-                </div>
-              ) : totalKeysCount !== null ? (
-                totalKeysCount
-              ) : (
-                "Failed to load"
-              )}
-            </span>
-                  </div>
-
-            </div>
+        {/* Owner Address */}
+        {ownerAddresses.length > 0 && (
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-text-secondary">Owner Address</label>
+            <Select value={ownerAddress} onValueChange={(v) => setValue('ownerAddress', v === '__all__' ? '' : v)}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="All Owners"/>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">All Owners</SelectItem>
+                {ownerAddresses.map(addr => (
+                  <SelectItem value={addr} key={addr}>
+                    {addr.slice(0, 12)}...{addr.slice(-6)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         )}
+
+        {/* Delegator */}
+        {delegators.length > 0 && (
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-text-secondary">Delegator</label>
+            <Select value={delegatorIdentity} onValueChange={(v) => setValue('delegatorIdentity', v === '__all__' ? '' : v)}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="All Delegators"/>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">All Delegators</SelectItem>
+                {delegators.map(d => (
+                  <SelectItem value={d.identity} key={d.identity}>
+                    {d.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
+        {/* Date Range */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-text-secondary">Date Range</label>
+          <div className="flex items-center gap-4 mb-2">
+            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <input
+                type="radio"
+                value="createdAt"
+                checked={dateField === 'createdAt'}
+                {...register('dateField')}
+                className="accent-blue-600"
+              />
+              Created
+            </label>
+            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <input
+                type="radio"
+                value="deliveredAt"
+                checked={dateField === 'deliveredAt'}
+                {...register('dateField')}
+                className="accent-blue-600"
+              />
+              Delivered
+            </label>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              {...register('dateFrom')}
+              className="flex-1 h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground"
+            />
+            <span className="text-sm text-text-secondary">to</span>
+            <input
+              type="date"
+              {...register('dateTo')}
+              className="flex-1 h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground"
+            />
+          </div>
+        </div>
+
+        {/* Export Status */}
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-text-secondary">Export Status</label>
+          <div className="flex items-center gap-4">
+            {([
+              ['all', 'All'],
+              ['not_exported', 'Not yet exported'],
+              ['previously_exported', 'Previously exported'],
+            ] as const).map(([value, label]) => (
+              <label key={value} className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  value={value}
+                  checked={exportStatus === value}
+                  {...register('exportStatus')}
+                  className="accent-blue-600"
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Summary */}
+        <div className="p-4 rounded-md bg-bg-elevated">
+          <div className="space-y-2">
+            <div className="text-xs text-text-tertiary">
+              {getFilterSummary()}
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-text-secondary">Keys to Export</span>
+              <span className="text-sm">
+                {isLoadingKeyCount ? (
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-500" />
+                ) : totalKeysCount !== null ? (
+                  toCurrencyFormat(totalKeysCount, 0, 0)
+                ) : (
+                  "Failed to load"
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
 
         <p>
           Example output:
           <br/>
           <div className="p-4 rounded-md bg-bg-elevated mt-2">
-            <pre className="whitespace-pre-wrap">{JSON.stringify([{ hex: '<pk1>' },{ hex: '<pk2>' }], null, 2)}</pre>
+            <pre className="whitespace-pre-wrap">{JSON.stringify([{hex: '<pk1>'}, {hex: '<pk2>'}], null, 2)}</pre>
           </div>
         </p>
+
         <Button
           className="w-full h-[40px]"
           onClick={exportKeys}
-          disabled={status === 'loading' || !addressGroup || !totalKeysCount || totalKeysCount <= 0}
+          disabled={status === 'loading' || !totalKeysCount || totalKeysCount <= 0}
         >
-          {status === 'loading' && (
-            <LoaderIcon className="animate-spin"/>
-          )}
+          {status === 'loading' && <LoaderIcon className="animate-spin"/>}
           {status === 'form' && 'Export Keys'}
         </Button>
       </>
@@ -195,27 +359,18 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
   } else if (status === 'success') {
     content = (
       <>
-        <div
-          className={'relative flex h-[64px] mt-[-5px] gradient-border-green'}
-        >
-          <div
-            className={`absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between`}>
-          <span className="text-[20px] text-text-secondary">
-            Keys Exported
-          </span>
+        <div className="relative flex h-[64px] mt-[-5px] gradient-border-green">
+          <div className="absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between">
+            <span className="text-[20px] text-text-secondary">Keys Exported</span>
             <div className="flex flex-row items-center gap-2">
-              <p className="font-mono !text-[20px]">
-                {toCurrencyFormat(keysExported, 0, 0)}
-              </p>
+              <p className="font-mono !text-[20px]">{toCurrencyFormat(keysExported, 0, 0)}</p>
             </div>
           </div>
         </div>
 
         <div className="flex flex-col bg-bg-elevated p-0 rounded-[8px]">
           <span className="text-[14px] text-text-primary p-[11px_16px]">
-            You have successfully exported {keysExported} keys from the address group "{
-            addressesGroup.find((a) => a.id === parseInt(addressGroup))?.name
-          }".
+            You have successfully exported {keysExported} keys.
           </span>
         </div>
 
@@ -226,9 +381,7 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
             router.push('/admin/keys')
           }}
         >
-          {isRedirecting && (
-            <LoaderIcon className="animate-spin"/>
-          )}
+          {isRedirecting && <LoaderIcon className="animate-spin"/>}
           {!isRedirecting && 'Close'}
         </Button>
       </>
@@ -236,14 +389,9 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
   } else if (status === 'error') {
     content = (
       <>
-        <div
-          className={'relative flex h-[64px] mt-[-5px] gradient-border-red'}
-        >
-          <div
-            className={`absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between`}>
-          <span className="text-[20px] text-text-secondary">
-            Oops! Something went wrong.
-          </span>
+        <div className="relative flex h-[64px] mt-[-5px] gradient-border-red">
+          <div className="absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between">
+            <span className="text-[20px] text-text-secondary">Oops! Something went wrong.</span>
           </div>
         </div>
 
@@ -262,12 +410,10 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
     <>
       <OverrideSidebar>
         <div className="flex flex-row justify-center w-full">
-          <div
-            className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8"
-          >
+          <div className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
             <ActivityHeader
-              title="Export Addresses"
-              subtitle={status === 'success' ? '' : 'Select the address group and export your keys json file.'}
+              title="Export Keys"
+              subtitle={status === 'success' ? '' : 'Configure filters and export your keys as a JSON file.'}
               onClose={() => setAbortDialogOpen(true)}
               isDisabled={status === 'success'}
             />
@@ -276,10 +422,10 @@ export default function ExportForm({addressesGroup}: ExportFormProps) {
         </div>
       </OverrideSidebar>
       <AbortConfirmationDialog
-        type={'export'}
+        type="export"
         isOpen={isAbortDialogOpen}
         onResponse={(abort) => {
-          setAbortDialogOpen(false);
+          setAbortDialogOpen(false)
           if (abort) {
             setIsRedirecting(true)
             router.push('/admin/keys')

--- a/apps/provider/src/app/admin/(internal)/keys/export/ExportForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/export/ExportForm.tsx
@@ -1,26 +1,23 @@
 'use client'
 import type {AddressGroupWithDetails, Delegator} from '@igniter/db/provider/schema'
 import type {KeyExportFilters} from '@/lib/dal/keys'
-import {useRouter} from 'next/navigation'
-import React, {useEffect, useState} from 'react'
+import React, {useEffect, useRef, useState} from 'react'
 import {useForm, useWatch} from 'react-hook-form'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@igniter/ui/components/select'
-import OverrideSidebar from '@igniter/ui/components/OverrideSidebar'
-import {ActivityHeader} from '@igniter/ui/components/ActivityHeader'
-import {AbortConfirmationDialog} from '@igniter/ui/components/AbortConfirmationDialog'
+import {Dialog, DialogContent, DialogTitle, DialogFooter} from '@igniter/ui/components/dialog'
 import {Button} from '@igniter/ui/components/button'
 import {LoaderIcon} from '@igniter/ui/assets'
 import {toCurrencyFormat} from '@igniter/ui/lib/utils'
-import {CountKeysForExport, ExportKeys} from '@/actions/Keys'
+import {CountKeysForExport, ExportKeys, ListDistinctOwnerAddresses} from '@/actions/Keys'
+import {ListAddressGroups} from '@/actions/AddressGroups'
+import {ListDelegators} from '@/actions/Delegators'
 import {exportToJson} from '@/app/admin/(internal)/keys/exportUtils'
 import {KeyStateLabels} from "@/app/admin/(internal)/keys/constants"
 import {KeyState} from "@igniter/db/provider/enums"
 
 
 interface ExportFormProps {
-  addressesGroup: AddressGroupWithDetails[]
-  delegators: Delegator[]
-  ownerAddresses: string[]
+  onClose: () => void
 }
 
 type ExportStatus = 'not_exported' | 'previously_exported' | 'all'
@@ -52,14 +49,24 @@ function buildFilters(values: FilterFormValues): KeyExportFilters {
   return filters
 }
 
-export default function ExportForm({addressesGroup, delegators, ownerAddresses}: ExportFormProps) {
-  const router = useRouter()
-  const [isRedirecting, setIsRedirecting] = useState(false)
-  const [isAbortDialogOpen, setAbortDialogOpen] = useState(false)
+export default function ExportForm({onClose}: ExportFormProps) {
+  const [addressesGroup, setAddressesGroup] = useState<AddressGroupWithDetails[]>([])
+  const [delegators, setDelegators] = useState<Delegator[]>([])
+  const [ownerAddresses, setOwnerAddresses] = useState<string[]>([])
+  const [isDataLoading, setIsDataLoading] = useState(true)
   const [status, setStatus] = useState<'form' | 'success' | 'loading' | 'error'>('form')
   const [keysExported, setKeysExported] = useState(0)
   const [totalKeysCount, setTotalKeysCount] = useState<number | null>(null)
   const [isLoadingKeyCount, setIsLoadingKeyCount] = useState(false)
+
+  useEffect(() => {
+    Promise.all([ListAddressGroups(), ListDelegators(), ListDistinctOwnerAddresses()]).then(([ag, del, own]) => {
+      if (ag.success) setAddressesGroup(ag.data)
+      if (del.success) setDelegators(del.data)
+      if (own.success) setOwnerAddresses(own.data)
+      setIsDataLoading(false)
+    })
+  }, [])
 
   const {register, setValue, setError, formState: {errors}, control} = useForm<FilterFormValues>({
     defaultValues: {
@@ -85,8 +92,12 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
   const dateTo = values.dateTo ?? ''
   const exportStatus = values.exportStatus ?? 'all'
 
+  const statesKey = JSON.stringify(selectedStates)
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+
   useEffect(() => {
-    const fetchCount = async () => {
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
       setIsLoadingKeyCount(true)
       try {
         const result = await CountKeysForExport(buildFilters(values as FilterFormValues))
@@ -97,9 +108,9 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
       } finally {
         setIsLoadingKeyCount(false)
       }
-    }
-    fetchCount()
-  }, [addressGroupId, selectedStates, ownerAddress, delegatorIdentity, dateFrom, dateTo, dateField, exportStatus])
+    }, 300)
+    return () => clearTimeout(debounceRef.current)
+  }, [addressGroupId, statesKey, ownerAddress, delegatorIdentity, dateFrom, dateTo, dateField, exportStatus])
 
   const handleStateToggle = (state: KeyState) => {
     const next = selectedStates.includes(state)
@@ -165,34 +176,44 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
 
   let content: React.ReactNode
 
-  if (status === 'form' || status === 'loading') {
+  if (isDataLoading) {
+    content = (
+      <div className="flex items-center justify-center py-12">
+        <LoaderIcon className="animate-spin h-6 w-6 text-text-secondary" />
+      </div>
+    )
+  } else if (status === 'form' || status === 'loading') {
     content = (
       <>
         {/* Address Group */}
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium text-text-secondary">Address Group</label>
-          <Select value={addressGroupId} onValueChange={(v) => setValue('addressGroupId', v === '__all__' ? '' : v, {shouldValidate: true})}>
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="All Groups"/>
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="__all__">All Groups</SelectItem>
-              {addressesGroup.map(group => (
-                <SelectItem value={group.id.toString()} key={group.id}>
-                  {group.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <div>
+          <div className="flex flex-row items-center gap-3">
+            <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Address Group</label>
+            <div className="flex-1">
+              <Select value={addressGroupId} onValueChange={(v) => setValue('addressGroupId', v === '__all__' ? '' : v, {shouldValidate: true})}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="All Groups"/>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">All Groups</SelectItem>
+                  {addressesGroup.map(group => (
+                    <SelectItem value={group.id.toString()} key={group.id}>
+                      {group.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
           {errors.addressGroupId && (
             <p className="text-xs text-red-500">{errors.addressGroupId.message}</p>
           )}
         </div>
 
         {/* Key States */}
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium text-text-secondary">Key State</label>
-          <div className="flex flex-wrap gap-2">
+        <div className="flex flex-row items-start gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary pt-1">Key State</label>
+          <div className="flex flex-wrap gap-2 flex-1">
             {Object.entries(KeyStateLabels).map(([value, label]) => {
               const state = value as KeyState
               const isSelected = selectedStates.includes(state)
@@ -216,88 +237,94 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
 
         {/* Owner Address */}
         {ownerAddresses.length > 0 && (
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium text-text-secondary">Owner Address</label>
-            <Select value={ownerAddress} onValueChange={(v) => setValue('ownerAddress', v === '__all__' ? '' : v)}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="All Owners"/>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">All Owners</SelectItem>
-                {ownerAddresses.map(addr => (
-                  <SelectItem value={addr} key={addr}>
-                    {addr.slice(0, 12)}...{addr.slice(-6)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div className="flex flex-row items-center gap-3">
+            <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Owner Address</label>
+            <div className="flex-1">
+              <Select value={ownerAddress} onValueChange={(v) => setValue('ownerAddress', v === '__all__' ? '' : v)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="All Owners"/>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">All Owners</SelectItem>
+                  {ownerAddresses.map(addr => (
+                    <SelectItem value={addr} key={addr}>
+                      {addr.slice(0, 12)}...{addr.slice(-6)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         )}
 
         {/* Delegator */}
         {delegators.length > 0 && (
-          <div className="space-y-1.5">
-            <label className="text-sm font-medium text-text-secondary">Delegator</label>
-            <Select value={delegatorIdentity} onValueChange={(v) => setValue('delegatorIdentity', v === '__all__' ? '' : v)}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="All Delegators"/>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">All Delegators</SelectItem>
-                {delegators.map(d => (
-                  <SelectItem value={d.identity} key={d.identity}>
-                    {d.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div className="flex flex-row items-center gap-3">
+            <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Delegator</label>
+            <div className="flex-1">
+              <Select value={delegatorIdentity} onValueChange={(v) => setValue('delegatorIdentity', v === '__all__' ? '' : v)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="All Delegators"/>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">All Delegators</SelectItem>
+                  {delegators.map(d => (
+                    <SelectItem value={d.identity} key={d.identity}>
+                      {d.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         )}
 
         {/* Date Range */}
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium text-text-secondary">Date Range</label>
-          <div className="flex items-center gap-4 mb-2">
-            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+        <div className="flex flex-row items-start gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary pt-1">Date Range</label>
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  value="createdAt"
+                  checked={dateField === 'createdAt'}
+                  {...register('dateField')}
+                  className="accent-blue-600"
+                />
+                Created
+              </label>
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  value="deliveredAt"
+                  checked={dateField === 'deliveredAt'}
+                  {...register('dateField')}
+                  className="accent-blue-600"
+                />
+                Delivered
+              </label>
+            </div>
+            <div className="flex items-center gap-2">
               <input
-                type="radio"
-                value="createdAt"
-                checked={dateField === 'createdAt'}
-                {...register('dateField')}
-                className="accent-blue-600"
+                type="date"
+                {...register('dateFrom')}
+                className="flex-1 h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground"
               />
-              Created
-            </label>
-            <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+              <span className="text-sm text-text-secondary">to</span>
               <input
-                type="radio"
-                value="deliveredAt"
-                checked={dateField === 'deliveredAt'}
-                {...register('dateField')}
-                className="accent-blue-600"
+                type="date"
+                {...register('dateTo')}
+                className="flex-1 h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground"
               />
-              Delivered
-            </label>
-          </div>
-          <div className="flex items-center gap-2">
-            <input
-              type="date"
-              {...register('dateFrom')}
-              className="flex-1 h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground"
-            />
-            <span className="text-sm text-text-secondary">to</span>
-            <input
-              type="date"
-              {...register('dateTo')}
-              className="flex-1 h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground"
-            />
+            </div>
           </div>
         </div>
 
         {/* Export Status */}
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium text-text-secondary">Export Status</label>
-          <div className="flex items-center gap-4">
+        <div className="flex flex-row items-start gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary pt-1">Export Status</label>
+          <div className="flex items-center gap-4 flex-1">
             {([
               ['all', 'All'],
               ['not_exported', 'Not yet exported'],
@@ -318,14 +345,22 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
         </div>
 
         {/* Summary */}
-        <div className="p-4 rounded-md bg-bg-elevated">
+        <div className={`p-4 rounded-md border transition-colors ${
+          isLoadingKeyCount
+            ? 'bg-bg-elevated border-border'
+            : totalKeysCount && totalKeysCount > 0
+              ? 'bg-emerald-500/5 border-emerald-500/30'
+              : 'bg-yellow-500/5 border-yellow-500/30'
+        }`}>
           <div className="space-y-2">
             <div className="text-xs text-text-tertiary">
               {getFilterSummary()}
             </div>
             <div className="flex items-center justify-between">
               <span className="font-medium text-text-secondary">Keys to Export</span>
-              <span className="text-sm">
+              <span className={`text-sm font-medium ${
+                isLoadingKeyCount ? '' : totalKeysCount && totalKeysCount > 0 ? 'text-emerald-400' : 'text-yellow-500'
+              }`}>
                 {isLoadingKeyCount ? (
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-500" />
                 ) : totalKeysCount !== null ? (
@@ -338,22 +373,22 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
           </div>
         </div>
 
-        <p>
-          Example output:
-          <br/>
-          <div className="p-4 rounded-md bg-bg-elevated mt-2">
-            <pre className="whitespace-pre-wrap">{JSON.stringify([{hex: '<pk1>'}, {hex: '<pk2>'}], null, 2)}</pre>
+        {/* Example output — collapsible */}
+        <details className="group">
+          <summary className="text-sm text-text-secondary cursor-pointer select-none hover:text-text-primary transition-colors">
+            Example output
+          </summary>
+          <div className="mt-2 rounded-lg border border-border bg-[#0d1117] p-4 font-mono text-xs leading-relaxed overflow-x-auto">
+            <span className="text-[#8b949e]">{'['}</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'{'}</span>{'\n'}
+            {'    '}<span className="text-[#7ee787]">{'"hex"'}</span><span className="text-[#8b949e]">:</span> <span className="text-[#a5d6ff]">{'"<pk1>"'}</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'}'}</span><span className="text-[#8b949e]">,</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'{'}</span>{'\n'}
+            {'    '}<span className="text-[#7ee787]">{'"hex"'}</span><span className="text-[#8b949e]">:</span> <span className="text-[#a5d6ff]">{'"<pk2>"'}</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'}'}</span>{'\n'}
+            <span className="text-[#8b949e]">{']'}</span>
           </div>
-        </p>
-
-        <Button
-          className="w-full h-[40px]"
-          onClick={exportKeys}
-          disabled={status === 'loading' || !totalKeysCount || totalKeysCount <= 0}
-        >
-          {status === 'loading' && <LoaderIcon className="animate-spin"/>}
-          {status === 'form' && 'Export Keys'}
-        </Button>
+        </details>
       </>
     )
   } else if (status === 'success') {
@@ -373,17 +408,6 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
             You have successfully exported {keysExported} keys.
           </span>
         </div>
-
-        <Button
-          className="w-full h-[40px]"
-          onClick={() => {
-            setIsRedirecting(true)
-            router.push('/admin/keys')
-          }}
-        >
-          {isRedirecting && <LoaderIcon className="animate-spin"/>}
-          {!isRedirecting && 'Close'}
-        </Button>
       </>
     )
   } else if (status === 'error') {
@@ -395,43 +419,66 @@ export default function ExportForm({addressesGroup, delegators, ownerAddresses}:
           </div>
         </div>
 
-        <Button
-          disabled={!totalKeysCount || totalKeysCount <= 0}
-          className="w-full h-[40px]"
-          onClick={exportKeys}
-        >
-          Try Again
-        </Button>
       </>
     )
   }
 
   return (
-    <>
-      <OverrideSidebar>
-        <div className="flex flex-row justify-center w-full">
-          <div className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
-            <ActivityHeader
-              title="Export Keys"
-              subtitle={status === 'success' ? '' : 'Configure filters and export your keys as a JSON file.'}
-              onClose={() => setAbortDialogOpen(true)}
-              isDisabled={status === 'success'}
-            />
-            {content}
+    <Dialog open={true}>
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        hideClose
+        className="gap-0 p-0 rounded-lg bg-bg-elevated sm:max-w-xl max-h-[85vh] overflow-hidden"
+      >
+        <DialogTitle asChild>
+          <div className="flex flex-row justify-between items-center py-3 px-5">
+            <span className="text-sm font-semibold">Export Keys</span>
           </div>
+        </DialogTitle>
+        <div className="h-px bg-border-primary" />
+
+        <div className="flex flex-col gap-5 p-6 overflow-y-auto max-h-[calc(85vh-110px)]">
+          {content}
         </div>
-      </OverrideSidebar>
-      <AbortConfirmationDialog
-        type="export"
-        isOpen={isAbortDialogOpen}
-        onResponse={(abort) => {
-          setAbortDialogOpen(false)
-          if (abort) {
-            setIsRedirecting(true)
-            router.push('/admin/keys')
-          }
-        }}
-      />
-    </>
+
+        <div className="h-px bg-border-primary" />
+        <DialogFooter className="px-5 py-3 flex flex-row items-center gap-2">
+          {(status === 'form' || status === 'loading') && (
+            <>
+              <div className="flex-1" />
+              <Button variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                onClick={exportKeys}
+                disabled={status === 'loading' || !totalKeysCount || totalKeysCount <= 0}
+              >
+                {status === 'loading' && <LoaderIcon className="animate-spin"/>}
+                {status === 'form' && 'Export Keys'}
+              </Button>
+            </>
+          )}
+          {status === 'success' && (
+            <>
+              <div className="flex-1" />
+              <Button onClick={onClose}>
+                Close
+              </Button>
+            </>
+          )}
+          {status === 'error' && (
+            <>
+              <div className="flex-1" />
+              <Button
+                disabled={!totalKeysCount || totalKeysCount <= 0}
+                onClick={exportKeys}
+              >
+                Try Again
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/provider/src/app/admin/(internal)/keys/export/page.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/export/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next'
 import { ListAddressGroups } from '@/actions/AddressGroups'
+import { ListDelegators } from '@/actions/Delegators'
+import { ListDistinctOwnerAddresses } from '@/actions/Keys'
 import ExportForm from '@/app/admin/(internal)/keys/export/ExportForm'
 import { GetAppName } from '@/actions/ApplicationSettings'
 
@@ -13,13 +15,27 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function ExportPage() {
-  const result = await ListAddressGroups()
+  const [addressGroupsResult, delegatorsResult, ownersResult] = await Promise.all([
+    ListAddressGroups(),
+    ListDelegators(),
+    ListDistinctOwnerAddresses(),
+  ])
 
-  if (!result.success) {
-    throw new Error(result.error.message);
+  if (!addressGroupsResult.success) {
+    throw new Error(addressGroupsResult.error.message);
+  }
+  if (!delegatorsResult.success) {
+    throw new Error(delegatorsResult.error.message);
+  }
+  if (!ownersResult.success) {
+    throw new Error(ownersResult.error.message);
   }
 
   return (
-    <ExportForm addressesGroup={result.data} />
+    <ExportForm
+      addressesGroup={addressGroupsResult.data}
+      delegators={delegatorsResult.data}
+      ownerAddresses={ownersResult.data}
+    />
   )
 }

--- a/apps/provider/src/app/admin/(internal)/keys/exportUtils.ts
+++ b/apps/provider/src/app/admin/(internal)/keys/exportUtils.ts
@@ -1,0 +1,12 @@
+export function exportToJson(jsonData: object, name: string) {
+  const jsonString = JSON.stringify(jsonData, null, 2)
+  const blob = new Blob([jsonString], {type: 'application/json'})
+  const url = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = name
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  window.URL.revokeObjectURL(url)
+}

--- a/apps/provider/src/app/admin/(internal)/keys/generate/GenerateForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/generate/GenerateForm.tsx
@@ -1,0 +1,219 @@
+'use client'
+import type { AddressGroupWithDetails } from '@igniter/db/provider/schema'
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@igniter/ui/components/select'
+import { LoaderIcon } from '@igniter/ui/assets'
+import { Button } from '@igniter/ui/components/button'
+import { toCurrencyFormat } from '@igniter/ui/lib/utils'
+import OverrideSidebar from '@igniter/ui/components/OverrideSidebar'
+import { ActivityHeader } from '@igniter/ui/components/ActivityHeader'
+import { AbortConfirmationDialog } from '@igniter/ui/components/AbortConfirmationDialog'
+import { GenerateKeys } from '@/actions/Keys'
+import {exportToJson} from '@/app/admin/(internal)/keys/exportUtils'
+
+
+interface GenerateFormProps {
+  addressesGroup: AddressGroupWithDetails[]
+}
+
+export default function GenerateForm({ addressesGroup }: GenerateFormProps) {
+  const router = useRouter()
+  const [isRedirecting, setIsRedirecting] = useState(false)
+  const [isAbortDialogOpen, setAbortDialogOpen] = useState(false)
+  const [status, setStatus] = useState<'form' | 'loading' | 'success' | 'error'>('form')
+  const [addressGroup, setAddressGroup] = useState<string>('')
+  const [keyCount, setKeyCount] = useState<string>('')
+  const [keysGenerated, setKeysGenerated] = useState(0)
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const parsedCount = parseInt(keyCount, 10)
+  const isValidCount = !isNaN(parsedCount) && parsedCount >= 1 && parsedCount <= 10000
+
+  const handleGenerate = async () => {
+    if (!addressGroup || !isValidCount || status === 'loading') return
+
+    setStatus('loading')
+    setErrorMessage('')
+    try {
+      const result = await GenerateKeys(Number(addressGroup), parsedCount)
+
+      if (!result || !result.success) {
+        throw new Error('Failed to generate keys')
+      }
+
+      const privateKeys = result.data
+      const groupName = addressesGroup.find(a => a.id === Number(addressGroup))?.name ?? 'keys'
+      const filename = `${groupName}-generated-${parsedCount}-keys-at-${new Date().toISOString().replace(/[:.]/g, '_')}.json`
+
+      exportToJson(privateKeys, filename)
+      setKeysGenerated(privateKeys.length)
+      setStatus('success')
+    } catch (e) {
+      setErrorMessage(e instanceof Error ? e.message : 'An unexpected error occurred')
+      setStatus('error')
+    }
+  }
+
+  let content: React.ReactNode
+
+  if (status === 'form' || status === 'loading') {
+    content = (
+      <>
+        <Select value={addressGroup} onValueChange={setAddressGroup}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select an address group" />
+          </SelectTrigger>
+          <SelectContent>
+            {addressesGroup.map(group => (
+              <SelectItem value={group.id.toString()} key={group.id}>
+                {group.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-text-secondary">Number of Keys</label>
+          <input
+            type="number"
+            min={1}
+            max={10000}
+            value={keyCount}
+            onChange={(e) => setKeyCount(e.target.value)}
+            placeholder="Enter amount (1 - 10,000)"
+            className="w-full h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[color:--color-blue-1]"
+          />
+        </div>
+
+        {addressGroup && isValidCount && (
+          <div className="p-4 rounded-md bg-bg-elevated">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-text-secondary">Address Group</span>
+                <span className="text-sm">
+                  {addressesGroup.find(g => g.id.toString() === addressGroup)?.name}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-text-secondary">Keys to Generate</span>
+                <span className="text-sm">{toCurrencyFormat(parsedCount, 0, 0)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="font-medium text-text-secondary">Initial State</span>
+                <span className="text-sm">Available</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <p>
+          Example output:
+          <br />
+          <div className="p-4 rounded-md bg-bg-elevated mt-2">
+            <pre className="whitespace-pre-wrap">{JSON.stringify([{ hex: '<pk1>' }, { hex: '<pk2>' }], null, 2)}</pre>
+          </div>
+        </p>
+
+        <Button
+          className="w-full h-[40px]"
+          onClick={handleGenerate}
+          disabled={status === 'loading' || !addressGroup || !isValidCount}
+        >
+          {status === 'loading' && <LoaderIcon className="animate-spin" />}
+          {status === 'form' && 'Generate & Download Keys'}
+        </Button>
+      </>
+    )
+  } else if (status === 'success') {
+    content = (
+      <>
+        <div className="relative flex h-[64px] mt-[-5px] gradient-border-green">
+          <div className="absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between">
+            <span className="text-[20px] text-text-secondary">Keys Generated</span>
+            <div className="flex flex-row items-center gap-2">
+              <p className="font-mono !text-[20px]">{toCurrencyFormat(keysGenerated, 0, 0)}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col bg-bg-elevated p-0 rounded-[8px]">
+          <span className="text-[14px] text-text-primary p-[11px_16px]">
+            You have successfully generated {keysGenerated} keys in the address group &quot;{
+              addressesGroup.find(a => a.id === Number(addressGroup))?.name
+            }&quot;. The keys file has been downloaded.
+          </span>
+        </div>
+
+        <Button
+          className="w-full h-[40px]"
+          onClick={() => {
+            setIsRedirecting(true)
+            router.push('/admin/keys')
+          }}
+        >
+          {isRedirecting && <LoaderIcon className="animate-spin" />}
+          {!isRedirecting && 'Close'}
+        </Button>
+      </>
+    )
+  } else if (status === 'error') {
+    content = (
+      <>
+        <div className="relative flex h-[64px] mt-[-5px] gradient-border-red">
+          <div className="absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between">
+            <span className="text-[20px] text-text-secondary">Oops! Something went wrong.</span>
+          </div>
+        </div>
+
+        {errorMessage && (
+          <div className="flex flex-col bg-bg-elevated p-0 rounded-[8px]">
+            <span className="text-[14px] text-text-primary p-[11px_16px]">{errorMessage}</span>
+          </div>
+        )}
+
+        <Button
+          className="w-full h-[40px]"
+          onClick={handleGenerate}
+        >
+          Try Again
+        </Button>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <OverrideSidebar>
+        <div className="flex flex-row justify-center w-full">
+          <div className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
+            <ActivityHeader
+              title="Generate Keys"
+              subtitle={status === 'success' ? '' : 'Generate new keys and download them as a JSON file.'}
+              onClose={() => setAbortDialogOpen(true)}
+              isDisabled={status === 'success'}
+            />
+            {content}
+          </div>
+        </div>
+      </OverrideSidebar>
+      <AbortConfirmationDialog
+        type="generate"
+        isOpen={isAbortDialogOpen}
+        onResponse={(abort) => {
+          setAbortDialogOpen(false)
+          if (abort) {
+            setIsRedirecting(true)
+            router.push('/admin/keys')
+          }
+        }}
+      />
+    </>
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/generate/GenerateForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/generate/GenerateForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 import type { AddressGroupWithDetails } from '@igniter/db/provider/schema'
-import React, { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import React, { useState, useEffect } from 'react'
+import { ListAddressGroups } from '@/actions/AddressGroups'
 import {
   Select,
   SelectContent,
@@ -12,26 +12,35 @@ import {
 import { LoaderIcon } from '@igniter/ui/assets'
 import { Button } from '@igniter/ui/components/button'
 import { toCurrencyFormat } from '@igniter/ui/lib/utils'
-import OverrideSidebar from '@igniter/ui/components/OverrideSidebar'
-import { ActivityHeader } from '@igniter/ui/components/ActivityHeader'
-import { AbortConfirmationDialog } from '@igniter/ui/components/AbortConfirmationDialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogFooter
+} from '@igniter/ui/components/dialog'
 import { GenerateKeys } from '@/actions/Keys'
 import {exportToJson} from '@/app/admin/(internal)/keys/exportUtils'
 
 
 interface GenerateFormProps {
-  addressesGroup: AddressGroupWithDetails[]
+  onClose: () => void
 }
 
-export default function GenerateForm({ addressesGroup }: GenerateFormProps) {
-  const router = useRouter()
-  const [isRedirecting, setIsRedirecting] = useState(false)
-  const [isAbortDialogOpen, setAbortDialogOpen] = useState(false)
+export default function GenerateForm({ onClose }: GenerateFormProps) {
+  const [addressesGroup, setAddressesGroup] = useState<AddressGroupWithDetails[]>([])
+  const [isDataLoading, setIsDataLoading] = useState(true)
   const [status, setStatus] = useState<'form' | 'loading' | 'success' | 'error'>('form')
   const [addressGroup, setAddressGroup] = useState<string>('')
   const [keyCount, setKeyCount] = useState<string>('')
   const [keysGenerated, setKeysGenerated] = useState(0)
   const [errorMessage, setErrorMessage] = useState('')
+
+  useEffect(() => {
+    ListAddressGroups().then(result => {
+      if (result.success) setAddressesGroup(result.data)
+      setIsDataLoading(false)
+    })
+  }, [])
 
   const parsedCount = parseInt(keyCount, 10)
   const isValidCount = !isNaN(parsedCount) && parsedCount >= 1 && parsedCount <= 10000
@@ -63,72 +72,77 @@ export default function GenerateForm({ addressesGroup }: GenerateFormProps) {
 
   let content: React.ReactNode
 
-  if (status === 'form' || status === 'loading') {
+  if (isDataLoading) {
+    content = (
+      <div className="flex items-center justify-center py-12">
+        <LoaderIcon className="animate-spin h-6 w-6 text-text-secondary" />
+      </div>
+    )
+  } else if (status === 'form' || status === 'loading') {
     content = (
       <>
-        <Select value={addressGroup} onValueChange={setAddressGroup}>
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select an address group" />
-          </SelectTrigger>
-          <SelectContent>
-            {addressesGroup.map(group => (
-              <SelectItem value={group.id.toString()} key={group.id}>
-                {group.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="flex flex-row items-center gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Address Group</label>
+          <Select value={addressGroup} onValueChange={setAddressGroup}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select an address group" />
+            </SelectTrigger>
+            <SelectContent>
+              {addressesGroup.map(group => (
+                <SelectItem value={group.id.toString()} key={group.id}>
+                  {group.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-        <div className="space-y-1.5">
-          <label className="text-sm font-medium text-text-secondary">Number of Keys</label>
+        <div className="flex flex-row items-center gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Number of Keys</label>
           <input
             type="number"
             min={1}
             max={10000}
             value={keyCount}
             onChange={(e) => setKeyCount(e.target.value)}
-            placeholder="Enter amount (1 - 10,000)"
+            placeholder="1 - 10,000"
             className="w-full h-9 rounded-lg border bg-(--input-bg) px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[color:--color-blue-1]"
           />
         </div>
 
         {addressGroup && isValidCount && (
-          <div className="p-4 rounded-md bg-bg-elevated">
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Address Group</span>
-                <span className="text-sm">
-                  {addressesGroup.find(g => g.id.toString() === addressGroup)?.name}
-                </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Keys to Generate</span>
-                <span className="text-sm">{toCurrencyFormat(parsedCount, 0, 0)}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Initial State</span>
-                <span className="text-sm">Available</span>
-              </div>
+          <div className="rounded-md border border-border-primary bg-bg-elevated">
+            <div className="flex flex-row items-center gap-3 px-4 py-2.5 border-b border-border-primary">
+              <span className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Address Group</span>
+              <span className="text-sm">{addressesGroup.find(g => g.id.toString() === addressGroup)?.name}</span>
+            </div>
+            <div className="flex flex-row items-center gap-3 px-4 py-2.5 border-b border-border-primary">
+              <span className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Keys to Generate</span>
+              <span className="text-sm">{toCurrencyFormat(parsedCount, 0, 0)}</span>
+            </div>
+            <div className="flex flex-row items-center gap-3 px-4 py-2.5">
+              <span className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Initial State</span>
+              <span className="text-sm">Available</span>
             </div>
           </div>
         )}
 
-        <p>
-          Example output:
-          <br />
-          <div className="p-4 rounded-md bg-bg-elevated mt-2">
-            <pre className="whitespace-pre-wrap">{JSON.stringify([{ hex: '<pk1>' }, { hex: '<pk2>' }], null, 2)}</pre>
+        <details className="group">
+          <summary className="text-sm text-text-secondary cursor-pointer select-none hover:text-text-primary transition-colors">
+            Example output
+          </summary>
+          <div className="mt-2 rounded-lg border border-border bg-[#0d1117] p-4 font-mono text-xs leading-relaxed overflow-x-auto">
+            <span className="text-[#8b949e]">{'['}</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'{'}</span>{'\n'}
+            {'    '}<span className="text-[#7ee787]">{'"hex"'}</span><span className="text-[#8b949e]">:</span> <span className="text-[#a5d6ff]">{'"<pk1>"'}</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'}'}</span><span className="text-[#8b949e]">,</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'{'}</span>{'\n'}
+            {'    '}<span className="text-[#7ee787]">{'"hex"'}</span><span className="text-[#8b949e]">:</span> <span className="text-[#a5d6ff]">{'"<pk2>"'}</span>{'\n'}
+            {'  '}<span className="text-[#8b949e]">{'}'}</span>{'\n'}
+            <span className="text-[#8b949e]">{']'}</span>
           </div>
-        </p>
+        </details>
 
-        <Button
-          className="w-full h-[40px]"
-          onClick={handleGenerate}
-          disabled={status === 'loading' || !addressGroup || !isValidCount}
-        >
-          {status === 'loading' && <LoaderIcon className="animate-spin" />}
-          {status === 'form' && 'Generate & Download Keys'}
-        </Button>
       </>
     )
   } else if (status === 'success') {
@@ -151,16 +165,6 @@ export default function GenerateForm({ addressesGroup }: GenerateFormProps) {
           </span>
         </div>
 
-        <Button
-          className="w-full h-[40px]"
-          onClick={() => {
-            setIsRedirecting(true)
-            router.push('/admin/keys')
-          }}
-        >
-          {isRedirecting && <LoaderIcon className="animate-spin" />}
-          {!isRedirecting && 'Close'}
-        </Button>
       </>
     )
   } else if (status === 'error') {
@@ -178,42 +182,58 @@ export default function GenerateForm({ addressesGroup }: GenerateFormProps) {
           </div>
         )}
 
-        <Button
-          className="w-full h-[40px]"
-          onClick={handleGenerate}
-        >
-          Try Again
-        </Button>
       </>
     )
   }
 
   return (
-    <>
-      <OverrideSidebar>
-        <div className="flex flex-row justify-center w-full">
-          <div className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8">
-            <ActivityHeader
-              title="Generate Keys"
-              subtitle={status === 'success' ? '' : 'Generate new keys and download them as a JSON file.'}
-              onClose={() => setAbortDialogOpen(true)}
-              isDisabled={status === 'success'}
-            />
-            {content}
+    <Dialog open={true}>
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        hideClose
+        className="gap-0 p-0 rounded-lg bg-bg-elevated sm:max-w-xl max-h-[85vh] overflow-hidden"
+      >
+        <DialogTitle asChild>
+          <div className="flex flex-row justify-between items-center py-3 px-5">
+            <span className="text-sm font-semibold">Generate Keys</span>
           </div>
+        </DialogTitle>
+        <div className="h-px bg-border-primary" />
+
+        <div className="flex flex-col gap-5 p-6 overflow-y-auto max-h-[calc(85vh-110px)]">
+          {content}
         </div>
-      </OverrideSidebar>
-      <AbortConfirmationDialog
-        type="generate"
-        isOpen={isAbortDialogOpen}
-        onResponse={(abort) => {
-          setAbortDialogOpen(false)
-          if (abort) {
-            setIsRedirecting(true)
-            router.push('/admin/keys')
-          }
-        }}
-      />
-    </>
+
+        <DialogFooter className="flex flex-row justify-end gap-2 px-5 py-3 border-t border-border-primary">
+          {status === 'success' ? (
+            <Button onClick={onClose}>
+              Close
+            </Button>
+          ) : status === 'error' ? (
+            <>
+              <Button variant="outline" onClick={() => onClose()}>
+                Cancel
+              </Button>
+              <Button onClick={handleGenerate}>
+                Try Again
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" onClick={() => onClose()}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleGenerate}
+                disabled={status === 'loading' || !addressGroup || !isValidCount}
+              >
+                {status === 'loading' && <LoaderIcon className="animate-spin" />}
+                {status === 'form' && 'Generate & Download Keys'}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/provider/src/app/admin/(internal)/keys/generate/page.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/generate/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next'
+import { GetAppName } from '@/actions/ApplicationSettings'
+import { ListAddressGroups } from '@/actions/AddressGroups'
+import GenerateForm from './GenerateForm'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const appName = await GetAppName()
+
+  return {
+    title: `Generate Keys - ${appName}`,
+    description: "Generate new keys for an address group",
+  }
+}
+
+export default async function GeneratePage() {
+  const result = await ListAddressGroups()
+
+  if (!result.success) {
+    throw new Error(result.error.message)
+  }
+
+  return (
+    <GenerateForm addressesGroup={result.data} />
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/import/ImportForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/import/ImportForm.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import type {AddressGroupWithDetails} from '@igniter/db/provider/schema'
-import { ActivityHeader } from '@igniter/ui/components/ActivityHeader'
-import { useRouter } from 'next/navigation'
-import { AbortConfirmationDialog } from '@igniter/ui/components/AbortConfirmationDialog'
-import React, { useState } from 'react'
+import { Dialog, DialogContent, DialogTitle, DialogFooter } from '@igniter/ui/components/dialog'
+import React, { useEffect, useState } from 'react'
+import { ListAddressGroups } from '@/actions/AddressGroups'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@igniter/ui/components/select'
 import { Dropzone, DropZoneArea, DropzoneTrigger, useDropzone } from '@igniter/ui/components/dropzone'
 import { CloudUploadIcon, FileWarning } from 'lucide-react'
@@ -12,7 +11,6 @@ import ImportProcess, { ImportProcessStatus } from '@/app/admin/(internal)/keys/
 import { Button } from '@igniter/ui/components/button'
 import { toCurrencyFormat } from '@igniter/ui/lib/utils'
 import { LoaderIcon } from '@igniter/ui/assets'
-import OverrideSidebar from '@igniter/ui/components/OverrideSidebar'
 
 const errorsMap: Record<keyof ImportProcessStatus, string> = {
   validateFile: 'There was an error trying to validate the file. Please try again.',
@@ -20,13 +18,12 @@ const errorsMap: Record<keyof ImportProcessStatus, string> = {
 };
 
 interface ImportFormProps {
-  addressesGroup: AddressGroupWithDetails[]
+  onClose: () => void
 }
 
-export default function ImportForm({addressesGroup}: ImportFormProps) {
-  const router = useRouter()
-  const [isRedirecting, setIsRedirecting] = useState<boolean>(false);
-  const [isAbortDialogOpen, setAbortDialogOpen] = useState(false)
+export default function ImportForm({onClose}: ImportFormProps) {
+  const [addressesGroup, setAddressesGroup] = useState<AddressGroupWithDetails[]>([])
+  const [isDataLoading, setIsDataLoading] = useState(true)
   const [status, setStatus] = useState<'form' | 'success'>('form')
   const [addressGroup, setAddressGroup] = useState<string>('')
   const [file, setFile] = useState<File | null>(null)
@@ -34,6 +31,13 @@ export default function ImportForm({addressesGroup}: ImportFormProps) {
   const [showInvalidFileMessage, setShowInvalidFileMessage] = useState(false)
   const [showKeysAlreadyExistsMessage, setShowKeysAlreadyExistsMessage] = useState(false)
   const [importErrorMessage, setImportErrorMessage] = useState('')
+
+  useEffect(() => {
+    ListAddressGroups().then(result => {
+      if (result.success) setAddressesGroup(result.data)
+      setIsDataLoading(false)
+    })
+  }, [])
 
   const dropzone = useDropzone({
     validation: {
@@ -71,9 +75,17 @@ export default function ImportForm({addressesGroup}: ImportFormProps) {
     }
   }
 
+  const hasError = showInvalidFileMessage || showKeysAlreadyExistsMessage
+
   let content: React.ReactNode;
 
-  if (status === 'form') {
+  if (isDataLoading) {
+    content = (
+      <div className="flex items-center justify-center py-12">
+        <LoaderIcon className="size-6 animate-spin text-text-tertiary" />
+      </div>
+    )
+  } else if (status === 'form') {
     content = (
       <>
         {importErrorMessage && (
@@ -84,76 +96,92 @@ export default function ImportForm({addressesGroup}: ImportFormProps) {
           </div>
         )}
 
-        <Select value={addressGroup} onValueChange={setAddressGroup}>
-          <SelectTrigger className={'w-full'}>
-            <SelectValue placeholder={'Select an address group'} />
-          </SelectTrigger>
-          <SelectContent>
-            {addressesGroup.map((addressGroup) => (
-              <SelectItem value={addressGroup.id.toString()} key={addressGroup.id.toString()}>
-                {addressGroup.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="flex flex-row items-center gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Address Group</label>
+          <Select value={addressGroup} onValueChange={setAddressGroup}>
+            <SelectTrigger className={'w-full'}>
+              <SelectValue placeholder={'Select an address group'} />
+            </SelectTrigger>
+            <SelectContent>
+              {addressesGroup.map((addressGroup) => (
+                <SelectItem value={addressGroup.id.toString()} key={addressGroup.id.toString()}>
+                  {addressGroup.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
         {addressGroup && (
-          <div className="p-4 rounded-md bg-bg-elevated">
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Name</span>
-                <span className="text-sm">
-          {addressesGroup.find(group => group.id.toString() === addressGroup)?.name}
-        </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="font-medium text-text-secondary">Visibility</span>
-                <span className="text-sm">
-          {addressesGroup.find(group => group.id.toString() === addressGroup)?.private ? 'Private' : 'Public'}
-        </span>
-              </div>
+          <div className="rounded-md border border-border-primary bg-bg-elevated">
+            <div className="flex flex-row items-center gap-3 px-4 py-2.5 border-b border-border-primary">
+              <span className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Name</span>
+              <span className="text-sm">
+                {addressesGroup.find(group => group.id.toString() === addressGroup)?.name}
+              </span>
+            </div>
+            <div className="flex flex-row items-center gap-3 px-4 py-2.5">
+              <span className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Visibility</span>
+              <span className="text-sm">
+                {addressesGroup.find(group => group.id.toString() === addressGroup)?.private ? 'Private' : 'Public'}
+              </span>
             </div>
           </div>
         )}
 
         <Dropzone {...dropzone}>
-          <DropZoneArea>
+          <DropZoneArea className="w-full !border-0 bg-transparent p-0">
             <DropzoneTrigger
-              className={'flex flex-col items-center gap-4 bg-transparent p-10 text-center text-sm'}
+              className={`flex flex-col items-center gap-2 w-full py-8 text-center text-sm cursor-pointer rounded-lg border border-dashed transition-colors ${
+                hasError
+                  ? 'border-red-500/50 bg-red-500/5'
+                  : file
+                    ? 'border-blue-500/50 bg-blue-500/5'
+                    : 'border-border bg-bg-surface/50 hover:bg-bg-hover/50'
+              }`}
             >
-              <CloudUploadIcon className="size-8" />
-              <div>
-                <p className="font-semibold">
-                  {file ? (<span>
-                    Uploaded file: <span className={'bg-bg-elevated px-2 py-0.5 rounded-[8px]'}>
-                      {file.name}
-                    </span>
-                  </span>) : 'Upload your keys json file'}
-                </p>
-                <p className="!text-xs text-muted-foreground mt-2">
-                  This file must be a json containing an array of hex private keys.
-                </p>
+              <div className={`flex items-center justify-center w-10 h-10 rounded-full mb-1 ${
+                hasError
+                  ? 'bg-red-500/10'
+                  : 'bg-blue-500/10'
+              }`}>
+                {hasError ? (
+                  <FileWarning className="size-5 text-red-400" />
+                ) : (
+                  <CloudUploadIcon className="size-5 text-blue-400" />
+                )}
               </div>
+              {hasError ? (
+                <div>
+                  <p className="text-sm font-medium text-red-400">
+                    {showInvalidFileMessage ? 'Invalid file format' : 'Keys already exist'}
+                  </p>
+                  <p className="text-xs text-text-tertiary mt-1">
+                    {showInvalidFileMessage
+                      ? 'Must be a JSON array of hex private keys'
+                      : 'This file contains keys that are already saved'}
+                  </p>
+                  <p className="text-xs text-text-tertiary mt-2">Click or drag to try another file</p>
+                </div>
+              ) : file ? (
+                <div>
+                  <p className="text-sm font-medium text-blue-400">{file.name}</p>
+                  <p className="text-xs text-text-tertiary mt-1">Click or drag to replace</p>
+                </div>
+              ) : (
+                <div>
+                  <p className="text-sm font-medium text-text-primary">
+                    Click to upload or drag and drop
+                  </p>
+                  <p className="text-xs text-text-tertiary mt-1">
+                    JSON file containing an array of hex private keys
+                  </p>
+                </div>
+              )}
             </DropzoneTrigger>
           </DropZoneArea>
         </Dropzone>
-        {(showInvalidFileMessage || showKeysAlreadyExistsMessage) && (
-          <div className={'flex flex-row items-center gap-2 mt-[-24px]'}>
-            <FileWarning className={'text-[color:var(--warning)]'} />
-            <p className={'!text-xs'}>
-              {showInvalidFileMessage ?
-                'The file you uploaded is not valid. It must be a json containing an array of hex private keys.' :
-                'The file you uploaded contains keys that are already saved. Please select a different file.'
-              }
-            </p>
-          </div>
-        )}
 
-        <ImportProcess
-          addressGroupId={addressGroup}
-          file={file!}
-          onImportCompleted={onImportCompleted}
-        />
       </>
     )
   } else {
@@ -181,51 +209,49 @@ export default function ImportForm({addressesGroup}: ImportFormProps) {
           }".
           </span>
         </div>
-
-        <Button
-          className="w-full h-[40px]"
-          onClick={() => {
-            setIsRedirecting(true)
-            router.push('/admin/keys')
-          }}
-        >
-          {isRedirecting && (
-            <LoaderIcon className="animate-spin"/>
-          )}
-          {!isRedirecting && 'Close'}
-        </Button>
       </>
     )
   }
 
   return (
-    <>
-      <OverrideSidebar>
-        <div className="flex flex-row justify-center w-full">
-          <div
-            className="flex flex-col w-[480px] border-x border-b border-[--balck-deviders] bg-[--black-1] p-[33px] rounded-b-[12px] gap-8"
-          >
-            <ActivityHeader
-              title="Import Addresses"
-              subtitle={status === 'success' ? '' : 'Select the address group and import your keys json file.'}
-              onClose={() => setAbortDialogOpen(true)}
-              isDisabled={status === 'success'}
-            />
-
-            {content}
+    <Dialog open={true}>
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        hideClose
+        className="gap-0 p-0 rounded-lg bg-bg-elevated sm:max-w-xl max-h-[85vh] overflow-hidden"
+      >
+        <DialogTitle asChild>
+          <div className="py-3 px-5">
+            <span className="text-sm font-semibold">
+              {status === 'success' ? 'Import Complete' : 'Import Addresses'}
+            </span>
           </div>
+        </DialogTitle>
+
+        <div className="h-px bg-border-primary" />
+
+        <div className="flex flex-col gap-5 p-6 overflow-y-auto max-h-[calc(85vh-110px)]">
+          {content}
         </div>
-      </OverrideSidebar>
-      <AbortConfirmationDialog
-        type={'import'}
-        isOpen={isAbortDialogOpen}
-        onResponse={(abort) => {
-          setAbortDialogOpen(false);
-          if (abort) {
-            router.push('/admin/keys')
-          }
-        }}
-      />
-    </>
+
+        <div className="h-px bg-border-primary" />
+        <DialogFooter className="px-5 py-3 flex flex-row items-center gap-2">
+          <div className="flex-1" />
+          <Button
+            variant="outline"
+            onClick={onClose}
+          >
+            {status === 'success' ? 'Close' : 'Cancel'}
+          </Button>
+          {status === 'form' && (
+            <ImportProcess
+              addressGroupId={addressGroup}
+              file={file!}
+              onImportCompleted={onImportCompleted}
+            />
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/provider/src/app/admin/(internal)/keys/import/ImportProcess.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/import/ImportProcess.tsx
@@ -15,7 +15,6 @@ import {
 import { Button } from '@igniter/ui/components/button'
 import { CheckSuccess, LoaderIcon, XIcon } from '@igniter/ui/assets'
 import { FileWarning } from 'lucide-react'
-import {useNotifications} from "@igniter/ui/context/Notifications/index";
 import {isValidPrivateKey} from '@igniter/pocket/utils';
 type StageStatus = 'pending' | 'success' | 'error' | 'invalid';
 
@@ -47,7 +46,7 @@ export default function ImportProcess({file, addressGroupId, onImportCompleted}:
     importKeys: 'pending',
   });
   const [keys, setKeys] = useState<Array<string>>([]);
-  const { addNotification } = useNotifications();
+
 
   function handleOpenChanged(open: boolean) {
     setOpen(open);
@@ -74,15 +73,6 @@ export default function ImportProcess({file, addressGroupId, onImportCompleted}:
         handleOpenChanged(false);
         return currentStatus;
       });
-
-      if (message) {
-        addNotification({
-          id: `import-keys-process-${stageName}-error`,
-          type: 'error',
-          showTypeIcon: true,
-          content: message,
-        });
-      }
     }, 1000);
   }
 
@@ -184,7 +174,7 @@ export default function ImportProcess({file, addressGroupId, onImportCompleted}:
   return (
     <Dialog open={open} onOpenChange={handleOpenChanged}>
       <DialogTrigger asChild>
-        <Button>Import Keys</Button>
+        <Button disabled={!addressGroupId || !file}>Import Keys</Button>
       </DialogTrigger>
       <DialogContent
         onInteractOutside={(event) => event.preventDefault()}

--- a/apps/provider/src/app/admin/(internal)/keys/page.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/page.tsx
@@ -37,6 +37,9 @@ export default async function AddressesPage() {
               <Link href={'/admin/keys/export'}>
                 <Button className="bg-pnf-mint text-gray-900 border-transparent hover:opacity-90">Export</Button>
               </Link>
+              <Link href={'/admin/keys/generate'}>
+                <Button className="bg-pnf-mint text-gray-900 border-transparent hover:opacity-90">Generate</Button>
+              </Link>
               <RequestRemediationButton />
               <ClearRemediationButton />
               <div className="w-px h-6 bg-border-primary" />

--- a/apps/provider/src/app/admin/(internal)/keys/page.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/page.tsx
@@ -1,12 +1,11 @@
 import type { Metadata } from 'next'
 import React from 'react'
 import KeysTable from '@/app/admin/(internal)/keys/table'
-import { Button } from '@igniter/ui/components/button'
-import Link from 'next/link'
 import { GetAppName } from '@/actions/ApplicationSettings'
 import ClearRemediationButton from '@/app/admin/(internal)/keys/ClearRemediationButton'
 import AutoStakeToggle from '@/app/admin/(internal)/keys/AutoStakeToggle'
 import RequestRemediationButton from '@/app/admin/(internal)/keys/RequestRemediationButton'
+import KeyActions from '@/app/admin/(internal)/keys/KeyActions'
 
 export const dynamic = "force-dynamic";
 
@@ -31,15 +30,7 @@ export default async function AddressesPage() {
               </p>
             </div>
             <div className="flex flex-row gap-3 items-center">
-              <Link href={'/admin/keys/import'}>
-                <Button>Import</Button>
-              </Link>
-              <Link href={'/admin/keys/export'}>
-                <Button className="bg-pnf-mint text-gray-900 border-transparent hover:opacity-90">Export</Button>
-              </Link>
-              <Link href={'/admin/keys/generate'}>
-                <Button className="bg-pnf-mint text-gray-900 border-transparent hover:opacity-90">Generate</Button>
-              </Link>
+              <KeyActions />
               <RequestRemediationButton />
               <ClearRemediationButton />
               <div className="w-px h-6 bg-border-primary" />

--- a/apps/provider/src/app/admin/(internal)/keys/table/columns.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/table/columns.tsx
@@ -1,7 +1,10 @@
+import React from 'react'
 import { ColumnDef } from "@igniter/ui/components/table";
 import { KeyState } from '@igniter/db/provider/enums'
 import { FilterGroup, SortOption } from '@igniter/ui/components/DataTable/index'
 import Address from '@igniter/ui/components/Address'
+import AvatarByString from '@igniter/ui/components/AvatarByString'
+import { getShortAddress } from '@igniter/ui/lib/utils'
 import {KeyStateLabels} from "@/app/admin/(internal)/keys/constants";
 import {useAddItemToDetail} from "@igniter/ui/components/QuickDetails/Provider";
 import {Button} from "@igniter/ui/components/button";
@@ -20,6 +23,7 @@ export interface Key {
   ownerAddress: string | null
   delegator: {
     name: string
+    identity: string
   } | null
   createdAt: Date
 }
@@ -61,12 +65,15 @@ export const columns: Array<ColumnDef<KeyWithRelations> & CsvColumnDef<KeyWithRe
       const ownerAddress = row.getValue("ownerAddress") as string;
 
       if (!ownerAddress) {
-        return 'Owner Not Set';
+        return <span className="text-text-tertiary">Owner Not Set</span>;
       }
 
-      return (
-          <Address address={ownerAddress} />
-      );
+      return <Address address={ownerAddress} showAvatar />;
+    },
+    filterFn: (row, _columnId, value) => {
+      const ownerAddress = row.getValue("ownerAddress") as string;
+      if (value === '__none__') return !ownerAddress;
+      return ownerAddress === value;
     },
   },
   {
@@ -98,7 +105,13 @@ export const columns: Array<ColumnDef<KeyWithRelations> & CsvColumnDef<KeyWithRe
           {delegator?.name || '-'}
         </span>
       );
-    }
+    },
+    filterFn: (row, _columnId, value) => {
+      const delegator = row.getValue("delegator") as Key['delegator'];
+      if (value === '__none__') return !delegator;
+      if (!delegator) return false;
+      return delegator.identity === value;
+    },
   },
   {
     accessorKey: "createdAt",
@@ -142,32 +155,86 @@ export const columns: Array<ColumnDef<KeyWithRelations> & CsvColumnDef<KeyWithRe
   },
 ]
 
-export function getFilters(addressesGroup: AddressGroup[]): Array<FilterGroup<KeyWithRelations>> {
- return [
-   {
-     group: "state",
-     items: [
-       [{label: "All Keys", value: "", column: "state", isDefault: true}],
+export function getFilters(addressesGroup: AddressGroup[], keys: KeyWithRelations[]): Array<FilterGroup<KeyWithRelations>> {
+  const distinctOwners = [...new Set(keys.map(k => k.ownerAddress).filter(Boolean))] as string[]
+  const delegatorMap = new Map<string, string>()
+  for (const key of keys) {
+    if (key.delegator) {
+      delegatorMap.set(key.delegator.identity, key.delegator.name)
+    }
+  }
 
-       (Object.values(KeyState).map((state) => ({
-         label: KeyStateLabels[state],
-         value: state,
-         column: "state"
-       })))
-     ]
-   },
-   {
-     group: 'addressGroup',
-     items: [
-       [{label: "All Address Groups", value: "", column: "addressGroup", isDefault: true}],
-       (addressesGroup.map((addressGroup: { name: any; id: any; }) => ({
-         label: addressGroup.name,
-         value: addressGroup.id,
-         column: "addressGroup"
-       })))
-     ]
-   }
- ]
+  const filters: Array<FilterGroup<KeyWithRelations>> = [
+    {
+      group: "state",
+      items: [
+        [{label: "All Keys", value: "", column: "state", isDefault: true}],
+        (Object.values(KeyState).map((state) => ({
+          label: KeyStateLabels[state],
+          value: state,
+          column: "state"
+        })))
+      ]
+    },
+    {
+      group: 'addressGroup',
+      items: [
+        [{label: "All Address Groups", value: "", column: "addressGroup", isDefault: true}],
+        (addressesGroup.map((addressGroup: { name: any; id: any; }) => ({
+          label: addressGroup.name,
+          value: addressGroup.id,
+          column: "addressGroup"
+        })))
+      ]
+    },
+  ]
+
+  const hasKeysWithoutOwner = keys.some(k => !k.ownerAddress)
+  const hasKeysWithoutDelegator = keys.some(k => !k.delegator)
+
+  if (distinctOwners.length > 0 || hasKeysWithoutOwner) {
+    filters.push({
+      group: 'ownerAddress',
+      items: [
+        [{label: "All Owners", value: "", column: "ownerAddress", isDefault: true}],
+        [
+          ...(hasKeysWithoutOwner ? [{
+            label: "No Owner",
+            value: "__none__",
+            column: "ownerAddress" as keyof KeyWithRelations,
+          }] : []),
+          ...distinctOwners.map((owner) => ({
+            label: <><AvatarByString string={owner} size={14} />{getShortAddress(owner, 5)}</>,
+            value: owner,
+            column: "ownerAddress" as keyof KeyWithRelations,
+          })),
+        ]
+      ]
+    })
+  }
+
+  if (delegatorMap.size > 0 || hasKeysWithoutDelegator) {
+    filters.push({
+      group: 'delegator',
+      items: [
+        [{label: "All Delegators", value: "", column: "delegator", isDefault: true}],
+        [
+          ...(hasKeysWithoutDelegator ? [{
+            label: "No Delegator",
+            value: "__none__",
+            column: "delegator" as keyof KeyWithRelations,
+          }] : []),
+          ...[...delegatorMap.entries()].map(([identity, name]) => ({
+            label: name,
+            value: identity,
+            column: "delegator" as keyof KeyWithRelations,
+          })),
+        ]
+      ]
+    })
+  }
+
+  return filters
 }
 
 export const sorts: Array<Array<SortOption<KeyWithRelations>>> = [

--- a/apps/provider/src/app/admin/(internal)/keys/table/index.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/table/index.tsx
@@ -67,13 +67,13 @@ export default function KeysTable() {
     <DataTable
       columns={columns}
       data={keys}
-      filters={getFilters(data?.addressesGroup || [])}
+      filters={getFilters(data?.addressesGroup || [], keys)}
       sorts={sorts}
       isLoading={isLoading}
       isError={isError}
       refetch={refetch}
-      searchableColumns={['address', 'ownerAddress']}
-      searchPlaceholder="Search by address or owner..."
+      searchableColumns={['address', 'ownerAddress', 'delegator']}
+      searchPlaceholder="Search by address, owner, or delegator..."
       countLabel="keys"
       headerLeft={
         newCount > 0 ? (

--- a/apps/provider/src/app/admin/details/KeyDetail/index.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/index.tsx
@@ -51,7 +51,7 @@ export default function KeyDetail(key: KeyWithRelations) {
     },
     isStakedKey && {
       label: 'Owner',
-      value: ownerAddress ? <Address address={ownerAddress ?? ''} /> : 'N/A',
+      value: ownerAddress ? <Address address={ownerAddress} showAvatar /> : 'N/A',
     },
     delegator && {
       label: 'Delivered To',

--- a/apps/provider/src/lib/dal/addressGroups.ts
+++ b/apps/provider/src/lib/dal/addressGroups.ts
@@ -183,3 +183,10 @@ export async function simpleList() {
   const dbClient = getDbClient()
   return dbClient.db.query.addressGroupTable.findMany()
 }
+
+export async function findById(id: number): Promise<AddressGroup | undefined> {
+  const dbClient = getDbClient()
+  return dbClient.db.query.addressGroupTable.findFirst({
+    where: eq(addressGroupTable.id, id),
+  })
+}

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -11,8 +11,13 @@ import {
   and,
   count,
   eq,
+  gte,
   inArray,
+  isNotNull,
+  isNull,
+  lte,
   sql,
+  type SQL,
 } from 'drizzle-orm'
 import { NodePgQueryResultHKT } from 'drizzle-orm/node-postgres'
 
@@ -429,4 +434,100 @@ export async function listKeysByAddresses(addresses: string[]): Promise<KeyWithG
       },
     },
   })
+}
+
+export interface KeyExportFilters {
+  addressGroupId?: number
+  states?: KeyState[]
+  ownerAddress?: string
+  delegatorIdentity?: string
+  dateFrom?: Date
+  dateTo?: Date
+  dateField?: 'createdAt' | 'deliveredAt'
+  exportStatus?: 'not_exported' | 'previously_exported' | 'all'
+}
+
+function buildExportFilterConditions(filters: KeyExportFilters): SQL[] {
+  const conditions: SQL[] = []
+
+  if (filters.addressGroupId) {
+    conditions.push(eq(keysTable.addressGroupId, filters.addressGroupId))
+  }
+
+  if (filters.states && filters.states.length > 0) {
+    conditions.push(inArray(keysTable.state, filters.states))
+  }
+
+  if (filters.ownerAddress) {
+    conditions.push(eq(keysTable.ownerAddress, filters.ownerAddress))
+  }
+
+  if (filters.delegatorIdentity) {
+    conditions.push(eq(keysTable.deliveredTo, filters.delegatorIdentity))
+  }
+
+  const dateColumn = filters.dateField === 'deliveredAt' ? keysTable.deliveredAt : keysTable.createdAt
+
+  if (filters.dateFrom) {
+    conditions.push(gte(dateColumn, filters.dateFrom))
+  }
+
+  if (filters.dateTo) {
+    conditions.push(lte(dateColumn, filters.dateTo))
+  }
+
+  if (filters.exportStatus === 'not_exported') {
+    conditions.push(isNull(keysTable.exportedAt))
+  } else if (filters.exportStatus === 'previously_exported') {
+    conditions.push(isNotNull(keysTable.exportedAt))
+  }
+
+  return conditions
+}
+
+export async function countKeysForExport(filters: KeyExportFilters): Promise<number> {
+  const dbClient = getDbClient()
+  const conditions = buildExportFilterConditions(filters)
+
+  const [result] = await dbClient.db.select({ count: count() })
+    .from(keysTable)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+
+  return Number(result?.count || 0)
+}
+
+export async function listKeysForExport(filters: KeyExportFilters) {
+  const dbClient = getDbClient()
+  const conditions = buildExportFilterConditions(filters)
+
+  return dbClient.db.query.keysTable.findMany({
+    ...(conditions.length > 0 && { where: and(...conditions) }),
+    columns: {
+      id: true,
+      privateKey: true,
+    },
+  })
+}
+
+export async function markKeysExported(keyIds: number[]): Promise<void> {
+  if (keyIds.length === 0) return
+  const dbClient = getDbClient()
+  await dbClient.db.update(keysTable)
+    .set({
+      exportedAt: new Date(),
+      exportCount: sql`COALESCE(${keysTable.exportCount}, 0) + 1`,
+    })
+    .where(inArray(keysTable.id, keyIds))
+}
+
+export async function listDistinctOwnerAddresses(): Promise<string[]> {
+  const dbClient = getDbClient()
+  const results = await dbClient.db
+    .selectDistinct({ ownerAddress: keysTable.ownerAddress })
+    .from(keysTable)
+    .where(isNotNull(keysTable.ownerAddress))
+
+  return results
+    .map(r => r.ownerAddress)
+    .filter((addr): addr is string => Boolean(addr)) as string[]
 }

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -16,6 +16,7 @@ import {
   isNotNull,
   isNull,
   lte,
+  ne,
   sql,
   type SQL,
 } from 'drizzle-orm'
@@ -525,9 +526,9 @@ export async function listDistinctOwnerAddresses(): Promise<string[]> {
   const results = await dbClient.db
     .selectDistinct({ ownerAddress: keysTable.ownerAddress })
     .from(keysTable)
-    .where(isNotNull(keysTable.ownerAddress))
+    .where(and(isNotNull(keysTable.ownerAddress), ne(keysTable.ownerAddress, '')))
 
   return results
     .map(r => r.ownerAddress)
-    .filter((addr): addr is string => Boolean(addr)) as string[]
+    .filter((addr): addr is string => Boolean(addr))
 }

--- a/packages/db/src/provider/schema/keys.ts
+++ b/packages/db/src/provider/schema/keys.ts
@@ -160,11 +160,7 @@ export const keysRelations = relations(keysTable, ({ one }) => ({
  *
  * This type is generated dynamically based on the schema of `keysTable`.
  */
-type KeyBase = typeof keysTable.$inferSelect;
-export type Key = Omit<KeyBase, 'exportedAt' | 'exportCount'> & {
-  exportedAt?: Date | null;
-  exportCount?: number | null;
-};
+export type Key = typeof keysTable.$inferSelect;
 
 /**
  * Type alias representing the inferred type for inserting data into the keys table.

--- a/packages/db/src/provider/schema/keys.ts
+++ b/packages/db/src/provider/schema/keys.ts
@@ -128,6 +128,8 @@ export const keysTable = pgTable('keys', {
   stakeAmountUpokt: bigint({ mode: 'bigint' }).default(0n),
   balanceUpokt: bigint({ mode: 'bigint' }).default(0n),
   services: json('services').$type<SupplierServiceConfig[]>().default([]),
+  exportedAt: timestamp(),
+  exportCount: integer().default(0),
 })
 
 /**
@@ -158,7 +160,11 @@ export const keysRelations = relations(keysTable, ({ one }) => ({
  *
  * This type is generated dynamically based on the schema of `keysTable`.
  */
-export type Key = typeof keysTable.$inferSelect;
+type KeyBase = typeof keysTable.$inferSelect;
+export type Key = Omit<KeyBase, 'exportedAt' | 'exportCount'> & {
+  exportedAt?: Date | null;
+  exportCount?: number | null;
+};
 
 /**
  * Type alias representing the inferred type for inserting data into the keys table.

--- a/packages/domain/src/provider/utils/__fixtures__/supplier-data.ts
+++ b/packages/domain/src/provider/utils/__fixtures__/supplier-data.ts
@@ -82,6 +82,8 @@ function makeKeyWithGroup(overrides: Record<string, unknown>): KeyWithGroup {
     stakeAmountUpokt: 100000000n,
     balanceUpokt: 50000000n,
     services: [],
+    exportedAt: null,
+    exportCount: null,
     addressGroup: {
       id: 1,
       name: 'default-group',

--- a/packages/ui/src/components/AbortConfirmationDialog.tsx
+++ b/packages/ui/src/components/AbortConfirmationDialog.tsx
@@ -12,7 +12,7 @@ import {LoaderIcon} from "../assets";
 export interface AbortConfirmationDialogProps {
     isOpen: boolean;
     onResponse: (abort: boolean) => void;
-    type?: 'stake' | 'unstake' | 'migration' | 'import' | 'export';
+    type?: 'stake' | 'unstake' | 'migration' | 'import' | 'export' | 'generate';
     isLoading?: boolean;
 }
 

--- a/packages/ui/src/components/Address.tsx
+++ b/packages/ui/src/components/Address.tsx
@@ -2,6 +2,7 @@
 import { Button } from './button'
 import CopyIcon from '../assets/icons/dark/copy.svg'
 import CheckIcon from '../assets/icons/dark/check_success.svg'
+import AvatarByString from './AvatarByString'
 import React from 'react'
 import { getShortAddress } from '../lib/utils'
 import { clsx } from 'clsx'
@@ -9,9 +10,10 @@ import { clsx } from 'clsx'
 interface AddressProps {
   address: string;
   onClick?: (address: string) => void;
+  showAvatar?: boolean;
 }
 
-export default function Address({address, onClick}: AddressProps) {
+export default function Address({address, onClick, showAvatar}: AddressProps) {
   const [isCopied, setIsCopied] = React.useState(false);
 
   const handleCopy = () => {
@@ -23,6 +25,7 @@ export default function Address({address, onClick}: AddressProps) {
 
   return (
     <div className={'flex items-center gap-3'}>
+      {showAvatar && <AvatarByString string={address} size={18} />}
       <Button
         variant={'link'}
         className={

--- a/packages/ui/src/components/DataTable/FilterDropdown.tsx
+++ b/packages/ui/src/components/DataTable/FilterDropdown.tsx
@@ -13,7 +13,7 @@ interface FilterDropdownProps<TData> {
   filterGroup: {
     group: string;
     items: Array<{
-      label: string;
+      label: React.ReactNode;
       value: string | number | boolean;
       column: keyof TData;
       isDefault?: boolean;
@@ -21,7 +21,7 @@ interface FilterDropdownProps<TData> {
   };
   columnFilters: ColumnFiltersState;
   table: Table<TData>;
-  defaultLabel: string;
+  defaultLabel: React.ReactNode;
   disabled?: boolean;
 }
 
@@ -32,8 +32,11 @@ export default function FilterDropdown<TData>({
   defaultLabel,
   disabled
                                               }: FilterDropdownProps<TData>) {
+  const columnId = String(filterGroup.items.flat()[0]?.column ?? '');
+
   const isFilterActive = (filterValue: string | number | boolean) => {
     return columnFilters.some((activeFilter) => {
+      if (activeFilter.id !== columnId) return false;
       if (typeof filterValue === "boolean") {
         const activeValue = activeFilter.value === "true" ? true :
           activeFilter.value === "false" ? false :
@@ -44,15 +47,16 @@ export default function FilterDropdown<TData>({
     });
   };
 
-  const activeFilterLabel = filterGroup.items
-    .flat()
-    .find((filter) => isFilterActive(filter.value))?.label || defaultLabel;
+  const activeFilter = columnFilters.find((f) => f.id === columnId);
+  const activeFilterLabel = activeFilter
+    ? filterGroup.items.flat().find((filter) => filter.value === activeFilter.value)?.label || defaultLabel
+    : defaultLabel;
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger disabled={disabled}>
         <div className="flex items-center gap-2 py-2 px-4">
-          <span className="text-sm">{activeFilterLabel}</span>
+          <span className="text-sm flex items-center gap-2">{activeFilterLabel}</span>
         </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top">
@@ -63,19 +67,14 @@ export default function FilterDropdown<TData>({
                 key={String(filter.value)}
                 className="min-w-[130px] px-4 py-2 cursor-pointer rounded-lg flex items-center justify-between hover:bg-bg-hover"
                 onClick={() => {
-                  if (filter.value === "") {
-                    table.resetColumnFilters();
-                  } else {
-                    table.setColumnFilters((_) => [
-                      {
-                        id: String(filter.column),
-                        value: filter.value,
-                      },
-                    ]);
-                  }
+                  table.setColumnFilters((prev) => {
+                    const without = prev.filter((f) => f.id !== columnId);
+                    if (filter.value === "") return without;
+                    return [...without, { id: columnId, value: filter.value }];
+                  });
                 }}
               >
-                <span className="text-sm">{filter.label}</span>
+                <span className="text-sm flex items-center gap-2">{filter.label}</span>
                 {isFilterActive(filter.value) && <CheckSmallIcon />}
               </DropdownMenuItem>
             ))}

--- a/packages/ui/src/components/DataTable/index.tsx
+++ b/packages/ui/src/components/DataTable/index.tsx
@@ -31,7 +31,7 @@ import ExportButton from '../ExportButton'
 import RowsPerPage from './RowsPerPage'
 
 export interface FilterItem<TData> {
-  label: string;
+  label: React.ReactNode;
   value: string | number | boolean;
   column: keyof TData;
   isDefault?: boolean;
@@ -67,6 +67,8 @@ export interface DataTableProps<TData extends object, TValue> {
   headerLeft?: React.ReactNode
   /** Label for the auto-generated count chip (e.g. "txs", "keys"). If set, shows a count chip with filtered row count. */
   countLabel?: string
+  /** Render a status line showing filtered/total counts */
+  renderStatus?: (filteredCount: number, totalCount: number) => React.ReactNode
 }
 
 export default function DataTable<TData extends object, TValue>({
@@ -84,6 +86,7 @@ export default function DataTable<TData extends object, TValue>({
   searchPlaceholder = 'Search...',
   headerLeft,
   countLabel,
+  renderStatus,
 }: DataTableProps<TData, TValue>) {
   const defaultSort = sorts.flat().find((sort) => sort.isDefault);
 
@@ -116,8 +119,10 @@ export default function DataTable<TData extends object, TValue>({
         if (Array.isArray(val)) {
           return val.some((v) => String(v).toLowerCase().includes(q))
         }
-        if (typeof val === 'object' && 'name' in val) {
-          return String(val.name).toLowerCase().includes(q)
+        if (typeof val === 'object' && val !== null) {
+          const fields = Object.values(val).filter(v => typeof v === 'string')
+          if (fields.some(f => f.toLowerCase().includes(q))) return true
+          return false
         }
         if (typeof val === 'object' && 'identity' in val) {
           return String(val.identity).toLowerCase().includes(q) || ('name' in val && String(val.name).toLowerCase().includes(q))
@@ -218,6 +223,11 @@ export default function DataTable<TData extends object, TValue>({
 
   return (
     <div>
+      {renderStatus && !isLoading && !isError && (
+        <div className="pb-2">
+          {renderStatus(table.getFilteredRowModel().rows.length, data.length)}
+        </div>
+      )}
       <div className="flex flex-wrap items-center justify-between gap-2 pb-6">
         <div className="flex items-center gap-3">
           {searchableColumns?.length ? (

--- a/packages/ui/src/components/OverrideSidebar.tsx
+++ b/packages/ui/src/components/OverrideSidebar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function OverrideSidebar({children}: React.PropsWithChildren) {
   return (
-    <div className={'w-[100vw] bg-bg-root absolute top-0 left-0 md:left-[-208px] h-[100vh] overflow-auto z-20'}>
+    <div className={'w-[100vw] bg-bg-root fixed top-0 left-0 h-[100dvh] z-20 overflow-y-auto'}>
       {children}
     </div>
   )


### PR DESCRIPTION
- Add owner address and delegator filters to the keys table, including "None" options for unassigned keys; fix `FilterDropdown` to support combinable filters across all columns
- Add global search input to the keys table (searches by key address, owner address, and delegator name/identity); show a live filtered key count
- Redesign the export form with expanded filters (address group, multi-state, owner, delegator, date range, export status); add `exportedAt` / `exportCount` tracking columns with a DB migration
- Add a key generation flow: select an address group and quantity, generate keys server-side, and download the JSON file immediately
- Apply avatar + `getShortAddress` formatting to the Owner column in the keys table and key detail panel, with copy support via `showAvatar` prop on `Address`
- Fix `OverrideSidebar` scroll by switching from `absolute` to `fixed` positioning

Closes #225
Closes #227

## Keys Page
Includes new Generate button, search input and new filters.

<img width="2112" height="1274" alt="image" src="https://github.com/user-attachments/assets/566a7290-cf46-4658-8e16-481eff967e72" />

## Export Keys page
With new filter options.

<img width="545" height="1219" alt="image" src="https://github.com/user-attachments/assets/2b4dc73e-45b3-4e71-8e62-7dd436cd3089" />

## Generate Keys page

<img width="487" height="615" alt="image" src="https://github.com/user-attachments/assets/fac70c4f-f3c7-489f-9cd4-ea30c569121d" />
