### PR TITLE
feat: migrate keys between address groups, fix rev-share duplicate address

### DIFF
--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -295,7 +295,11 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
         }
       }
 
-      if (!isOwnerInitialStakeRemediationNeeded && update.state === KeyState.Staked) {
+      const hasAddressGroupMigrationPending = (key.remediationHistory ?? []).some(
+        (rh) => rh.reason === RemediationHistoryEntryReason.AddressGroupMigration
+      )
+
+      if (!isOwnerInitialStakeRemediationNeeded && !hasAddressGroupMigrationPending && update.state === KeyState.Staked) {
         const expectedServices = getExpectedServicesFromKey(key)
 
         // only compare to the active services from the history, so if a service stake change is about to take place, we override it
@@ -344,7 +348,8 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
         remediationReasons?.length &&
         !remediationReasons.includes(RemediationHistoryEntryReason.OwnerInitialStake) &&
         !remediationReasons.includes(RemediationHistoryEntryReason.ServiceMismatch) &&
-        !remediationReasons.includes(RemediationHistoryEntryReason.DelegatorAddressMissing)
+        !remediationReasons.includes(RemediationHistoryEntryReason.DelegatorAddressMissing) &&
+        !remediationReasons.includes(RemediationHistoryEntryReason.AddressGroupMigration)
       ) {
         update.state = KeyState.AttentionNeeded
       }
@@ -462,8 +467,14 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
       ? remediationHistory.find((rh) => rh.reason === RemediationHistoryEntryReason.ServiceMismatch) ?? null
       : null
 
+    const hasAddressGroupMigrationReason = params.reasons.includes(RemediationHistoryEntryReason.AddressGroupMigration);
+
+    const addressGroupMigrationEntry = hasAddressGroupMigrationReason
+      ? remediationHistory.find((rh) => rh.reason === RemediationHistoryEntryReason.AddressGroupMigration) ?? null
+      : null
+
     // Nothing actionable? DO NOT stake.
-    if (!ownerInitialStakeEntry && !serviceMismatchEntry) {
+    if (!ownerInitialStakeEntry && !serviceMismatchEntry && !addressGroupMigrationEntry) {
       log.info('remediateSupplier: No actionable remediation in reasons. Skipping stake.', {
         params,
         reasons: params.reasons,
@@ -592,7 +603,7 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
 
     // Record the transaction
     try {
-      const activeEntry = ownerInitialStakeEntry || serviceMismatchEntry
+      const activeEntry = ownerInitialStakeEntry || serviceMismatchEntry || addressGroupMigrationEntry
       const isManual = activeEntry?.message?.includes('requested by operator') ?? false
 
       await dal.transactions.insert({
@@ -624,7 +635,7 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
     } else {
       update.state = KeyState.Staked
       // Tx succeeded — clear the remediation entry that triggered this
-      const reasonToClear = ownerInitialStakeEntry?.reason || serviceMismatchEntry?.reason
+      const reasonToClear = ownerInitialStakeEntry?.reason || serviceMismatchEntry?.reason || addressGroupMigrationEntry?.reason
       if (reasonToClear) {
         update.remediationHistory = remediationHistory.filter((rh) => rh.reason !== reasonToClear)
       }

--- a/apps/provider-workflows/src/bootstrap.ts
+++ b/apps/provider-workflows/src/bootstrap.ts
@@ -14,6 +14,7 @@ enum ScheduledWorkflowType {
   SupplierStatus = 'SupplierStatus',
   SupplierRemediation = 'SupplierRemediation',
   SupplierInitialStake = 'SupplierInitialStake',
+  SupplierAddressGroupMigration = 'SupplierAddressGroupMigration',
 }
 
 const ScheduledWorkflowConfig: Record<
@@ -47,6 +48,14 @@ const ScheduledWorkflowConfig: Record<
       reasons: [RemediationHistoryEntryReason.OwnerInitialStake]
     }],
     envVar: 'SCHEDULE_SUPPLIER_INITIAL_STAKE_INTERVAL',
+  },
+  [ScheduledWorkflowType.SupplierAddressGroupMigration]: {
+    workflowType: 'SupplierRemediation',
+    interval: '30s',
+    args: [{
+      reasons: [RemediationHistoryEntryReason.AddressGroupMigration]
+    }],
+    envVar: 'SCHEDULE_SUPPLIER_ADDRESS_GROUP_MIGRATION_INTERVAL',
   },
 }
 

--- a/apps/provider/src/actions/Keys.ts
+++ b/apps/provider/src/actions/Keys.ts
@@ -29,7 +29,7 @@ import {
   withRequireOwner,
 } from '@/lib/utils/actionUtils'
 import { findById as findAddressGroupById } from '@/lib/dal/addressGroups'
-import { TriggerRemediationSchedule } from '@/actions/Schedules'
+import { TriggerAddressGroupMigrationSchedule } from '@/actions/Schedules'
 
 export async function CountKeys(): Promise<ActionResult<number>> {
   return withRequireOwner(async () => countKeys())
@@ -256,7 +256,7 @@ export async function MigrateKeysToAddressGroup(filters: KeyMigrationFilters, ta
       parsed.targetAddressGroupId,
     )
 
-    await TriggerRemediationSchedule()
+    await TriggerAddressGroupMigrationSchedule()
 
     return migrated
   })

--- a/apps/provider/src/actions/Keys.ts
+++ b/apps/provider/src/actions/Keys.ts
@@ -8,23 +8,28 @@ import {
   countKeys,
   countPrivateKeysByAddressGroup,
   countKeysForExport,
+  countKeysForMigration,
   getPrivateKeyById,
   insertMany,
   listDistinctOwnerAddresses,
   listKeysForExport,
+  listKeysForMigration,
   listKeysWithPk,
   listPrivateKeysByAddressGroup,
   markKeysExported,
+  migrateKeysToAddressGroup,
   updateKeysState,
   updateRewardsSettings,
   updateKeysStateWhereCurrentStateIn,
   type KeyExportFilters,
+  type KeyMigrationFilters,
 } from '@/lib/dal/keys'
 import {
   type ActionResult,
   withRequireOwner,
 } from '@/lib/utils/actionUtils'
 import { findById as findAddressGroupById } from '@/lib/dal/addressGroups'
+import { TriggerRemediationSchedule } from '@/actions/Schedules'
 
 export async function CountKeys(): Promise<ActionResult<number>> {
   return withRequireOwner(async () => countKeys())
@@ -213,5 +218,46 @@ export async function GenerateKeys(addressGroupId: number, count: number) {
     await insertMany(keysToInsert)
 
     return generatedKeys
+  })
+}
+
+const KeyMigrationFiltersSchema = z.object({
+  keyIds: z.array(z.number().int().positive()).optional(),
+  addressGroupId: z.number().int().positive().optional(),
+  states: z.array(z.nativeEnum(KeyState)).optional(),
+  ownerAddress: z.string().optional(),
+  delegatorIdentity: z.string().optional(),
+})
+
+export async function CountKeysForMigration(filters: KeyMigrationFilters): Promise<ActionResult<number>> {
+  return withRequireOwner(async () => {
+    const parsed = KeyMigrationFiltersSchema.parse(filters)
+    return countKeysForMigration(parsed)
+  })
+}
+
+export async function MigrateKeysToAddressGroup(filters: KeyMigrationFilters, targetAddressGroupId: number): Promise<ActionResult<number>> {
+  return withRequireOwner(async () => {
+    const parsed = z.object({
+      filters: KeyMigrationFiltersSchema,
+      targetAddressGroupId: z.number().int().positive(),
+    }).parse({ filters, targetAddressGroupId })
+
+    const targetGroup = await findAddressGroupById(parsed.targetAddressGroupId)
+    if (!targetGroup) throw new Error(`Address group ${parsed.targetAddressGroupId} does not exist`)
+
+    const keys = await listKeysForMigration(parsed.filters)
+    const keysToMigrate = keys.filter((k) => k.addressGroupId !== parsed.targetAddressGroupId)
+
+    if (keysToMigrate.length === 0) return 0
+
+    const migrated = await migrateKeysToAddressGroup(
+      keysToMigrate.map((k) => k.id),
+      parsed.targetAddressGroupId,
+    )
+
+    await TriggerRemediationSchedule()
+
+    return migrated
   })
 }

--- a/apps/provider/src/actions/Schedules.ts
+++ b/apps/provider/src/actions/Schedules.ts
@@ -36,3 +36,13 @@ export async function TriggerRemediationSchedule(): Promise<ActionResult<void>> 
     await handle.trigger()
   })
 }
+
+const ADDRESS_GROUP_MIGRATION_SCHEDULE_ID = 'SupplierAddressGroupMigration-scheduled'
+
+export async function TriggerAddressGroupMigrationSchedule(): Promise<ActionResult<void>> {
+  return withRequireOwner(async () => {
+    const client = getTemporalClient()
+    const handle = client.schedule.getHandle(ADDRESS_GROUP_MIGRATION_SCHEDULE_ID)
+    await handle.trigger()
+  })
+}

--- a/apps/provider/src/app/admin/(internal)/keys/KeyActions.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/KeyActions.tsx
@@ -5,10 +5,11 @@ import { Button } from '@igniter/ui/components/button'
 import ImportForm from './import/ImportForm'
 import ExportForm from './export/ExportForm'
 import GenerateForm from './generate/GenerateForm'
+import MigrateForm from './migrate/MigrateForm'
 
 export default function KeyActions() {
   const [activeModal, setActiveModal] = useState<
-    'import' | 'export' | 'generate' | null
+    'import' | 'export' | 'generate' | 'migrate' | null
   >(null)
 
   return (
@@ -26,6 +27,12 @@ export default function KeyActions() {
       >
         Export
       </Button>
+      <Button
+        variant="outline"
+        onClick={() => setActiveModal('migrate')}
+      >
+        Migrate
+      </Button>
 
       {activeModal === 'import' && (
         <ImportForm onClose={() => setActiveModal(null)} />
@@ -35,6 +42,9 @@ export default function KeyActions() {
       )}
       {activeModal === 'generate' && (
         <GenerateForm onClose={() => setActiveModal(null)} />
+      )}
+      {activeModal === 'migrate' && (
+        <MigrateForm onClose={() => setActiveModal(null)} />
       )}
     </>
   )

--- a/apps/provider/src/app/admin/(internal)/keys/migrate/MigrateForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/migrate/MigrateForm.tsx
@@ -1,0 +1,377 @@
+'use client'
+import type { KeyMigrationFilters } from '@/lib/dal/keys'
+import React, { useRef, useState } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@igniter/ui/components/select'
+import { Dialog, DialogContent, DialogTitle, DialogFooter } from '@igniter/ui/components/dialog'
+import { Button } from '@igniter/ui/components/button'
+import { LoaderIcon } from '@igniter/ui/assets'
+import { toCurrencyFormat } from '@igniter/ui/lib/utils'
+import { CountKeysForMigration, MigrateKeysToAddressGroup, ListDistinctOwnerAddresses } from '@/actions/Keys'
+import { ListAddressGroups } from '@/actions/AddressGroups'
+import { ListDelegators } from '@/actions/Delegators'
+import { KeyStateLabels } from '@/app/admin/(internal)/keys/constants'
+import { KeyState } from '@igniter/db/provider/enums'
+
+interface MigrateFormProps {
+  onClose: () => void
+}
+
+interface FilterFormValues {
+  addressGroupId: string
+  selectedStates: KeyState[]
+  ownerAddress: string
+  delegatorIdentity: string
+  targetAddressGroupId: string
+}
+
+function buildFilters(values: FilterFormValues): KeyMigrationFilters {
+  const filters: KeyMigrationFilters = {}
+  if (values.addressGroupId) filters.addressGroupId = Number(values.addressGroupId)
+  if (values.selectedStates.length > 0) filters.states = values.selectedStates
+  if (values.ownerAddress) filters.ownerAddress = values.ownerAddress
+  if (values.delegatorIdentity) filters.delegatorIdentity = values.delegatorIdentity
+  return filters
+}
+
+export default function MigrateForm({ onClose }: MigrateFormProps) {
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<'form' | 'loading' | 'success' | 'error'>('form')
+  const [keysMigrated, setKeysMigrated] = useState(0)
+
+  const { data: formData, isLoading: isDataLoading } = useQuery({
+    queryKey: ['migrate-form-data'],
+    queryFn: async () => {
+      const [ag, del, own] = await Promise.all([
+        ListAddressGroups(),
+        ListDelegators(),
+        ListDistinctOwnerAddresses(),
+      ])
+      return {
+        addressesGroup: ag.success ? ag.data : [],
+        delegators: del.success ? del.data : [],
+        ownerAddresses: own.success ? own.data : [],
+      }
+    },
+    staleTime: 30_000,
+  })
+
+  const addressesGroup = formData?.addressesGroup ?? []
+  const delegators = formData?.delegators ?? []
+  const ownerAddresses = formData?.ownerAddresses ?? []
+
+  const { setValue, control } = useForm<FilterFormValues>({
+    defaultValues: {
+      addressGroupId: '',
+      selectedStates: [],
+      ownerAddress: '',
+      delegatorIdentity: '',
+      targetAddressGroupId: '',
+    },
+  })
+
+  const values = useWatch({ control })
+
+  const addressGroupId = values.addressGroupId ?? ''
+  const selectedStates = values.selectedStates ?? []
+  const ownerAddress = values.ownerAddress ?? ''
+  const delegatorIdentity = values.delegatorIdentity ?? ''
+  const targetAddressGroupId = values.targetAddressGroupId ?? ''
+
+  const filters = buildFilters(values as FilterFormValues)
+  const filtersKey = JSON.stringify(filters)
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+  const [debouncedFilters, setDebouncedFilters] = useState<KeyMigrationFilters>(filters)
+
+  React.useEffect(() => {
+    clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => setDebouncedFilters(filters), 300)
+    return () => clearTimeout(debounceRef.current)
+  }, [filtersKey])
+
+  const { data: totalKeysCount, isFetching: isLoadingKeyCount } = useQuery({
+    queryKey: ['migrate-keys-count', debouncedFilters],
+    queryFn: async () => {
+      const result = await CountKeysForMigration(debouncedFilters)
+      if (!result.success) throw new Error(result.error.message)
+      return result.data
+    },
+    staleTime: 0,
+  })
+
+  const handleStateToggle = (state: KeyState) => {
+    const next = selectedStates.includes(state)
+      ? selectedStates.filter((s) => s !== state)
+      : [...selectedStates, state]
+    setValue('selectedStates', next)
+  }
+
+  const migrateKeys = async () => {
+    if (status === 'loading' || !targetAddressGroupId) return
+    setStatus('loading')
+    try {
+      const result = await MigrateKeysToAddressGroup(filters, Number(targetAddressGroupId))
+      if (!result || !result.success) throw new Error(result?.error?.message ?? 'Failed to migrate keys')
+      setKeysMigrated(result.data)
+      await queryClient.invalidateQueries({ queryKey: ['keys'] })
+      setStatus('success')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  const getFilterSummary = (): string => {
+    const parts: string[] = []
+    if (addressGroupId) {
+      const group = addressesGroup.find((a) => a.id === Number(addressGroupId))
+      if (group) parts.push(`Group: ${group.name}`)
+    }
+    if (selectedStates.length > 0) {
+      parts.push(selectedStates.map((s) => KeyStateLabels[s]).join(' + '))
+    }
+    if (ownerAddress) parts.push(`Owner: ${ownerAddress.slice(0, 8)}...`)
+    if (delegatorIdentity) {
+      const d = delegators.find((d) => d.identity === delegatorIdentity)
+      if (d) parts.push(`Delegator: ${d.name}`)
+    }
+    return parts.length > 0 ? parts.join(' · ') : 'No filters applied'
+  }
+
+  const targetGroup = addressesGroup.find((g) => g.id === Number(targetAddressGroupId))
+  const canMigrate = !!targetAddressGroupId && !!totalKeysCount && totalKeysCount > 0
+
+  let content: React.ReactNode
+
+  if (isDataLoading) {
+    content = (
+      <div className="flex items-center justify-center py-12">
+        <LoaderIcon className="animate-spin h-6 w-6 text-text-secondary" />
+      </div>
+    )
+  } else if (status === 'form' || status === 'loading') {
+    content = (
+      <>
+        {/* Source Address Group */}
+        <div className="flex flex-row items-center gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Source Group</label>
+          <div className="flex-1">
+            <Select value={addressGroupId} onValueChange={(v) => setValue('addressGroupId', v === '__all__' ? '' : v)}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="All Groups" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all__">All Groups</SelectItem>
+                {addressesGroup.map((group) => (
+                  <SelectItem value={group.id.toString()} key={group.id}>
+                    {group.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Key States */}
+        <div className="flex flex-row items-start gap-3">
+          <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary pt-1">Key State</label>
+          <div className="flex flex-wrap gap-2 flex-1">
+            {Object.entries(KeyStateLabels).map(([value, label]) => {
+              const state = value as KeyState
+              const isSelected = selectedStates.includes(state)
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => handleStateToggle(state)}
+                  className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                    isSelected
+                      ? 'bg-blue-600 border-blue-600 text-white'
+                      : 'bg-bg-elevated border-border text-text-secondary hover:bg-bg-hover'
+                  }`}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Owner Address */}
+        {ownerAddresses.length > 0 && (
+          <div className="flex flex-row items-center gap-3">
+            <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Owner Address</label>
+            <div className="flex-1">
+              <Select value={ownerAddress} onValueChange={(v) => setValue('ownerAddress', v === '__all__' ? '' : v)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="All Owners" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">All Owners</SelectItem>
+                  {ownerAddresses.map((addr) => (
+                    <SelectItem value={addr} key={addr}>
+                      {addr.slice(0, 12)}...{addr.slice(-6)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
+
+        {/* Delegator */}
+        {delegators.length > 0 && (
+          <div className="flex flex-row items-center gap-3">
+            <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Delegator</label>
+            <div className="flex-1">
+              <Select value={delegatorIdentity} onValueChange={(v) => setValue('delegatorIdentity', v === '__all__' ? '' : v)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="All Delegators" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__all__">All Delegators</SelectItem>
+                  {delegators.map((d) => (
+                    <SelectItem value={d.identity} key={d.identity}>
+                      {d.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        )}
+
+        {/* Summary */}
+        <div className={`p-4 rounded-md border transition-colors ${
+          isLoadingKeyCount
+            ? 'bg-bg-elevated border-border'
+            : totalKeysCount && totalKeysCount > 0
+              ? 'bg-emerald-500/5 border-emerald-500/30'
+              : 'bg-yellow-500/5 border-yellow-500/30'
+        }`}>
+          <div className="space-y-2">
+            <div className="text-xs text-text-tertiary">{getFilterSummary()}</div>
+            <div className="flex items-center justify-between">
+              <span className="font-medium text-text-secondary">Keys to Migrate</span>
+              <span className={`text-sm font-medium ${
+                isLoadingKeyCount ? '' : totalKeysCount && totalKeysCount > 0 ? 'text-emerald-400' : 'text-yellow-500'
+              }`}>
+                {isLoadingKeyCount ? (
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-500" />
+                ) : totalKeysCount !== null && totalKeysCount !== undefined ? (
+                  toCurrencyFormat(totalKeysCount, 0, 0)
+                ) : (
+                  'Failed to load'
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Target Address Group */}
+        <div>
+          <div className="flex flex-row items-center gap-3">
+            <label className="text-xs shrink-0 whitespace-nowrap w-28 text-text-secondary">Target Group</label>
+            <div className="flex-1">
+              <Select value={targetAddressGroupId} onValueChange={(v) => setValue('targetAddressGroupId', v)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select target group" />
+                </SelectTrigger>
+                <SelectContent>
+                  {addressesGroup
+                    .filter((g) => g.id.toString() !== addressGroupId)
+                    .map((group) => (
+                      <SelectItem value={group.id.toString()} key={group.id}>
+                        {group.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          {targetGroup && (
+            <p className="text-xs text-text-tertiary mt-1 pl-[calc(112px+0.75rem)]">
+              Migrated keys will be queued for remediation to match this group&apos;s service configuration.
+            </p>
+          )}
+        </div>
+      </>
+    )
+  } else if (status === 'success') {
+    content = (
+      <>
+        <div className="relative flex h-[64px] mt-[-5px] gradient-border-green">
+          <div className="absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px] justify-between">
+            <span className="text-[20px] text-text-secondary">Keys Migrated</span>
+            <p className="font-mono !text-[20px]">{toCurrencyFormat(keysMigrated, 0, 0)}</p>
+          </div>
+        </div>
+        <div className="flex flex-col bg-bg-elevated p-0 rounded-[8px]">
+          <span className="text-[14px] text-text-primary p-[11px_16px]">
+            Successfully migrated {keysMigrated} {keysMigrated === 1 ? 'key' : 'keys'} to{' '}
+            <span className="font-semibold">{targetGroup?.name}</span>. They have been queued for remediation.
+          </span>
+        </div>
+      </>
+    )
+  } else {
+    content = (
+      <div className="relative flex h-[64px] mt-[-5px] gradient-border-red">
+        <div className="absolute inset-0 flex flex-row items-center bg-bg-root rounded-[8px] p-[18px_25px]">
+          <span className="text-[20px] text-text-secondary">Oops! Something went wrong.</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Dialog open={true}>
+      <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
+        hideClose
+        className="gap-0 p-0 rounded-lg bg-bg-elevated sm:max-w-xl max-h-[85vh] overflow-hidden"
+      >
+        <DialogTitle asChild>
+          <div className="flex flex-row justify-between items-center py-3 px-5">
+            <span className="text-sm font-semibold">Migrate Keys</span>
+          </div>
+        </DialogTitle>
+        <div className="h-px bg-border-primary" />
+
+        <div className="flex flex-col gap-5 p-6 overflow-y-auto max-h-[calc(85vh-110px)]">
+          {content}
+        </div>
+
+        <div className="h-px bg-border-primary" />
+        <DialogFooter className="px-5 py-3 flex flex-row items-center gap-2">
+          {(status === 'form' || status === 'loading') && (
+            <>
+              <div className="flex-1" />
+              <Button variant="outline" onClick={onClose} disabled={status === 'loading'}>
+                Cancel
+              </Button>
+              <Button onClick={migrateKeys} disabled={status === 'loading' || !canMigrate}>
+                {status === 'loading' ? <LoaderIcon className="animate-spin" /> : 'Migrate Keys'}
+              </Button>
+            </>
+          )}
+          {status === 'success' && (
+            <>
+              <div className="flex-1" />
+              <Button onClick={onClose}>Close</Button>
+            </>
+          )}
+          {status === 'error' && (
+            <>
+              <div className="flex-1" />
+              <Button disabled={!canMigrate} onClick={migrateKeys}>
+                Try Again
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/migrate/MigrateForm.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/migrate/MigrateForm.tsx
@@ -37,7 +37,7 @@ function buildFilters(values: FilterFormValues): KeyMigrationFilters {
 
 export default function MigrateForm({ onClose }: MigrateFormProps) {
   const queryClient = useQueryClient()
-  const [status, setStatus] = useState<'form' | 'loading' | 'success' | 'error'>('form')
+  const [status, setStatus] = useState<'form' | 'confirm' | 'loading' | 'success' | 'error'>('form')
   const [keysMigrated, setKeysMigrated] = useState(0)
 
   const { data: formData, isLoading: isDataLoading } = useQuery({
@@ -108,6 +108,11 @@ export default function MigrateForm({ onClose }: MigrateFormProps) {
     setValue('selectedStates', next)
   }
 
+  const confirmMigration = () => {
+    if (!canMigrate) return
+    setStatus('confirm')
+  }
+
   const migrateKeys = async () => {
     if (status === 'loading' || !targetAddressGroupId) return
     setStatus('loading')
@@ -139,6 +144,7 @@ export default function MigrateForm({ onClose }: MigrateFormProps) {
     return parts.length > 0 ? parts.join(' · ') : 'No filters applied'
   }
 
+  const sourceGroup = addressesGroup.find((g) => g.id === Number(addressGroupId))
   const targetGroup = addressesGroup.find((g) => g.id === Number(targetAddressGroupId))
   const canMigrate = !!targetAddressGroupId && !!totalKeysCount && totalKeysCount > 0
 
@@ -150,7 +156,13 @@ export default function MigrateForm({ onClose }: MigrateFormProps) {
         <LoaderIcon className="animate-spin h-6 w-6 text-text-secondary" />
       </div>
     )
-  } else if (status === 'form' || status === 'loading') {
+  } else if (status === 'loading') {
+    content = (
+      <div className="flex items-center justify-center py-12">
+        <LoaderIcon className="animate-spin h-6 w-6 text-text-secondary" />
+      </div>
+    )
+  } else if (status === 'form') {
     content = (
       <>
         {/* Source Address Group */}
@@ -298,6 +310,28 @@ export default function MigrateForm({ onClose }: MigrateFormProps) {
         </div>
       </>
     )
+  } else if (status === 'confirm') {
+    content = (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-text-secondary">Keys to migrate</span>
+            <span className="font-semibold">{toCurrencyFormat(totalKeysCount ?? 0, 0, 0)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-text-secondary">Source group</span>
+            <span className="font-semibold">{sourceGroup?.name ?? 'All Groups'}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-text-secondary">Target group</span>
+            <span className="font-semibold">{targetGroup?.name}</span>
+          </div>
+        </div>
+        <div className="p-3 rounded-md bg-yellow-500/5 border border-yellow-500/30 text-xs text-yellow-400">
+          Migrated keys will be re-staked to match the target group&apos;s service configuration and will consume POKT to execute the transactions.
+        </div>
+      </div>
+    )
   } else if (status === 'success') {
     content = (
       <>
@@ -345,14 +379,33 @@ export default function MigrateForm({ onClose }: MigrateFormProps) {
 
         <div className="h-px bg-border-primary" />
         <DialogFooter className="px-5 py-3 flex flex-row items-center gap-2">
-          {(status === 'form' || status === 'loading') && (
+          {status === 'form' && (
             <>
               <div className="flex-1" />
-              <Button variant="outline" onClick={onClose} disabled={status === 'loading'}>
+              <Button variant="outline" onClick={onClose}>
                 Cancel
               </Button>
-              <Button onClick={migrateKeys} disabled={status === 'loading' || !canMigrate}>
-                {status === 'loading' ? <LoaderIcon className="animate-spin" /> : 'Migrate Keys'}
+              <Button onClick={confirmMigration} disabled={!canMigrate}>
+                Migrate Keys
+              </Button>
+            </>
+          )}
+          {status === 'confirm' && (
+            <>
+              <div className="flex-1" />
+              <Button variant="outline" onClick={() => setStatus('form')}>
+                Back
+              </Button>
+              <Button onClick={migrateKeys}>
+                Confirm Migration
+              </Button>
+            </>
+          )}
+          {status === 'loading' && (
+            <>
+              <div className="flex-1" />
+              <Button disabled>
+                <LoaderIcon className="animate-spin" />
               </Button>
             </>
           )}
@@ -365,6 +418,9 @@ export default function MigrateForm({ onClose }: MigrateFormProps) {
           {status === 'error' && (
             <>
               <div className="flex-1" />
+              <Button variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
               <Button disabled={!canMigrate} onClick={migrateKeys}>
                 Try Again
               </Button>

--- a/apps/provider/src/app/admin/(internal)/transactions/table/columns.tsx
+++ b/apps/provider/src/app/admin/(internal)/transactions/table/columns.tsx
@@ -27,6 +27,7 @@ const ReasonLabels: Record<string, string> = {
   [RemediationHistoryEntryReason.OwnerInitialStake]: 'Initial Stake',
   [RemediationHistoryEntryReason.SupplierStakeTooLow]: 'Stake Too Low',
   [RemediationHistoryEntryReason.SupplierFundsTooLow]: 'Funds Too Low',
+  [RemediationHistoryEntryReason.AddressGroupMigration]: 'Address Group Migration',
 }
 
 const TriggerLabels: Record<string, string> = {

--- a/apps/provider/src/app/admin/details/KeyDetail/MigrateKeyButton.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/MigrateKeyButton.tsx
@@ -16,10 +16,12 @@ interface MigrateKeyButtonProps {
   currentGroupName: string | null
 }
 
+type Status = 'idle' | 'submitting' | 'success' | 'error'
+
 export function MigrateKeyButton({ keyId, currentGroupId, currentGroupName }: MigrateKeyButtonProps) {
   const router = useRouter()
-  const [showConfirm, setShowConfirm] = React.useState(false)
-  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [open, setOpen] = React.useState(false)
+  const [status, setStatus] = React.useState<Status>('idle')
   const [error, setError] = React.useState<string | null>(null)
   const [targetGroupId, setTargetGroupId] = React.useState('')
 
@@ -30,33 +32,52 @@ export function MigrateKeyButton({ keyId, currentGroupId, currentGroupName }: Mi
       if (!result.success) throw new Error(result.error.message)
       return result.data
     },
-    enabled: showConfirm,
+    enabled: open,
     staleTime: 30_000,
   })
 
   const availableGroups = addressGroups.filter((g) => g.id !== currentGroupId)
+  const targetGroup = addressGroups.find((g) => g.id === Number(targetGroupId))
 
   const handleOpen = () => {
     setTargetGroupId('')
     setError(null)
-    setShowConfirm(true)
+    setStatus('idle')
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    if (status === 'submitting') return
+    if (status === 'success') router.refresh()
+    setOpen(false)
   }
 
   const handleConfirm = async () => {
     if (!targetGroupId) return
     setError(null)
-    setIsSubmitting(true)
+    setStatus('submitting')
     try {
       const result = await MigrateKeysToAddressGroup({ keyIds: [keyId] }, Number(targetGroupId))
       if (!result.success) throw new Error(result.error.message)
-      setShowConfirm(false)
-      router.refresh()
+      setStatus('success')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to migrate key. Please try again.')
-    } finally {
-      setIsSubmitting(false)
+      setStatus('error')
     }
   }
+
+  const footerActions = status === 'success' ? (
+    <Button onClick={handleClose}>Close</Button>
+  ) : (
+    <>
+      <Button variant="outline" onClick={handleClose} disabled={status === 'submitting'} type="button">
+        Cancel
+      </Button>
+      <Button onClick={handleConfirm} disabled={status === 'submitting' || !targetGroupId}>
+        {status === 'submitting' ? 'Migrating…' : 'Migrate'}
+      </Button>
+    </>
+  )
 
   return (
     <>
@@ -66,48 +87,49 @@ export function MigrateKeyButton({ keyId, currentGroupId, currentGroupName }: Mi
 
       <ConfirmationDialog
         title="Migrate to group"
-        open={showConfirm}
-        onClose={() => { if (!isSubmitting) setShowConfirm(false) }}
-        footerActions={(
+        open={open}
+        onClose={handleClose}
+        footerActions={footerActions}
+      >
+        {status === 'success' ? (
+          <div className="flex flex-col gap-3 py-3 text-[14px]">
+            <div className="p-3 rounded-md bg-emerald-500/5 border border-emerald-500/30 text-sm text-emerald-400">
+              Key successfully migrated to <span className="font-semibold">{targetGroup?.name}</span>. It has been queued for remediation.
+            </div>
+          </div>
+        ) : (
           <>
-            <Button variant="outline" onClick={() => setShowConfirm(false)} disabled={isSubmitting} type="button">
-              Cancel
-            </Button>
-            <Button onClick={handleConfirm} disabled={isSubmitting || !targetGroupId}>
-              {isSubmitting ? 'Migrating…' : 'Migrate'}
-            </Button>
+            {status === 'error' && error && (
+              <div className="px-4 py-2 text-[12px] text-red-400 bg-bg-root">
+                {error}
+              </div>
+            )}
+            <div className="flex flex-col gap-4 py-3 text-[14px]">
+              {currentGroupName && (
+                <div className="text-text-secondary">
+                  Current group: <span className="font-semibold text-text-primary">{currentGroupName}</span>
+                </div>
+              )}
+              <Select value={targetGroupId} onValueChange={setTargetGroupId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select target group" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableGroups.map((group) => (
+                    <SelectItem value={group.id.toString()} key={group.id}>
+                      {group.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {targetGroupId && (
+                <p className="text-xs text-text-tertiary">
+                  This key will be queued for remediation to match the new group&apos;s service configuration.
+                </p>
+              )}
+            </div>
           </>
         )}
-      >
-        {error && (
-          <div className="px-4 py-2 text-[12px] text-red-400 bg-bg-root">
-            {error}
-          </div>
-        )}
-        <div className="flex flex-col gap-4 py-3 text-[14px]">
-          {currentGroupName && (
-            <div className="text-text-secondary">
-              Current group: <span className="font-semibold text-text-primary">{currentGroupName}</span>
-            </div>
-          )}
-          <Select value={targetGroupId} onValueChange={setTargetGroupId}>
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Select target group" />
-            </SelectTrigger>
-            <SelectContent>
-              {availableGroups.map((group) => (
-                <SelectItem value={group.id.toString()} key={group.id}>
-                  {group.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {targetGroupId && (
-            <p className="text-xs text-text-tertiary">
-              This key will be queued for remediation to match the new group&apos;s service configuration.
-            </p>
-          )}
-        </div>
       </ConfirmationDialog>
     </>
   )

--- a/apps/provider/src/app/admin/details/KeyDetail/MigrateKeyButton.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/MigrateKeyButton.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
+import { ActionButton } from '@/app/admin/details/KeyDetail/ActionButton'
+import { ConfirmationDialog } from '@/components/ConfirmationDialog'
+import { Button } from '@igniter/ui/components/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@igniter/ui/components/select'
+import { ListBasicAddressGroups } from '@/actions/AddressGroups'
+import { MigrateKeysToAddressGroup } from '@/actions/Keys'
+
+interface MigrateKeyButtonProps {
+  keyId: number
+  currentGroupId: number | null
+  currentGroupName: string | null
+}
+
+export function MigrateKeyButton({ keyId, currentGroupId, currentGroupName }: MigrateKeyButtonProps) {
+  const router = useRouter()
+  const [showConfirm, setShowConfirm] = React.useState(false)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [targetGroupId, setTargetGroupId] = React.useState('')
+
+  const { data: addressGroups = [] } = useQuery({
+    queryKey: ['basic-address-groups'],
+    queryFn: async () => {
+      const result = await ListBasicAddressGroups()
+      if (!result.success) throw new Error(result.error.message)
+      return result.data
+    },
+    enabled: showConfirm,
+    staleTime: 30_000,
+  })
+
+  const availableGroups = addressGroups.filter((g) => g.id !== currentGroupId)
+
+  const handleOpen = () => {
+    setTargetGroupId('')
+    setError(null)
+    setShowConfirm(true)
+  }
+
+  const handleConfirm = async () => {
+    if (!targetGroupId) return
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const result = await MigrateKeysToAddressGroup({ keyIds: [keyId] }, Number(targetGroupId))
+      if (!result.success) throw new Error(result.error.message)
+      setShowConfirm(false)
+      router.refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to migrate key. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <ActionButton onClick={handleOpen}>
+        Migrate to group
+      </ActionButton>
+
+      <ConfirmationDialog
+        title="Migrate to group"
+        open={showConfirm}
+        onClose={() => { if (!isSubmitting) setShowConfirm(false) }}
+        footerActions={(
+          <>
+            <Button variant="outline" onClick={() => setShowConfirm(false)} disabled={isSubmitting} type="button">
+              Cancel
+            </Button>
+            <Button onClick={handleConfirm} disabled={isSubmitting || !targetGroupId}>
+              {isSubmitting ? 'Migrating…' : 'Migrate'}
+            </Button>
+          </>
+        )}
+      >
+        {error && (
+          <div className="px-4 py-2 text-[12px] text-red-400 bg-bg-root">
+            {error}
+          </div>
+        )}
+        <div className="flex flex-col gap-4 py-3 text-[14px]">
+          {currentGroupName && (
+            <div className="text-text-secondary">
+              Current group: <span className="font-semibold text-text-primary">{currentGroupName}</span>
+            </div>
+          )}
+          <Select value={targetGroupId} onValueChange={setTargetGroupId}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select target group" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableGroups.map((group) => (
+                <SelectItem value={group.id.toString()} key={group.id}>
+                  {group.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {targetGroupId && (
+            <p className="text-xs text-text-tertiary">
+              This key will be queued for remediation to match the new group&apos;s service configuration.
+            </p>
+          )}
+        </div>
+      </ConfirmationDialog>
+    </>
+  )
+}

--- a/apps/provider/src/app/admin/details/KeyDetail/RemediationHistoryList.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/RemediationHistoryList.tsx
@@ -23,6 +23,8 @@ export function RemediationHistoryList({ entries, keyId, keyState }: { entries: 
         return "Supplier's stake too low"
       case RemediationHistoryEntryReason.SupplierFundsTooLow:
         return "Supplier's funds too low"
+      case RemediationHistoryEntryReason.AddressGroupMigration:
+        return 'Address group migration'
       default:
         return String(r)
     }

--- a/apps/provider/src/app/admin/details/KeyDetail/index.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/index.tsx
@@ -196,7 +196,7 @@ export default function KeyDetail(key: KeyWithRelations) {
 
       <Summary rows={generalKeyDetails} />
 
-      {addressGroup && [KeyState.Staked, KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(state) && (
+      {addressGroup && (
         <MigrateKeyButton
           keyId={id}
           currentGroupId={addressGroup.id}

--- a/apps/provider/src/app/admin/details/KeyDetail/index.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/index.tsx
@@ -12,7 +12,8 @@ import {KeyState, KeyStateNameMap} from "@igniter/db/provider/enums"
 import { QuickInfoPopOverIcon } from '@igniter/ui/components/QuickInfoPopOverIcon'
 import {RemediationHistoryList} from "@/app/admin/details/KeyDetail/RemediationHistoryList";
 import {KeyStateLabels} from "@/app/admin/(internal)/keys/constants";
-import PrivateKeyReveal from "@/app/admin/details/KeyDetail/PrivateKeyReveal";
+import PrivateKeyReveal from "@/app/admin/details/KeyDetail/PrivateKeyReveal"
+import { MigrateKeyButton } from "@/app/admin/details/KeyDetail/MigrateKeyButton";
 
 export interface KeyDetail {
   type: 'key'
@@ -194,6 +195,14 @@ export default function KeyDetail(key: KeyWithRelations) {
       )}
 
       <Summary rows={generalKeyDetails} />
+
+      {addressGroup && [KeyState.Staked, KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(state) && (
+        <MigrateKeyButton
+          keyId={id}
+          currentGroupId={addressGroup.id}
+          currentGroupName={addressGroup.name}
+        />
+      )}
 
       {isStakedKey && delegator && (
         <div className="flex flex-col gap-2">

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -602,46 +602,51 @@ export async function listKeysForMigration(filters: KeyMigrationFilters): Promis
 
 const MIGRATION_CHUNK_SIZE = 500
 
+function upsertMigrationEntry(remediationHistory: unknown, entry: RemediationHistoryEntry): RemediationHistoryEntry[] {
+  const history = [...((remediationHistory as RemediationHistoryEntry[]) ?? [])]
+  const existingIndex = history.findIndex((item) => item.reason === entry.reason)
+  if (existingIndex !== -1) {
+    history[existingIndex] = entry
+  } else {
+    history.push(entry)
+    history.sort((a, b) => b.timestamp - a.timestamp)
+  }
+  return history
+}
+
+function buildRemediationHistoryCaseExpr(keys: { id: number; remediationHistory: unknown }[], entry: RemediationHistoryEntry): SQL {
+  const whenClauses = keys.map((key) => {
+    const updatedHistory = upsertMigrationEntry(key.remediationHistory, entry)
+    return sql`WHEN ${keysTable.id} = ${key.id} THEN ${JSON.stringify(updatedHistory)}::json`
+  })
+  return sql`CASE ${sql.join(whenClauses, sql` `)} ELSE ${keysTable.remediationHistory} END`
+}
+
+const STATES_REQUIRING_RESET = [KeyState.AttentionNeeded, KeyState.RemediationFailed]
+
 export async function migrateKeysToAddressGroup(keyIds: number[], targetAddressGroupId: number): Promise<number> {
   if (keyIds.length === 0) return 0
   const dbClient = getDbClient()
 
-  const now = Date.now()
   const migrationEntry: RemediationHistoryEntry = {
     message: `Key migrated to address group ${targetAddressGroupId}`,
     reason: RemediationHistoryEntryReason.AddressGroupMigration,
-    timestamp: now,
+    timestamp: Date.now(),
   }
 
   await dbClient.db.transaction(async (tx) => {
-    for (let i = 0; i < keyIds.length; i += MIGRATION_CHUNK_SIZE) {
-      const chunkIds = keyIds.slice(i, i + MIGRATION_CHUNK_SIZE)
+    const chunks = Array.from({ length: Math.ceil(keyIds.length / MIGRATION_CHUNK_SIZE) }, (_, i) =>
+      keyIds.slice(i * MIGRATION_CHUNK_SIZE, (i + 1) * MIGRATION_CHUNK_SIZE),
+    )
 
+    for (const chunkIds of chunks) {
       const keys = await tx
         .select({ id: keysTable.id, state: keysTable.state, remediationHistory: keysTable.remediationHistory })
         .from(keysTable)
         .where(inArray(keysTable.id, chunkIds))
 
-      const stateResetIds: number[] = []
-      const historyCaseChunks: SQL[] = []
-
-      for (const key of keys) {
-        const history = [...((key.remediationHistory as RemediationHistoryEntry[]) ?? [])]
-        const existingIndex = history.findIndex((item) => item.reason === migrationEntry.reason)
-        if (existingIndex !== -1) {
-          history[existingIndex] = migrationEntry
-        } else {
-          history.push(migrationEntry)
-          history.sort((a, b) => b.timestamp - a.timestamp)
-        }
-        historyCaseChunks.push(sql`WHEN ${keysTable.id} = ${key.id} THEN ${JSON.stringify(history)}::json`)
-
-        if ([KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(key.state)) {
-          stateResetIds.push(key.id)
-        }
-      }
-
-      const historyCase = sql`CASE ${sql.join(historyCaseChunks, sql` `)} ELSE ${keysTable.remediationHistory} END`
+      const historyCase = buildRemediationHistoryCaseExpr(keys, migrationEntry)
+      const stateResetIds = keys.filter((key) => STATES_REQUIRING_RESET.includes(key.state)).map((key) => key.id)
 
       await tx
         .update(keysTable)

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -5,7 +5,7 @@ import type {
 } from '@igniter/db/provider/schema'
 import * as schema from '@igniter/db/provider/schema'
 import { getDbClient } from '@/db'
-import { KeyState } from '@igniter/db/provider/enums'
+import { KeyState, RemediationHistoryEntryReason } from '@igniter/db/provider/enums'
 import { PgTransaction } from 'drizzle-orm/pg-core'
 import {
   and,
@@ -531,6 +531,115 @@ export async function markKeysExported(keyIds: number[]): Promise<void> {
       exportCount: sql`COALESCE(${keysTable.exportCount}, 0) + 1`,
     })
     .where(inArray(keysTable.id, keyIds))
+}
+
+export interface KeyMigrationFilters {
+  keyIds?: number[]
+  addressGroupId?: number
+  states?: KeyState[]
+  ownerAddress?: string
+  delegatorIdentity?: string
+}
+
+function buildMigrationFilterConditions(filters: KeyMigrationFilters): SQL[] {
+  const conditions: SQL[] = []
+
+  if (filters.keyIds && filters.keyIds.length > 0) {
+    conditions.push(inArray(keysTable.id, filters.keyIds))
+  }
+
+  if (filters.addressGroupId) {
+    conditions.push(eq(keysTable.addressGroupId, filters.addressGroupId))
+  }
+
+  if (filters.states && filters.states.length > 0) {
+    conditions.push(inArray(keysTable.state, filters.states))
+  }
+
+  if (filters.ownerAddress) {
+    conditions.push(eq(keysTable.ownerAddress, filters.ownerAddress))
+  }
+
+  if (filters.delegatorIdentity) {
+    conditions.push(eq(keysTable.deliveredTo, filters.delegatorIdentity))
+  }
+
+  return conditions
+}
+
+export async function countKeysForMigration(filters: KeyMigrationFilters): Promise<number> {
+  const dbClient = getDbClient()
+  const conditions = buildMigrationFilterConditions(filters)
+
+  const [result] = await dbClient.db.select({ count: count() })
+    .from(keysTable)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+
+  return Number(result?.count || 0)
+}
+
+export async function listKeysForMigration(filters: KeyMigrationFilters): Promise<Array<{
+  id: number
+  address: string
+  addressGroupId: number | null
+  state: KeyState
+  remediationHistory: RemediationHistoryEntry[] | null
+}>> {
+  const dbClient = getDbClient()
+  const conditions = buildMigrationFilterConditions(filters)
+
+  return dbClient.db.query.keysTable.findMany({
+    ...(conditions.length > 0 && { where: and(...conditions) }),
+    columns: {
+      id: true,
+      address: true,
+      addressGroupId: true,
+      state: true,
+      remediationHistory: true,
+    },
+  })
+}
+
+export async function migrateKeysToAddressGroup(keyIds: number[], targetAddressGroupId: number): Promise<number> {
+  if (keyIds.length === 0) return 0
+  const dbClient = getDbClient()
+
+  await dbClient.db.transaction(async (tx) => {
+    const keys = await tx
+      .select({ id: keysTable.id, state: keysTable.state, remediationHistory: keysTable.remediationHistory })
+      .from(keysTable)
+      .where(inArray(keysTable.id, keyIds))
+
+    for (const key of keys) {
+      const entry: RemediationHistoryEntry = {
+        message: `Key migrated to address group ${targetAddressGroupId}`,
+        reason: RemediationHistoryEntryReason.AddressGroupMigration,
+        timestamp: Date.now(),
+      }
+
+      const history = [...((key.remediationHistory as RemediationHistoryEntry[]) ?? [])]
+      const existingIndex = history.findIndex((item) => item.reason === entry.reason)
+      if (existingIndex !== -1) {
+        history[existingIndex] = entry
+      } else {
+        history.push(entry)
+        history.sort((a, b) => b.timestamp - a.timestamp)
+      }
+
+      const needsStateReset = [KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(key.state)
+
+      await tx
+        .update(keysTable)
+        .set({
+          addressGroupId: targetAddressGroupId,
+          remediationHistory: history,
+          ...(needsStateReset && { state: KeyState.Staked }),
+        })
+        .where(eq(keysTable.id, key.id))
+    }
+  })
+
+  return keyIds.length
 }
 
 export async function listDistinctOwnerAddresses(): Promise<string[]> {

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -600,42 +600,60 @@ export async function listKeysForMigration(filters: KeyMigrationFilters): Promis
   })
 }
 
+const MIGRATION_CHUNK_SIZE = 500
+
 export async function migrateKeysToAddressGroup(keyIds: number[], targetAddressGroupId: number): Promise<number> {
   if (keyIds.length === 0) return 0
   const dbClient = getDbClient()
 
+  const now = Date.now()
+  const migrationEntry: RemediationHistoryEntry = {
+    message: `Key migrated to address group ${targetAddressGroupId}`,
+    reason: RemediationHistoryEntryReason.AddressGroupMigration,
+    timestamp: now,
+  }
+
   await dbClient.db.transaction(async (tx) => {
-    const keys = await tx
-      .select({ id: keysTable.id, state: keysTable.state, remediationHistory: keysTable.remediationHistory })
-      .from(keysTable)
-      .where(inArray(keysTable.id, keyIds))
+    for (let i = 0; i < keyIds.length; i += MIGRATION_CHUNK_SIZE) {
+      const chunkIds = keyIds.slice(i, i + MIGRATION_CHUNK_SIZE)
 
-    for (const key of keys) {
-      const entry: RemediationHistoryEntry = {
-        message: `Key migrated to address group ${targetAddressGroupId}`,
-        reason: RemediationHistoryEntryReason.AddressGroupMigration,
-        timestamp: Date.now(),
+      const keys = await tx
+        .select({ id: keysTable.id, state: keysTable.state, remediationHistory: keysTable.remediationHistory })
+        .from(keysTable)
+        .where(inArray(keysTable.id, chunkIds))
+
+      const stateResetIds: number[] = []
+      const historyCaseChunks: SQL[] = []
+
+      for (const key of keys) {
+        const history = [...((key.remediationHistory as RemediationHistoryEntry[]) ?? [])]
+        const existingIndex = history.findIndex((item) => item.reason === migrationEntry.reason)
+        if (existingIndex !== -1) {
+          history[existingIndex] = migrationEntry
+        } else {
+          history.push(migrationEntry)
+          history.sort((a, b) => b.timestamp - a.timestamp)
+        }
+        historyCaseChunks.push(sql`WHEN ${keysTable.id} = ${key.id} THEN ${JSON.stringify(history)}::json`)
+
+        if ([KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(key.state)) {
+          stateResetIds.push(key.id)
+        }
       }
 
-      const history = [...((key.remediationHistory as RemediationHistoryEntry[]) ?? [])]
-      const existingIndex = history.findIndex((item) => item.reason === entry.reason)
-      if (existingIndex !== -1) {
-        history[existingIndex] = entry
-      } else {
-        history.push(entry)
-        history.sort((a, b) => b.timestamp - a.timestamp)
-      }
-
-      const needsStateReset = [KeyState.AttentionNeeded, KeyState.RemediationFailed].includes(key.state)
+      const historyCase = sql`CASE ${sql.join(historyCaseChunks, sql` `)} ELSE ${keysTable.remediationHistory} END`
 
       await tx
         .update(keysTable)
-        .set({
-          addressGroupId: targetAddressGroupId,
-          remediationHistory: history,
-          ...(needsStateReset && { state: KeyState.Staked }),
-        })
-        .where(eq(keysTable.id, key.id))
+        .set({ addressGroupId: targetAddressGroupId, remediationHistory: historyCase })
+        .where(inArray(keysTable.id, chunkIds))
+
+      if (stateResetIds.length > 0) {
+        await tx
+          .update(keysTable)
+          .set({ state: KeyState.Staked })
+          .where(inArray(keysTable.id, stateResetIds))
+      }
     }
   })
 

--- a/packages/db/src/provider/schema/enums.ts
+++ b/packages/db/src/provider/schema/enums.ts
@@ -160,6 +160,7 @@ export enum RemediationHistoryEntryReason {
   OwnerInitialStake = '1003',
   SupplierStakeTooLow = '1004',
   SupplierFundsTooLow = '1005',
+  AddressGroupMigration = '1006',
 }
 
 /**

--- a/packages/domain/src/middleman/utils/supplierChanges.ts
+++ b/packages/domain/src/middleman/utils/supplierChanges.ts
@@ -9,10 +9,11 @@ export type DetectedSupplierChange = {
 }
 
 function getOwnerRevShare(service: NodeService, ownerAddress: string): number | undefined {
-  const entry = service.revShare.find(
+  const entries = service.revShare.filter(
     (rs) => rs.address.toLowerCase() === ownerAddress.toLowerCase(),
   )
-  return entry?.revSharePercentage
+  if (entries.length === 0) return undefined
+  return entries.reduce((sum: number, rs: { revSharePercentage: number }) => sum + rs.revSharePercentage, 0)
 }
 
 /**

--- a/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.test.ts
+++ b/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.test.ts
@@ -5,6 +5,7 @@ import {
 import { SupplierServiceConfig, ServiceRevenueShare } from '@igniter/pocket';
 
 jest.mock('@igniter/domain/provider/utils', () => ({
+    ...jest.requireActual('@igniter/domain/provider/utils'),
     getRevShare: jest.fn(),
     getEndpointInterpolatedUrl: jest.fn(),
 }));
@@ -120,6 +121,28 @@ describe('BuildSupplierServiceConfigHandler', () => {
         const [cfg] = handler.execute(input);
 
         expect(cfg?.revShare.some((r: ServiceRevenueShare) => r.revSharePercentage === 0)).toBe(false);
+    });
+
+    it('merges duplicate address entries when ownerAddress equals operatorAddress', () => {
+        // When owner and operator are the same address, getRevShare adds it once
+        // (as supplierShare) and the handler adds it again as the owner remainder.
+        // The result should have a single merged entry.
+        mockedGetRevShare.mockReturnValue([
+            { address: ownerAddress, revSharePercentage: 30 }, // operator == owner
+        ]);
+
+        const sameAddressInput = {
+            ...input,
+            operatorAddress: ownerAddress, // same as ownerAddress
+        };
+
+        const result = handler.execute(sameAddressInput);
+        const cfg = result[0]!;
+
+        const ownerEntries = cfg.revShare.filter((r: ServiceRevenueShare) => r.address === ownerAddress);
+        expect(ownerEntries).toHaveLength(1);
+        // 30% from getRevShare + 50% remainder = 80% total for owner; request_addr gets 20%
+        expect(ownerEntries[0]?.revSharePercentage).toBe(80);
     });
 
     it('throws RevenueShareOverflowError when total revshare exceeds 100', () => {

--- a/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.ts
+++ b/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.ts
@@ -1,5 +1,5 @@
 import {BuildSupplierServiceConfigInput} from '@igniter/domain/provider/operations';
-import {getRevShare, getEndpointInterpolatedUrl} from "@igniter/domain/provider/utils";
+import {getRevShare, getEndpointInterpolatedUrl, deduplicateRevShare} from "@igniter/domain/provider/utils";
 import {SupplierServiceConfig} from "@igniter/pocket/proto/pocket/shared/service";
 import {RevenueShareOverflowError} from "@igniter/domain/provider/errors";
 import {RPCTypeMap} from '@igniter/pocket';
@@ -28,7 +28,8 @@ export class BuildSupplierServiceConfigHandler {
                 });
             }
 
-            const totalRevShare = revShare.reduce((sum, r) => sum + r.revSharePercentage, 0);
+            const deduplicatedRevShare = deduplicateRevShare(revShare);
+            const totalRevShare = deduplicatedRevShare.reduce((sum, r) => sum + r.revSharePercentage, 0);
 
             if (totalRevShare > 100) {
                 throw new RevenueShareOverflowError(totalRevShare);
@@ -38,7 +39,7 @@ export class BuildSupplierServiceConfigHandler {
 
             return {
                 serviceId: cfg.serviceId,
-                revShare,
+                revShare: deduplicatedRevShare,
                 endpoints: svc.endpoints.map((ep) => {
                     const rpcKey = String(ep.rpcType);
                     const overrideUrl = overrides[rpcKey];

--- a/packages/domain/src/provider/operations/suppliers/CompareSupplierServiceConfig/CompareSupplierServiceConfigHandler.test.ts
+++ b/packages/domain/src/provider/operations/suppliers/CompareSupplierServiceConfig/CompareSupplierServiceConfigHandler.test.ts
@@ -157,6 +157,35 @@ describe('CompareSupplierServiceConfigHandler with fixtures', () => {
         expect(result.diff).toEqual([]);
     });
 
+    it('returns isEqual true when one side has duplicate addresses that sum to the same total', () => {
+        // Chain may return two entries for the same address (e.g. 10% + 89%),
+        // while the expected config has a single merged entry (99%).
+        const withDuplicates: SupplierServiceConfig[] = [{
+            serviceId: 'anvil',
+            endpoints: [{ url: 'https://test.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+            revShare: [
+                { address: OWNER_ADDRESS, revSharePercentage: 10 },
+                { address: PROVIDER_ADDRESS, revSharePercentage: 1 },
+                { address: OWNER_ADDRESS, revSharePercentage: 89 },
+            ],
+        }];
+        const consolidated: SupplierServiceConfig[] = [{
+            serviceId: 'anvil',
+            endpoints: [{ url: 'https://test.example.com', rpcType: RPCType.JSON_RPC, configs: [] }],
+            revShare: [
+                { address: OWNER_ADDRESS, revSharePercentage: 99 },
+                { address: PROVIDER_ADDRESS, revSharePercentage: 1 },
+            ],
+        }];
+
+        const result = handler.execute({
+            serviceConfigSetA: withDuplicates,
+            serviceConfigSetB: consolidated,
+        });
+
+        expect(result.isEqual).toBe(true);
+    });
+
     it('returns isEqual true when revShare entries are in different order', () => {
         const serviceA: SupplierServiceConfig[] = [{
             serviceId: 'anvil',

--- a/packages/domain/src/provider/operations/suppliers/CompareSupplierServiceConfig/CompareSupplierServiceConfigHandler.ts
+++ b/packages/domain/src/provider/operations/suppliers/CompareSupplierServiceConfig/CompareSupplierServiceConfigHandler.ts
@@ -9,6 +9,7 @@ import {
   ConfigOption,
 } from '@igniter/pocket';
 import diff from 'microdiff';
+import { deduplicateRevShare } from '@igniter/domain/provider/utils';
 import {getLogger, Logger} from "@igniter/logger";
 
 
@@ -36,7 +37,7 @@ export class CompareSupplierServiceConfigHandler {
         serviceId: cfg.serviceId,
 
         revShare: copyAndSort<ServiceRevenueShare>(
-          cfg.revShare,
+          deduplicateRevShare(cfg.revShare),
           compareStringField<ServiceRevenueShare>('address'),
         ),
 

--- a/packages/domain/src/provider/utils/services.test.ts
+++ b/packages/domain/src/provider/utils/services.test.ts
@@ -1,4 +1,4 @@
-import { getRevShare } from './services';
+import { getRevShare, deduplicateRevShare } from './services';
 import type { AddressGroupService } from '@igniter/db/provider/schema';
 
 describe('getRevShare', () => {
@@ -53,5 +53,44 @@ describe('getRevShare', () => {
 
     const result = getRevShare(ags, 'pokt1operator');
     expect(result).toEqual([{ address: 'pokt1operator', revSharePercentage: 10 }]);
+  });
+});
+
+describe('deduplicateRevShare', () => {
+  it('sums percentages for duplicate addresses', () => {
+    const result = deduplicateRevShare([
+      { address: 'pokt1owner', revSharePercentage: 10 },
+      { address: 'pokt1other', revSharePercentage: 1 },
+      { address: 'pokt1owner', revSharePercentage: 89 },
+    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { address: 'pokt1owner', revSharePercentage: 99 },
+        { address: 'pokt1other', revSharePercentage: 1 },
+      ]),
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it('is case-insensitive when matching addresses', () => {
+    const result = deduplicateRevShare([
+      { address: 'pokt1OWNER', revSharePercentage: 10 },
+      { address: 'pokt1owner', revSharePercentage: 89 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.revSharePercentage).toBe(99);
+  });
+
+  it('returns unchanged array when all addresses are unique', () => {
+    const input = [
+      { address: 'pokt1alice', revSharePercentage: 20 },
+      { address: 'pokt1bob', revSharePercentage: 80 },
+    ];
+    const result = deduplicateRevShare(input);
+    expect(result).toEqual(input);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(deduplicateRevShare([])).toEqual([]);
   });
 });

--- a/packages/domain/src/provider/utils/services.ts
+++ b/packages/domain/src/provider/utils/services.ts
@@ -1,5 +1,26 @@
 import type {AddressGroupService} from "@igniter/db/provider/schema";
 
+/**
+ * Merges revShare entries that share the same address by summing their percentages.
+ * The chain can return (or we can produce) multiple entries for the same address;
+ * this normalises them to a single entry per address so comparisons and stakes are correct.
+ */
+export function deduplicateRevShare<T extends { address: string; revSharePercentage: number }>(
+  revShare: T[],
+): T[] {
+  const map = new Map<string, T>()
+  for (const entry of revShare) {
+    const key = entry.address.toLowerCase()
+    const existing = map.get(key)
+    if (existing) {
+      map.set(key, { ...existing, revSharePercentage: existing.revSharePercentage + entry.revSharePercentage })
+    } else {
+      map.set(key, { ...entry, address: entry.address })
+    }
+  }
+  return [...map.values()]
+}
+
 export function getRevShare(addressGroupService: AddressGroupService, operatorAddress: string) {
   const revShare = addressGroupService.revShare.map(({address, share}) => ({
     address,

--- a/packages/domain/src/provider/utils/suppliers.test.ts
+++ b/packages/domain/src/provider/utils/suppliers.test.ts
@@ -321,6 +321,71 @@ describe('getExpectedServicesFromKey', () => {
 
     expect(getExpectedServicesFromKey(key)).toEqual([]);
   });
+
+  it('filters out 0% rev share entries and recalculates owner remainder', () => {
+    const key = {
+      address: 'pokt1supplier',
+      ownerAddress: 'pokt1owner',
+      delegatorRewardsAddress: 'pokt1delegator',
+      delegatorRevSharePercentage: 0, // 0% should be excluded
+      addressGroup: {
+        relayMiner: { identity: 'rm1', domain: 'example.com', region: { urlValue: 'us' } },
+        addressGroupServices: [
+          {
+            serviceId: 'svc1',
+            addSupplierShare: true,
+            supplierShare: 0, // 0% should also be excluded
+            revShare: [{ address: 'pokt1provider', share: 20 }],
+            service: {
+              endpoints: [{ rpcType: RPCType.JSON_RPC, url: 'https://test.com' }],
+            },
+          },
+        ],
+      },
+    } as any;
+
+    const result = getExpectedServicesFromKey(key);
+    const svc = result[0]!;
+
+    // delegator=0 (filtered), supplier=0 (filtered), provider=20, owner=80
+    expect(svc.revShare).toHaveLength(2);
+    expect(svc.revShare).toEqual([
+      { address: 'pokt1provider', revSharePercentage: 20 },
+      { address: 'pokt1owner', revSharePercentage: 80 },
+    ]);
+  });
+
+  it('normalizes rpcType to numeric enum values', () => {
+    const key = {
+      address: 'pokt1supplier',
+      ownerAddress: 'pokt1owner',
+      delegatorRewardsAddress: null,
+      delegatorRevSharePercentage: null,
+      addressGroup: {
+        relayMiner: { identity: 'rm1', domain: 'example.com', region: { urlValue: 'us' } },
+        addressGroupServices: [
+          {
+            serviceId: 'svc1',
+            addSupplierShare: false,
+            supplierShare: 0,
+            revShare: [],
+            service: {
+              endpoints: [
+                { rpcType: 'JSON_RPC' as any, url: 'https://test.com' },
+                { rpcType: 'REST' as any, url: 'https://test.com/rest' },
+              ],
+            },
+          },
+        ],
+      },
+    } as any;
+
+    const result = getExpectedServicesFromKey(key);
+    const svc = result[0]!;
+
+    expect(svc.endpoints[0].rpcType).toBe(RPCType.JSON_RPC); // 3
+    expect(svc.endpoints[1].rpcType).toBe(RPCType.REST);     // 4
+  });
 });
 
 // ── Fixture-based tests ─────────────────────────────────────────────────

--- a/packages/domain/src/provider/utils/suppliers.ts
+++ b/packages/domain/src/provider/utils/suppliers.ts
@@ -4,6 +4,7 @@ import {RPCType, SupplierEndpoint, SupplierServiceConfig} from '@igniter/pocket/
 import {PROTOCOL_DEFAULT_URL} from "@igniter/domain/provider/constants";
 import {KeyWithGroup} from "@igniter/db/provider/schema";
 import {RPCTypeMap} from '@igniter/pocket/constants';
+import {deduplicateRevShare} from "./services";
 
 export function getSchemeForRpcType(rpcType: RPCType) {
     switch (rpcType) {
@@ -161,6 +162,7 @@ export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierSer
 
     const newExpectedService: SupplierServiceConfig = {
       serviceId: addressGroupService.serviceId,
+      revShare: deduplicateRevShare(filteredRevShare),
       endpoints: addressGroupService.service.endpoints?.map((endpoint) => ({
         url: getEndpointInterpolatedUrl(endpoint, {
           sid: addressGroupService.serviceId,
@@ -174,7 +176,6 @@ export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierSer
           : endpoint.rpcType,
         configs: []
       })),
-      revShare: filteredRevShare,
     }
 
     expectedServices.push(newExpectedService)

--- a/packages/ui/src/components/AppSidebar.tsx
+++ b/packages/ui/src/components/AppSidebar.tsx
@@ -28,7 +28,7 @@ export default function AppSidebar({
 }: Readonly<AppSidebarProps>) {
   return (
     <Sidebar
-      className="top-(--header-height) !h-[calc(100svh-var(--header-height))]"
+      className="top-[calc(var(--header-height)+var(--notification-height,0px))] !h-[calc(100svh-var(--header-height)-var(--notification-height,0px))]"
       {...sidebarProps}
     >
       <SidebarHeader></SidebarHeader>

--- a/packages/ui/src/components/OverrideSidebar.tsx
+++ b/packages/ui/src/components/OverrideSidebar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function OverrideSidebar({children}: React.PropsWithChildren) {
   return (
-    <div className={'w-[100vw] bg-bg-root fixed top-0 left-0 h-[100dvh] z-20 overflow-y-auto'}>
+    <div className={'w-[100vw] bg-bg-root fixed left-0 top-[var(--notification-height,0px)] h-[calc(100dvh-var(--notification-height,0px))] z-20 overflow-y-auto'}>
       {children}
     </div>
   )

--- a/packages/ui/src/context/Notifications/index.tsx
+++ b/packages/ui/src/context/Notifications/index.tsx
@@ -149,7 +149,7 @@ export default function NotificationsProvider({children}: React.PropsWithChildre
 
       notificationsRender = (
         <div
-          className={'sticky top-0 z-20 flex flex-col h-[70px] pt-5 bg-bg-root'}
+          className={'sticky top-0 z-30 flex flex-col h-[70px] pt-5 bg-bg-root'}
         >
           <div className={'flex items-center gap-2 justify-between mx-30'}>
             <div className={'flex flex-row items-center gap-3'}>
@@ -206,8 +206,10 @@ export default function NotificationsProvider({children}: React.PropsWithChildre
         }
       }}
     >
-      {notificationsRender}
-      {children}
+      <div className="contents" style={{ '--notification-height': notifications.length > 0 ? '70px' : '0px' } as React.CSSProperties}>
+        {notificationsRender}
+        {children}
+      </div>
     </NotificationsContext>
   )
 }


### PR DESCRIPTION
Adds the ability to migrate keys between address groups from both the keys list and individual key detail views. Also fixes a rev-share duplicate address bug in middleman workflows and provider service config operations.

- **Key migration feature**: Providers can now reassign keys to a different address group after import. A bulk "Migrate" dialog on the keys list page supports filtering by source group, state, owner address, and delegator before selecting a target group. A per-key "Migrate" button is also available on the key detail page.
- **Remediation on migration**: Migrated keys have a `AddressGroupMigration` remediation history entry appended and are reset from `AttentionNeeded`/`RemediationFailed` → `Staked`, then the remediation schedule is triggered automatically.
- **New `AddressGroupMigration` enum value**: Adds `RemediationHistoryEntryReason.AddressGroupMigration = '1006'` to the provider enums package and a corresponding label in `RemediationHistoryList`.
- **Rev-share duplicate address fix**: When a supplier's `revShare` array contains multiple entries for the same address (e.g. from chain data), they are now summed rather than using only the first match. A shared `deduplicateRevShare` utility is applied in `supplierChanges.ts` (middleman), `BuildSupplierServiceConfigHandler`, `CompareSupplierServiceConfigHandler`, and `getExpectedServicesFromKey`.
