### PR TITLE
fix: Resolve DB timeout on import suppliers and improve query efficiency

### DIFF
--- a/apps/middleman/src/app/admin/(internal)/providers/table/columns.tsx
+++ b/apps/middleman/src/app/admin/(internal)/providers/table/columns.tsx
@@ -7,6 +7,7 @@ import {Provider} from "@igniter/db/middleman/schema";
 import {useState} from "react";
 import {UpdateEnabled, UpdateVisibility} from "@/actions/Providers";
 import {Switch} from "@igniter/ui/components/switch";
+import { copyToClipboard } from "@igniter/ui/lib/utils";
 
 export const columns: ColumnDef<Provider>[] = [
   {
@@ -25,7 +26,7 @@ export const columns: ColumnDef<Provider>[] = [
         <div className="flex items-center space-x-2">
           <span>{shortenedIdentity}</span>
           <button
-            onClick={() => navigator.clipboard.writeText(identity)}
+            onClick={() => copyToClipboard(identity)}
             className="p-1 rounded"
             title="Copy to clipboard"
           >

--- a/apps/middleman/src/app/api/provider-rpc/route.ts
+++ b/apps/middleman/src/app/api/provider-rpc/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: Request) {
       console.error('Provider not found');
       return new Response("Provider not found", {status: 404});
     }
-    console.log('Provider loaded:', JSON.stringify(provider, null, 2));
+    console.log('Provider loaded:', JSON.stringify({ id: provider.id, name: provider.name, }, null, 2))
   } catch (error) {
     console.error(error);
     return new Response("Unable to load the provider", {status: 500});

--- a/apps/middleman/src/app/app/(lists)/suppliers/table/columns.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/table/columns.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CsvColumnDef } from '@igniter/ui/lib/csv'
-import {NodeWithDetails, Provider, Transaction} from '@igniter/db/middleman/schema'
+import {NodeWithDetails, Provider} from '@igniter/db/middleman/schema'
 import {NodeStatus} from '@igniter/db/middleman/enums'
 import {
   CopyIcon,
@@ -14,6 +14,7 @@ import {
 } from "@igniter/ui/components/DataTable/index";
 import {
   amountToPokt,
+  copyToClipboard,
   getShortAddress,
   roundAndSeparate,
 } from "@igniter/ui/lib/utils";
@@ -21,17 +22,17 @@ import {CellContext, ColumnDef} from "@tanstack/react-table";
 import { useCallback } from "react";
 import { toast } from "sonner";
 import { useAddItemToDetail } from '@igniter/ui/components/QuickDetails/Provider';
+import { QuickInfoPopOverIcon } from '@igniter/ui/components/QuickInfoPopOverIcon';
 
-export type NodeDetails = NodeWithDetails & {
+export type NodeDetails = Omit<NodeWithDetails, 'transactionsToNodes'> & {
   height: number;
-  transactions: Transaction[];
 };
 
 const createAddressCellRenderer = (attribute: keyof Pick<NodeDetails, 'address' | 'ownerAddress'>) => ({ row }: CellContext<NodeDetails, unknown>) => {
       const address = row.getValue(attribute) as string;
 
       const onClickCopy = useCallback(() => {
-        navigator.clipboard.writeText(address).then(() => {
+        copyToClipboard(address).then(() => {
           toast.success("Address copied to clipboard");
         });
       }, [address]);
@@ -80,11 +81,21 @@ export const columns: (ColumnDef<NodeDetails> & CsvColumnDef<NodeDetails>)[] = [
   },
   {
     id: "height",
-    header: "Height",
+    header: () => (
+      <div className="flex items-center justify-end gap-1">
+        <span>Height</span>
+        <QuickInfoPopOverIcon
+          title="Last Updated Height"
+          description="The block height at which this supplier's on-chain state was last synced."
+          url=""
+        />
+      </div>
+    ),
     accessorKey: "height",
     meta: {
       headerAlign: 'right'
     },
+    csvHeader: "Height",
     csvFormatterFn: (item: NodeDetails) => item.height.toString(),
     cell: ({ row }) => {
       return (
@@ -185,19 +196,6 @@ export const columns: (ColumnDef<NodeDetails> & CsvColumnDef<NodeDetails>)[] = [
                   operationalFundsAmount: Number(node.balance.toString()),
                   provider: node.provider,
                   services: node.services ?? [],
-                  transactions: node.transactions.map(t => ({
-                    id: t.id,
-                    type: t.type,
-                    status: t.status,
-                    createdAt: t.createdAt!,
-                    operations: JSON.parse(t.unsignedPayload).body.messages,
-                    hash: t.hash || '',
-                    estimatedFee: t.estimatedFee,
-                    consumedFee: t.consumedFee,
-                    provider: node.provider?.name || '',
-                    providerFee: t.providerFee,
-                    typeProviderFee: t.typeProviderFee,
-                  })),
                 }
               })
             }}

--- a/apps/middleman/src/app/app/(lists)/suppliers/table/index.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/table/index.tsx
@@ -7,22 +7,6 @@ import { useQuery } from '@tanstack/react-query'
 import {ItemBase, useDetailContext} from '@igniter/ui/components/QuickDetails/Provider'
 import { useEffect } from 'react'
 
-const getHeight = (transactions: NodeDetails['transactions']) => {
-  const stakeTxs = transactions
-    ?.filter((tx) => tx.type === "Stake");
-
-  if (!stakeTxs || stakeTxs.length === 0) return undefined;
-
-  const mostRecentStake = stakeTxs
-    .slice()
-    .sort((a, b) =>
-      new Date(b.createdAt!).getTime() -
-      new Date(a.createdAt!).getTime()
-    )[0];
-
-  return mostRecentStake?.executionHeight;
-}
-
 export default function NodesTable() {
   const { data, isError, isLoading, refetch } = useQuery({
     queryKey: ["nodes"],
@@ -48,19 +32,6 @@ export default function NodesTable() {
               stakeAmount: Number(node.stakeAmount),
               operationalFundsAmount: Number(node.balance.toString()),
               services: node.services ?? [],
-              transactions: node.transactionsToNodes.map((transaction) => transaction.transaction).map(t => ({
-                id: t.id,
-                type: t.type,
-                status: t.status,
-                createdAt: t.createdAt!,
-                operations: JSON.parse(t.unsignedPayload).body.messages,
-                hash: t.hash || '',
-                estimatedFee: t.estimatedFee,
-                consumedFee: t.consumedFee,
-                provider: node.provider?.name || '',
-                providerFee: t.providerFee,
-                typeProviderFee: t.typeProviderFee,
-              })),
             }
           }, index)
         }
@@ -81,13 +52,11 @@ export default function NodesTable() {
   }, [data])
 
   const nodes: Array<NodeDetails> = data?.map((node) => {
-    const transactions = node.transactionsToNodes.map((transaction) => transaction.transaction)
     return {
       ...node,
       provider: node.provider ?? null,
       stakeAmount: node.stakeAmount,
-      transactions,
-      height: getHeight(transactions) || 0,
+      height: node.lastUpdatedHeight ?? 0,
     }
   }) || [];
 

--- a/apps/middleman/src/app/app/unstake/components/NodeSelectionStep.tsx
+++ b/apps/middleman/src/app/app/unstake/components/NodeSelectionStep.tsx
@@ -5,14 +5,18 @@ import { Button } from "@igniter/ui/components/button";
 import { Skeleton } from "@igniter/ui/components/skeleton";
 import { Input } from "@igniter/ui/components/input";
 import { Checkbox } from "@igniter/ui/components/checkbox";
-import { useQuery } from "@tanstack/react-query";
-import { GetUserNodes } from "@/actions/Nodes";
 import { useState, useMemo } from "react";
-import { NodeWithDetails } from "@igniter/db/middleman/schema";
 import { getShortAddress, toCurrencyFormat } from "@igniter/ui/lib/utils";
 import AvatarByString from "@igniter/ui/components/AvatarByString";
+import { GetUserNodes } from "@/actions/Nodes";
+
+type UserNodes = Awaited<ReturnType<typeof GetUserNodes>>;
 
 export interface NodeSelectionStepProps {
+  nodes: UserNodes | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
   ownerAddress: string;
   selectedNodes: string[];
   onNodesSelected: (nodeAddresses: string[]) => void;
@@ -21,6 +25,10 @@ export interface NodeSelectionStepProps {
 }
 
 export function NodeSelectionStep({
+  nodes,
+  isLoading,
+  isError,
+  onRetry,
   ownerAddress,
   selectedNodes,
   onNodesSelected,
@@ -29,16 +37,6 @@ export function NodeSelectionStep({
 }: Readonly<NodeSelectionStepProps>) {
   const [searchTerm, setSearchTerm] = useState("");
   const [internalSelectedNodes, setInternalSelectedNodes] = useState<string[]>(selectedNodes);
-
-  const {
-    data: nodes,
-    isLoading,
-    isError,
-    refetch,
-  } = useQuery({
-    queryKey: ['user-nodes'],
-    queryFn: GetUserNodes,
-  });
 
   // Filter nodes based on owner address and search term
   const filteredNodes = useMemo(() => {
@@ -53,17 +51,13 @@ export function NodeSelectionStep({
 
     const lowerSearch = searchTerm.toLowerCase();
     return ownerNodes.filter(node => {
-      // Search by operator address (node address)
       if (node.address.toLowerCase().includes(lowerSearch)) return true;
-
-      // Search by provider name
       if (node.provider?.name?.toLowerCase().includes(lowerSearch)) return true;
-
       return false;
     });
   }, [nodes, ownerAddress, searchTerm]);
 
-  const handleToggleNode = (node: NodeWithDetails) => {
+  const handleToggleNode = (node: { address: string }) => {
     setInternalSelectedNodes(prev =>
       prev.includes(node.address)
         ? prev.filter(addr => addr !== node.address)
@@ -79,12 +73,10 @@ export function NodeSelectionStep({
     );
 
     if (allSelected) {
-      // Unselect all filtered nodes
       setInternalSelectedNodes(prev =>
         prev.filter(addr => !filteredAddresses.includes(addr))
       );
     } else {
-      // Select all filtered nodes
       setInternalSelectedNodes(prev => {
         const newSelected = [...prev];
         filteredAddresses.forEach(addr => {
@@ -101,10 +93,6 @@ export function NodeSelectionStep({
     if (filteredNodes.length === 0) return false;
     return filteredNodes.every(node => internalSelectedNodes.includes(node.address));
   }, [filteredNodes, internalSelectedNodes]);
-
-  const handleContinue = () => {
-    onNodesSelected(internalSelectedNodes);
-  };
 
   return (
     <div className="flex flex-col w-[480px] border-x border-b border-border-primary bg-bg-root p-[33px] rounded-b-[12px] gap-6">
@@ -136,7 +124,7 @@ export function NodeSelectionStep({
           <span className="text-[14px] font-medium text-[var(--text-primary)]">
             Failed to load nodes
           </span>
-          <Button onClick={() => refetch()} className="mt-2 w-fit">
+          <Button onClick={onRetry} className="mt-2 w-fit">
             Retry
           </Button>
         </div>
@@ -171,43 +159,41 @@ export function NodeSelectionStep({
               </div>
 
               <div className="flex flex-col max-h-[400px] overflow-y-auto border border-[var(--border-primary)] rounded-b-[8px]">
-                {filteredNodes.map((node) => {
-                  return (
-                    <div
-                      key={node.address}
-                      className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--border-primary)] last:border-b-0 hover:bg-[var(--bg-surface)] cursor-pointer"
-                      onClick={() => handleToggleNode(node)}
-                    >
-                      <div className="flex flex-row items-center gap-3 flex-1">
-                        <Checkbox
-                          checked={internalSelectedNodes.includes(node.address)}
-                          onCheckedChange={() => handleToggleNode(node)}
-                        />
-                        <div className="flex flex-col gap-1">
-                          <div className="flex flex-row items-center gap-2">
-                            <AvatarByString string={node.address} />
-                            <span className="font-mono text-[14px] text-[var(--text-primary)]">
-                              {getShortAddress(node.address, 5)}
-                            </span>
-                          </div>
-                          {node.provider?.name && (
-                            <div className="flex flex-row items-center gap-2 text-[12px] text-[var(--text-tertiary)]">
-                              <span>Provider: {node.provider.name}</span>
-                            </div>
-                          )}
+                {filteredNodes.map((node) => (
+                  <div
+                    key={node.address}
+                    className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--border-primary)] last:border-b-0 hover:bg-[var(--bg-surface)] cursor-pointer"
+                    onClick={() => handleToggleNode(node)}
+                  >
+                    <div className="flex flex-row items-center gap-3 flex-1">
+                      <Checkbox
+                        checked={internalSelectedNodes.includes(node.address)}
+                        onCheckedChange={() => handleToggleNode(node)}
+                      />
+                      <div className="flex flex-col gap-1">
+                        <div className="flex flex-row items-center gap-2">
+                          <AvatarByString string={node.address} />
+                          <span className="font-mono text-[14px] text-[var(--text-primary)]">
+                            {getShortAddress(node.address, 5)}
+                          </span>
                         </div>
-                      </div>
-                      <div className="flex flex-col items-end gap-0">
-                        <span className="font-mono text-[14px] text-[var(--text-primary)]">
-                          {toCurrencyFormat(parseFloat(node.stakeAmount) / 1e6, 2, 2)}
-                        </span>
-                        <span className="font-mono text-[12px] text-[var(--text-tertiary)]">
-                          $POKT
-                        </span>
+                        {node.provider?.name && (
+                          <div className="flex flex-row items-center gap-2 text-[12px] text-[var(--text-tertiary)]">
+                            <span>Provider: {node.provider.name}</span>
+                          </div>
+                        )}
                       </div>
                     </div>
-                  );
-                })}
+                    <div className="flex flex-col items-end gap-0">
+                      <span className="font-mono text-[14px] text-[var(--text-primary)]">
+                        {toCurrencyFormat(parseFloat(node.stakeAmount) / 1e6, 2, 2)}
+                      </span>
+                      <span className="font-mono text-[12px] text-[var(--text-tertiary)]">
+                        $POKT
+                      </span>
+                    </div>
+                  </div>
+                ))}
               </div>
             </>
           )}
@@ -215,7 +201,7 @@ export function NodeSelectionStep({
       )}
 
       <Button
-        onClick={handleContinue}
+        onClick={() => onNodesSelected(internalSelectedNodes)}
         disabled={internalSelectedNodes.length === 0}
         className="w-full"
       >

--- a/apps/middleman/src/app/app/unstake/components/OwnerAddressSelectionStep.tsx
+++ b/apps/middleman/src/app/app/unstake/components/OwnerAddressSelectionStep.tsx
@@ -2,16 +2,21 @@
 
 import { ActivityHeader } from '@igniter/ui/components/ActivityHeader';
 import { useWalletConnection } from '@igniter/ui/context/WalletConnection/index';
-import { useEffect, useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { getShortAddress, toCurrencyFormat } from '@igniter/ui/lib/utils';
 import { Checkbox } from '@igniter/ui/components/checkbox';
 import { Button } from '@igniter/ui/components/button';
 import { Skeleton } from '@igniter/ui/components/skeleton';
 import AvatarByString from '@igniter/ui/components/AvatarByString';
-import { useQuery } from '@tanstack/react-query';
 import { GetUserNodes } from '@/actions/Nodes';
 
+type UserNodes = Awaited<ReturnType<typeof GetUserNodes>>;
+
 interface OwnerAddressSelectionStepProps {
+  nodes: UserNodes | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry: () => void;
   onClose: () => void;
   onBack: () => void;
   selectedOwnerAddress?: string;
@@ -25,6 +30,10 @@ interface OwnerAddressData {
 }
 
 export function OwnerAddressSelectionStep({
+  nodes,
+  isLoading,
+  isError,
+  onRetry,
   onClose,
   onBack,
   onOwnerAddressSelected,
@@ -32,16 +41,6 @@ export function OwnerAddressSelectionStep({
 }: OwnerAddressSelectionStepProps) {
   const { connectedIdentity, connectedIdentities } = useWalletConnection();
   const [selectedOwnerAddress, setSelectedOwnerAddress] = useState(selectedOwnerAddressFromProps || '');
-
-  const {
-    data: nodes,
-    isLoading,
-    isError,
-    refetch,
-  } = useQuery({
-    queryKey: ['user-nodes'],
-    queryFn: GetUserNodes,
-  });
 
   // Calculate node count and total staked amount per owner address
   const ownerAddressData = useMemo(() => {
@@ -101,7 +100,7 @@ export function OwnerAddressSelectionStep({
           <span className="text-[14px] font-medium text-[var(--text-primary)]">
             Failed to load owner addresses
           </span>
-          <Button onClick={() => refetch()} className="mt-2 w-fit">
+          <Button onClick={onRetry} className="mt-2 w-fit">
             Retry
           </Button>
         </div>
@@ -119,7 +118,7 @@ export function OwnerAddressSelectionStep({
 
           {ownerAddressData.length > 0 && (
             <div className="flex flex-col gap-4 h-full overflow-y-auto">
-              {ownerAddressData.map((data, index) => {
+              {ownerAddressData.map((data) => {
                 const isPrimaryAccount = data.address === connectedIdentity;
                 return (
                   <div key={data.address}>

--- a/apps/middleman/src/app/app/unstake/components/ReviewStep/index.tsx
+++ b/apps/middleman/src/app/app/unstake/components/ReviewStep/index.tsx
@@ -6,8 +6,8 @@ import { Skeleton } from "@igniter/ui/components/skeleton";
 import { QuickInfoPopOverIcon } from "@igniter/ui/components/QuickInfoPopOverIcon";
 import { CaretSmallIcon, CornerIcon } from "@igniter/ui/assets";
 import { useQuery } from "@tanstack/react-query";
-import { GetUserNodes } from "@/actions/Nodes";
 import { GetUnstakeDuration } from "@/actions/Unstake";
+import { GetUserNodes } from "@/actions/Nodes";
 import { formatDuration } from "@/lib/utils/time";
 import { useMemo, useState } from "react";
 import { getShortAddress, toCurrencyFormat } from "@igniter/ui/lib/utils";
@@ -16,7 +16,13 @@ import { UnstakingProcess, UnstakingProcessStatus } from "@/app/app/unstake/comp
 import { Transaction } from "@igniter/db/middleman/schema";
 import React from "react";
 
+type UserNodes = Awaited<ReturnType<typeof GetUserNodes>>;
+
 export interface ReviewStepProps {
+  nodes: UserNodes | undefined;
+  isLoadingNodes: boolean;
+  isErrorNodes: boolean;
+  onRetryNodes: () => void;
   selectedNodeAddresses: string[];
   ownerAddress: string;
   errorMessage?: string;
@@ -36,6 +42,10 @@ interface OwnerAddressGroup {
 }
 
 export function ReviewStep({
+  nodes,
+  isLoadingNodes,
+  isErrorNodes,
+  onRetryNodes,
   selectedNodeAddresses,
   ownerAddress,
   errorMessage,
@@ -44,16 +54,6 @@ export function ReviewStep({
   onClose
 }: Readonly<ReviewStepProps>) {
   const [isShowingNodeDetails, setIsShowingNodeDetails] = useState(false);
-
-  const {
-    data: nodes,
-    isLoading: isLoadingNodes,
-    isError: isErrorNodes,
-    refetch: refetchNodes,
-  } = useQuery({
-    queryKey: ['user-nodes'],
-    queryFn: GetUserNodes,
-  });
 
   const {
     data: unstakeDurationData,
@@ -104,8 +104,6 @@ export function ReviewStep({
   const totalStakeAmount = useMemo(() => {
     return selectedNodes.reduce((sum, node) => sum + parseFloat(node.stakeAmount), 0);
   }, [selectedNodes]);
-
-  const totalTransactions = ownerAddressGroups.length;
 
   const formattedDuration = unstakeDurationData ? formatDuration(unstakeDurationData.durationSeconds) : null;
 
@@ -167,7 +165,7 @@ export function ReviewStep({
             Failed to load unstake information.
             <div className="flex gap-2 mt-2">
               {isErrorNodes && (
-                <Button onClick={() => refetchNodes()} className="h-[30px]">
+                <Button onClick={onRetryNodes} className="h-[30px]">
                   Retry Nodes
                 </Button>
               )}

--- a/apps/middleman/src/app/app/unstake/page.tsx
+++ b/apps/middleman/src/app/app/unstake/page.tsx
@@ -38,6 +38,9 @@ export default function UnstakePage() {
 
   const {
     data: nodes,
+    isLoading: isLoadingNodes,
+    isError: isErrorNodes,
+    refetch: refetchNodes,
   } = useQuery({
     queryKey: ['user-nodes'],
     queryFn: GetUserNodes,
@@ -138,6 +141,10 @@ export default function UnstakePage() {
 
           {step === UnstakeActivitySteps.OwnerAddressSelection && (
             <OwnerAddressSelectionStep
+              nodes={nodes}
+              isLoading={isLoadingNodes}
+              isError={isErrorNodes}
+              onRetry={refetchNodes}
               selectedOwnerAddress={selectedOwnerAddress}
               onOwnerAddressSelected={handleOwnerAddressSelected}
               onBack={() => setStep(UnstakeActivitySteps.Information)}
@@ -147,6 +154,10 @@ export default function UnstakePage() {
 
           {step === UnstakeActivitySteps.NodeSelection && (
             <NodeSelectionStep
+              nodes={nodes}
+              isLoading={isLoadingNodes}
+              isError={isErrorNodes}
+              onRetry={refetchNodes}
               ownerAddress={selectedOwnerAddress}
               selectedNodes={selectedNodeAddresses}
               onNodesSelected={handleNodesSelected}
@@ -163,6 +174,10 @@ export default function UnstakePage() {
 
           {step === UnstakeActivitySteps.Review && (
             <ReviewStep
+              nodes={nodes}
+              isLoadingNodes={isLoadingNodes}
+              isErrorNodes={isErrorNodes}
+              onRetryNodes={refetchNodes}
               selectedNodeAddresses={selectedNodeAddresses}
               ownerAddress={selectedOwnerAddress}
               errorMessage={unstakingErrorMessage}

--- a/apps/middleman/src/app/detail/NodeDetail.tsx
+++ b/apps/middleman/src/app/detail/NodeDetail.tsx
@@ -22,6 +22,8 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { GetUnstakeDuration } from '@/actions/Unstake'
 import { GetSupplierChanges, AcknowledgeAllByNode } from '@/actions/SupplierChanges'
 import { formatDuration } from '@/lib/utils/time'
+import { GetNode } from '@/actions/Nodes'
+import { Skeleton } from '@igniter/ui/components/skeleton'
 
 export interface NodeDetailBody {
   [key: string]: unknown;
@@ -32,7 +34,7 @@ export interface NodeDetailBody {
   provider: Provider | null;
   stakeAmount: number;
   operationalFundsAmount: number;
-  transactions: Array<TransactionDetailBody>;
+  transactions?: Array<TransactionDetailBody>;
   services: NodeService[];
 }
 
@@ -245,10 +247,10 @@ export default function NodeDetail({
    address,
    ownerAddress,
    status,
-   transactions,
    provider,
    operationalFundsAmount,
    stakeAmount,
+   transactions: transactionsFromProps,
    services,
 }: NodeDetailBody) {
   const addItem = useAddItemToDetail()
@@ -264,6 +266,26 @@ export default function NodeDetail({
     queryFn: GetUnstakeDuration,
     enabled: status === NodeStatus.Staked,
   });
+  
+  const { data: nodeData, isLoading: isLoadingTransactions } = useQuery({
+    queryKey: ['node-transactions', address],
+    queryFn: () => GetNode(address),
+    enabled: !transactionsFromProps?.length,
+  });
+
+  const transactions: TransactionDetailBody[] = transactionsFromProps ?? (nodeData?.transactionsToNodes ?? []).map((t) => ({
+    id: t.transaction.id,
+    type: t.transaction.type,
+    status: t.transaction.status,
+    createdAt: t.transaction.createdAt!,
+    operations: JSON.parse(t.transaction.unsignedPayload).body.messages,
+    hash: t.transaction.hash || '',
+    estimatedFee: t.transaction.estimatedFee,
+    consumedFee: t.transaction.consumedFee,
+    provider: provider?.name || '',
+    providerFee: t.transaction.providerFee,
+    typeProviderFee: t.transaction.typeProviderFee,
+  }));
 
   const summaryRows: Array<SummaryRow> = [
     {
@@ -295,7 +317,12 @@ export default function NodeDetail({
     }
   ]
 
-  if (transactions.length) {
+  if (isLoadingTransactions) {
+    summaryRows.push({
+      label: <Skeleton className="w-24 h-4 bg-bg-elevated" />,
+      value: null,
+    })
+  } else if (transactions.length) {
     summaryRows.push({
       label: (
         <div className={'flex items-center gap-2'}>

--- a/apps/middleman/src/lib/dal/nodes.ts
+++ b/apps/middleman/src/lib/dal/nodes.ts
@@ -11,14 +11,6 @@ export async function getNodesByUser(userIdentity: string) {
     where: eq(nodesTable.createdBy, userIdentity),
     with: {
       provider: true,
-      transactionsToNodes: {
-        with: {
-          transaction: true,
-        },
-        limit: 10,
-        // here we can't order directly by cratedAt of transactionsToNodes because findMany doesn't support orderBy on relations
-        orderBy: (t) => [desc(t.transactionId)]
-      },
     },
   });
 }

--- a/apps/provider/src/app/admin/(internal)/delegators/table/columns.tsx
+++ b/apps/provider/src/app/admin/(internal)/delegators/table/columns.tsx
@@ -11,6 +11,7 @@ import {
   SortOption,
 } from '@igniter/ui/components/DataTable/index'
 import {CsvColumnDef} from "@igniter/ui/lib/csv";
+import { copyToClipboard } from "@igniter/ui/lib/utils";
 
 export const columns: Array<ColumnDef<Delegator> & CsvColumnDef<Delegator>> = [
   {
@@ -29,7 +30,7 @@ export const columns: Array<ColumnDef<Delegator> & CsvColumnDef<Delegator>> = [
         <div className="flex items-center space-x-2">
           <span>{shortenedIdentity}</span>
           <button
-            onClick={() => navigator.clipboard.writeText(identity)}
+            onClick={() => copyToClipboard(identity)}
             className="p-1 rounded"
             title="Copy to clipboard"
           >

--- a/apps/provider/src/app/admin/details/KeyDetail/PrivateKeyReveal.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/PrivateKeyReveal.tsx
@@ -5,6 +5,7 @@ import {clsx} from 'clsx'
 import {Button} from '@igniter/ui/components/button'
 import {LoaderIcon, WarningIcon, CopyIcon, CheckSuccess as CheckIcon} from '@igniter/ui/assets'
 import {RevealPrivateKey} from '@/actions/Keys'
+import { copyToClipboard } from '@igniter/ui/lib/utils'
 
 const AUTO_HIDE_SECONDS = 30
 
@@ -69,7 +70,7 @@ export default function PrivateKeyReveal({keyId}: {keyId: number}) {
 
   const handleCopy = () => {
     if (!privateKey) return
-    navigator.clipboard.writeText(privateKey).then(() => {
+    copyToClipboard(privateKey).then(() => {
       setIsCopied(true)
       setTimeout(() => setIsCopied(false), 1500)
     })

--- a/apps/provider/src/app/admin/details/KeyDetail/RemediationHistoryList.tsx
+++ b/apps/provider/src/app/admin/details/KeyDetail/RemediationHistoryList.tsx
@@ -6,6 +6,7 @@ import {UpdateKeysState} from "@/actions/Keys";
 import {ActionButton} from "@/app/admin/details/KeyDetail/ActionButton";
 import {ConfirmationDialog} from "@/components/ConfirmationDialog";
 import {Button} from "@igniter/ui/components/button";
+import { copyToClipboard } from "@igniter/ui/lib/utils";
 
 export function RemediationHistoryList({ entries, keyId, keyState }: { entries: RemediationHistoryEntry[]; keyId: number, keyState: KeyState }) {
 
@@ -84,28 +85,7 @@ export function RemediationHistoryList({ entries, keyId, keyState }: { entries: 
     const [copied, setCopied] = React.useState(false)
 
     const copy = async () => {
-      try {
-        if (navigator && 'clipboard' in navigator) {
-          await navigator.clipboard.writeText(text)
-        } else {
-          throw new Error('clipboard api not available')
-        }
-      } catch {
-        // Fallback for older browsers
-        try {
-          const textarea = document.createElement('textarea')
-          textarea.value = text
-          textarea.setAttribute('readonly', '')
-          textarea.style.position = 'absolute'
-          textarea.style.left = '-9999px'
-          document.body.appendChild(textarea)
-          textarea.select()
-          document.execCommand('copy')
-          document.body.removeChild(textarea)
-        } catch {
-          // ignore
-        }
-      }
+      await copyToClipboard(text)
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
     }

--- a/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
+++ b/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
@@ -4,7 +4,7 @@ import {zodResolver} from "@hookform/resolvers/zod";
 import {useForm} from "react-hook-form";
 import {z} from "zod";
 import {Button} from "@igniter/ui/components/button";
-import {getShortAddress} from "@igniter/ui/lib/utils";
+import { copyToClipboard, getShortAddress } from "@igniter/ui/lib/utils";
 import {
   Form,
   FormControl,
@@ -390,7 +390,7 @@ export function AddOrUpdateServiceDialog({
                         <button
                           type="button"
                           className="text-text-tertiary hover:text-text-primary transition-colors"
-                          onClick={() => navigator.clipboard.writeText(serviceOnChain.ownerAddress)}
+                          onClick={() => copyToClipboard(serviceOnChain.ownerAddress)}
                           title="Copy address"
                         >
                           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>

--- a/packages/ui/src/components/Address.tsx
+++ b/packages/ui/src/components/Address.tsx
@@ -4,7 +4,7 @@ import CopyIcon from '../assets/icons/dark/copy.svg'
 import CheckIcon from '../assets/icons/dark/check_success.svg'
 import AvatarByString from './AvatarByString'
 import React from 'react'
-import { getShortAddress } from '../lib/utils'
+import { copyToClipboard, getShortAddress } from '../lib/utils'
 import { clsx } from 'clsx'
 
 interface AddressProps {
@@ -17,7 +17,7 @@ export default function Address({address, onClick, showAvatar}: AddressProps) {
   const [isCopied, setIsCopied] = React.useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(address).then(() => {
+    copyToClipboard(address).then(() => {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 1000);
     });

--- a/packages/ui/src/components/TransactionHash.tsx
+++ b/packages/ui/src/components/TransactionHash.tsx
@@ -3,6 +3,7 @@ import { Button } from './button'
 import CopyIcon from '../assets/icons/dark/copy.svg'
 import CheckIcon from '../assets/icons/dark/check_success.svg'
 import React from 'react'
+import { copyToClipboard } from '../lib/utils'
 
 interface TransactionHashProps {
   hash: string;
@@ -14,7 +15,7 @@ export default function TransactionHash({hash, onClick}: TransactionHashProps) {
   const truncateHash = hash.slice(0, 7) + '...' + hash.slice(-7);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(hash).then(() => {
+    copyToClipboard(hash).then(() => {
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 1000);
     });

--- a/packages/ui/src/components/WalletPicker/index.tsx
+++ b/packages/ui/src/components/WalletPicker/index.tsx
@@ -18,7 +18,7 @@ import DialogContentSectionHeader from "@igniter/ui/components/DialogContentSect
 import WalletPickerItem, {WalletPickerItemProps} from "./components/WalletPickerItem";
 import {DialogClose} from "../dialog";
 import {useWalletConnection} from "@igniter/ui/context/WalletConnection/index";
-import { getShortAddress } from "../../lib/utils";
+import { copyToClipboard, getShortAddress } from "../../lib/utils";
 import { Checkbox } from '../checkbox'
 import { LoaderIcon } from '../../assets'
 import AvatarByString from "../AvatarByString";
@@ -450,7 +450,7 @@ function SignInStep({
 
     const copyErrorToClipboard = async () => {
       if (errorDetails) {
-        await navigator.clipboard.writeText(errorDetails)
+        await copyToClipboard(errorDetails)
         setCopied(true)
         setTimeout(() => setCopied(false), 2000)
       }

--- a/packages/ui/src/lib/csv.ts
+++ b/packages/ui/src/lib/csv.ts
@@ -3,6 +3,7 @@ import * as CSV from 'csv-string'
 export interface CsvColumnDef<T extends object> {
   accessorKey?: keyof T
   header?: string
+  csvHeader?: string
   csvFormatterFn?: (rowData: T) => string
 }
 
@@ -67,7 +68,7 @@ export const exportToCsvFromClient = <T extends object>({
     (item: T) => (rowsDataString += convertRowToString<T>(columns,item))
   )
 
-  const blob = new Blob([CSV.stringify(columns.filter(item => !!item.accessorKey && !!item.csvFormatterFn).map(item => item.header!)) + rowsDataString], {
+  const blob = new Blob([CSV.stringify(columns.filter(item => !!item.accessorKey && !!item.csvFormatterFn).map(item => item.csvHeader ?? item.header!)) + rowsDataString], {
     type: 'text/csv;charset=utf-8;',
   })
   const url = URL.createObjectURL(blob)

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -49,6 +49,22 @@ export function amountToPokt(amount: string | number): number {
   return isNaN(Number(amount)) ? 0 : Number(amount) / UPOKT_CONSTANT;
 }
 
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text);
+  }
+  // Fallback for non-secure contexts (plain HTTP)
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+}
+
 export function toDateFormat(value: Date | null) {
     return value
         ? value.toLocaleString("en-US", {


### PR DESCRIPTION
## Summary

- **Fix DB timeout crash on overview/import-suppliers pages**: `getNodesByUser` was fetching all nodes with up to 10 transactions each via a heavy JOIN, causing PostgreSQL statement timeouts for users with many suppliers. Removed `transactionsToNodes` from the list query entirely.
- **Load supplier transactions on demand**: The supplier detail panel now fetches transactions via `GetNode` only when the panel is opened (and only if not already provided by the caller), keeping the list query lean.
- **Fix suppliers table Height column**: Replaced the `executionHeight` derived from stake transactions with `lastUpdatedHeight` from the node record. Added an info tooltip explaining what the field represents. Added `csvHeader` to `CsvColumnDef` so JSX column headers export correctly to CSV.
- **Eliminate redundant `GetUserNodes` calls in the unstake flow**: All four components (`page.tsx`, `OwnerAddressSelectionStep`, `NodeSelectionStep`, `ReviewStep`) were independently calling `useQuery(['user-nodes'])`. The query now lives only in `page.tsx` and data is passed as props to each step.
- **Clipboard fallback for non-HTTPS contexts**: Added `copyToClipboard` utility that falls back to `document.execCommand('copy')` when `navigator.clipboard` is unavailable (plain HTTP deployments). Migrated all 9 usages across both apps and the UI package.
