### PR TITLE
fix: mark stake transactions correctly when they land more than one block after broadcast

### DIFF
--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -475,13 +475,16 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
     )
   },
   /**
-   * Checks whether a supplier exists on-chain with the given operator address.
-   * Used as a Tier 4 positive-only fallback for Stake transactions when `verifyTransaction`
-   * exhausts its retries without finding the tx hash.
+   * Returns true only when a supplier exists on-chain at `operatorAddress` AND it is
+   * owned by `expectedOwnerAddress`. Used as a Tier 4 positive-only fallback for Stake
+   * transactions when `verifyTransaction` exhausts its retries without finding the tx
+   * hash. The ownership check guards against a false positive: during the ~30-block
+   * verify window another operator could stake the same address, so existence alone is
+   * not proof that *our* stake is the one that landed.
    */
-  async checkSupplierOnChain(operatorAddress: string): Promise<boolean> {
+  async checkSupplierOnChain(operatorAddress: string, expectedOwnerAddress: string): Promise<boolean> {
     const supplier = await pocketRpcClient.getSupplier(operatorAddress)
-    return !!supplier
+    return !!supplier && supplier.ownerAddress === expectedOwnerAddress
   },
   /**
    * Creates new nodes based on the data extracted from a provided transaction.

--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -455,28 +455,33 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
   /**
    * Verifies the transaction status by the given transaction hash.
    *
-   * @param {string} hash - The hash of the transaction to be verified.
-   * @return {Promise<readonly [boolean, number, string]>} A promise that resolves to a tuple containing the success status (boolean), the transaction code (number), and the gas used (string). Throws an error if the transaction data is incomplete or not found.
+   * Returns `[success, code, gasUsed]` when the tx is found on-chain. Throws a retriable
+   * `ApplicationFailure` when the tx is not (yet) found — the workflow's activity retry
+   * policy handles re-checking across blocks until the expiration window closes.
    */
-  async verifyTransaction(hash: string, height?: number, operatorAddress?: string) {
+  async verifyTransaction(
+    hash: string,
+    height?: number,
+  ): Promise<readonly [boolean, number, string]> {
     const tx = await pocketRpcClient.getTransaction(hash, height)
     if (tx) {
       return [tx.success, tx.code, tx.gasUsed?.toString() || '0'] as const
     }
 
-    // Tier 4: all lookup methods failed — check supplier state directly
-    if (operatorAddress) {
-      log.warn('TX not found via any method, checking supplier state', { hash, operatorAddress })
-      const supplier = await pocketRpcClient.getSupplier(operatorAddress)
-      if (supplier) {
-        log.info('Supplier exists on-chain, marking TX as success', { hash, operatorAddress })
-        return [true, 0, '0'] as const
-      }
-      log.warn('Supplier not found on-chain, marking TX as failure', { hash, operatorAddress })
-      return [false, -1, '0'] as const
-    }
-
-    throw new Error('Transaction data is incomplete or not found')
+    throw ApplicationFailure.retryable(
+      'Transaction not found on-chain',
+      'TX_NOT_FOUND',
+      { hash, height },
+    )
+  },
+  /**
+   * Checks whether a supplier exists on-chain with the given operator address.
+   * Used as a Tier 4 positive-only fallback for Stake transactions when `verifyTransaction`
+   * exhausts its retries without finding the tx hash.
+   */
+  async checkSupplierOnChain(operatorAddress: string): Promise<boolean> {
+    const supplier = await pocketRpcClient.getSupplier(operatorAddress)
+    return !!supplier
   },
   /**
    * Creates new nodes based on the data extracted from a provided transaction.

--- a/apps/middleman-workflows/src/lib/blockchain/index.ts
+++ b/apps/middleman-workflows/src/lib/blockchain/index.ts
@@ -148,7 +148,14 @@ export class Blockchain implements IBlockchain {
       const maxBlocks = 30;
       try {
         const comet = await connectComet(this.rpcUrl);
-        for (let h = height; h < height + maxBlocks; h++) {
+        const status = await comet.status();
+        const latestHeight = status.syncInfo.latestBlockHeight;
+        // Only scan blocks that already exist on-chain. Future heights throw and would
+        // waste the scan budget; the workflow-level poll loop handles waiting for new
+        // blocks. Tier 3's role is to recover from a lagging/broken tx_index within
+        // already-produced blocks, not to wait for the chain to advance.
+        const endHeight = Math.min(height + maxBlocks, latestHeight);
+        for (let h = height; h <= endHeight; h++) {
           try {
             const block = await comet.block(h);
             const txs = block.block.txs;

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
@@ -1,6 +1,4 @@
 import {
-  ActivityFailure,
-  ApplicationFailure,
   proxyActivities,
   WorkflowError,
 } from '@temporalio/workflow'
@@ -9,24 +7,9 @@ import { TransactionStatus, TransactionType } from '@igniter/db/middleman/enums'
 import {SendTransactionResult} from "@/lib/blockchain";
 
 const TX_EXPIRATION_BLOCKS = 30
-const TX_NOT_FOUND_ERROR_TYPE = 'TX_NOT_FOUND'
 
 interface TransactionArgs {
   transactionId: number;
-}
-
-/**
- * Returns true when `err` is the retries-exhausted wrapper around the retriable
- * `TX_NOT_FOUND` ApplicationFailure thrown by the `verifyTransaction` activity.
- * Any other failure (RPC unreachable, deserialization, bugs) returns false and
- * should be rethrown so the workflow fails loudly rather than silently marking
- * the tx as failure on insufficient evidence.
- */
-function isTxNotFoundFailure(err: unknown): boolean {
-  if (err instanceof ActivityFailure && err.cause instanceof ApplicationFailure) {
-    return err.cause.type === TX_NOT_FOUND_ERROR_TYPE
-  }
-  return false
 }
 
 /**
@@ -172,24 +155,18 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     // retriable TX_NOT_FOUND until the policy is exhausted.
     [success, code, gasUsed] = await verifyTransaction(txHash, baseHeight);
     txFoundOnChain = true;
-  } catch (err) {
-    // Only fall through to Tier 4 when retries were exhausted specifically with
-    // TX_NOT_FOUND. Any other failure (RPC unreachable, bug, unexpected shape) is
-    // rethrown so the workflow fails and the tx stays Pending for human triage —
-    // avoids false "failure" marks when we lack evidence either way.
-    if (!isTxNotFoundFailure(err)) {
-      throw err;
-    }
-
-    // Retries exhausted. Tier 4: check supplier state directly. Only a positive result
-    // (supplier on-chain) is conclusive; a missing supplier keeps the tx marked failed.
+  } catch {
     if (operatorAddress) {
-      const supplierExists = await checkSupplierOnChain(operatorAddress);
-      if (supplierExists) {
-        success = true;
-        code = 0;
-        gasUsed = '0';
-        supplierFallbackHit = true;
+      try {
+        const supplierExists = await checkSupplierOnChain(operatorAddress);
+        if (supplierExists) {
+          success = true;
+          code = 0;
+          gasUsed = '0';
+          supplierFallbackHit = true;
+        }
+      } catch {
+        // supplier check also failed — tx stays marked as Failure (success stays false)
       }
     }
   }

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
@@ -1,4 +1,6 @@
 import {
+  ActivityFailure,
+  ApplicationFailure,
   proxyActivities,
   WorkflowError,
 } from '@temporalio/workflow'
@@ -7,9 +9,24 @@ import { TransactionStatus, TransactionType } from '@igniter/db/middleman/enums'
 import {SendTransactionResult} from "@/lib/blockchain";
 
 const TX_EXPIRATION_BLOCKS = 30
+const TX_NOT_FOUND_ERROR_TYPE = 'TX_NOT_FOUND'
 
 interface TransactionArgs {
   transactionId: number;
+}
+
+/**
+ * Returns true when `err` is the retries-exhausted wrapper around the retriable
+ * `TX_NOT_FOUND` ApplicationFailure thrown by the `verifyTransaction` activity.
+ * Any other failure (RPC unreachable, deserialization, bugs) returns false and
+ * should be rethrown so the workflow fails loudly rather than silently marking
+ * the tx as failure on insufficient evidence.
+ */
+function isTxNotFoundFailure(err: unknown): boolean {
+  if (err instanceof ActivityFailure && err.cause instanceof ApplicationFailure) {
+    return err.cause.type === TX_NOT_FOUND_ERROR_TYPE
+  }
+  return false
 }
 
 /**
@@ -44,7 +61,7 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     updateTransaction,
     executeTransaction,
     getBlockHeight,
-    verifyTransaction,
+    checkSupplierOnChain,
     createNewNodesFromTransaction,
     notifyProviderOfStakedAddresses,
     notifyProviderOfFailedStakes,
@@ -54,6 +71,18 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     startToCloseTimeout: "30s",
     retry: {
       maximumAttempts: 3,
+    },
+  });
+
+  // verifyTransaction polls the chain on its own retry schedule: one attempt per block
+  // (pocket block time ≈ 1 min) up to TX_EXPIRATION_BLOCKS, matching the on-chain
+  // mempool expiration window. Throws retriable `TX_NOT_FOUND` until the tx lands.
+  const { verifyTransaction } = proxyActivities<ReturnType<typeof delegatorActivities>>({
+    startToCloseTimeout: "30s",
+    retry: {
+      initialInterval: "60s",
+      backoffCoefficient: 1,
+      maximumAttempts: TX_EXPIRATION_BLOCKS,
     },
   });
 
@@ -127,20 +156,64 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     await waitForNextBlock(txHeight);
   }
 
-  const [success, code, gasUsed] = await verifyTransaction(
-    result?.transactionHash || transaction.hash!,
-    transaction.executionHeight || txHeight,
-    extractOperatorAddress(transaction),
-  );
+  const txHash = result?.transactionHash || transaction.hash!;
+  const baseHeight = transaction.executionHeight || txHeight;
+  const operatorAddress = extractOperatorAddress(transaction);
+
+  let success = false;
+  let code = -1;
+  let gasUsed = '0';
+  let txFoundOnChain = false;
+  let supplierFallbackHit = false;
+
+  try {
+    // Retries are driven by Temporal's activity retry policy — one attempt per block
+    // up to TX_EXPIRATION_BLOCKS. A found tx returns the tuple; a missing tx throws
+    // retriable TX_NOT_FOUND until the policy is exhausted.
+    [success, code, gasUsed] = await verifyTransaction(txHash, baseHeight);
+    txFoundOnChain = true;
+  } catch (err) {
+    // Only fall through to Tier 4 when retries were exhausted specifically with
+    // TX_NOT_FOUND. Any other failure (RPC unreachable, bug, unexpected shape) is
+    // rethrown so the workflow fails and the tx stays Pending for human triage —
+    // avoids false "failure" marks when we lack evidence either way.
+    if (!isTxNotFoundFailure(err)) {
+      throw err;
+    }
+
+    // Retries exhausted. Tier 4: check supplier state directly. Only a positive result
+    // (supplier on-chain) is conclusive; a missing supplier keeps the tx marked failed.
+    if (operatorAddress) {
+      const supplierExists = await checkSupplierOnChain(operatorAddress);
+      if (supplierExists) {
+        success = true;
+        code = 0;
+        gasUsed = '0';
+        supplierFallbackHit = true;
+      }
+    }
+  }
 
   const txStatus = success ? TransactionStatus.Success : TransactionStatus.Failure;
-
   const verificationHeight = await getBlockHeight();
+
+  let verificationLog: string | undefined;
+  if (txFoundOnChain) {
+    if (code !== 0) {
+      verificationLog = `verification failed with code ${code}`;
+    }
+  } else if (supplierFallbackHit) {
+    verificationLog = 'verified via supplier state fallback (tx hash not found)';
+  } else {
+    verificationLog = `tx not found on-chain after ${TX_EXPIRATION_BLOCKS} retries (baseHeight=${baseHeight})`;
+  }
 
   await updateTransaction(transactionId, {
     status: txStatus,
     verificationHeight,
     consumedFee: Number(gasUsed || 0),
+    code,
+    log: verificationLog,
   });
 
     if (transaction.type === TransactionType.Stake) {

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
@@ -161,12 +161,15 @@ export async function ExecuteTransaction(args: TransactionArgs) {
   });
 
   if (!skipWait) {
-    // Wait for txHeight + 2 (waitForNextBlock blocks until currentHeight >= arg + 1).
-    // txHeight is sampled before broadcast, so if the chain advanced during broadcast
-    // a plain "+1" wait can no-op and trigger verifyTransaction before the tx is
-    // indexed. The extra block gives indexing margin; the verify retry loop covers the
-    // rarer case where broadcast spanned multiple blocks.
-    await waitForNextBlock(txHeight + 1);
+    // Re-sample the height AFTER broadcast: txHeight was captured before
+    // executeTransaction, so if the chain advanced during broadcast a wait based on the
+    // stale txHeight can no-op and trigger verifyTransaction before the tx is indexed.
+    // waitForNextBlock blocks until currentHeight >= arg + 1, so passing the fresh
+    // post-broadcast height guarantees we wait for at least one block past it — the
+    // indexing margin — regardless of how many blocks broadcast spanned. The verify
+    // retry loop covers any remaining lag.
+    const heightAfterBroadcast = await getBlockHeight();
+    await waitForNextBlock(heightAfterBroadcast);
   }
 
   const txHash = result?.transactionHash || transaction.hash!;

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
@@ -1,4 +1,6 @@
 import {
+  ActivityFailure,
+  ApplicationFailure,
   proxyActivities,
   WorkflowError,
 } from '@temporalio/workflow'
@@ -7,32 +9,55 @@ import { TransactionStatus, TransactionType } from '@igniter/db/middleman/enums'
 import {SendTransactionResult} from "@/lib/blockchain";
 
 const TX_EXPIRATION_BLOCKS = 30
+const TX_NOT_FOUND_ERROR_TYPE = 'TX_NOT_FOUND'
 
 interface TransactionArgs {
   transactionId: number;
 }
 
 /**
- * Extracts the operator address from a transaction's unsigned payload.
- * Used for Tier 4 fallback (supplier state check) when TX lookup fails.
+ * Returns true when `err` is the retries-exhausted wrapper around the retriable
+ * `TX_NOT_FOUND` ApplicationFailure thrown by the `verifyTransaction` activity.
+ * Any other failure (RPC unreachable, deserialization, bugs) returns false and
+ * should be rethrown so the workflow fails loudly rather than silently marking
+ * the tx as failure on insufficient evidence.
  */
-function extractOperatorAddress(transaction: { unsignedPayload?: string | null }): string | undefined {
+function isTxNotFoundFailure(err: unknown): boolean {
+  if (err instanceof ActivityFailure && err.cause instanceof ApplicationFailure) {
+    return err.cause.type === TX_NOT_FOUND_ERROR_TYPE
+  }
+  return false
+}
+
+/**
+ * Extracts the owner + operator addresses from a Stake transaction's unsigned payload.
+ * Used for the Tier 4 fallback (supplier state check) when TX lookup fails — both are
+ * needed so the fallback can confirm the on-chain supplier is actually owned by us
+ * rather than someone who staked the same operator address during the verify window.
+ */
+function extractStakeAddresses(
+  transaction: { unsignedPayload?: string | null },
+): { operatorAddress?: string; ownerAddress?: string } {
   try {
-    if (!transaction.unsignedPayload) return undefined
+    if (!transaction.unsignedPayload) return {}
     const payload = JSON.parse(transaction.unsignedPayload)
     const messages = payload?.body?.messages
-    if (!Array.isArray(messages)) return undefined
+    if (!Array.isArray(messages)) return {}
     for (const msg of messages) {
       if (
         msg.typeUrl === '/pocket.supplier.MsgStakeSupplier' &&
         typeof msg.value?.operatorAddress === 'string'
       ) {
-        return msg.value.operatorAddress
+        return {
+          operatorAddress: msg.value.operatorAddress,
+          ownerAddress:
+            typeof msg.value?.ownerAddress === 'string' ? msg.value.ownerAddress : undefined,
+        }
       }
     }
-    return undefined
+    return {}
   } catch {
-    return undefined
+    return {}
   }
 }
 
@@ -136,18 +161,24 @@ export async function ExecuteTransaction(args: TransactionArgs) {
   });
 
   if (!skipWait) {
-    await waitForNextBlock(txHeight);
+    // Wait for txHeight + 2 (waitForNextBlock blocks until currentHeight >= arg + 1).
+    // txHeight is sampled before broadcast, so if the chain advanced during broadcast
+    // a plain "+1" wait can no-op and trigger verifyTransaction before the tx is
+    // indexed. The extra block gives indexing margin; the verify retry loop covers the
+    // rarer case where broadcast spanned multiple blocks.
+    await waitForNextBlock(txHeight + 1);
   }
 
   const txHash = result?.transactionHash || transaction.hash!;
   const baseHeight = transaction.executionHeight || txHeight;
-  const operatorAddress = extractOperatorAddress(transaction);
+  const { operatorAddress, ownerAddress } = extractStakeAddresses(transaction);
 
   let success = false;
   let code = -1;
   let gasUsed = '0';
   let txFoundOnChain = false;
   let supplierFallbackHit = false;
+  let verifyErroredUnexpectedly = false;
 
   try {
     // Retries are driven by Temporal's activity retry policy — one attempt per block
@@ -155,10 +186,23 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     // retriable TX_NOT_FOUND until the policy is exhausted.
     [success, code, gasUsed] = await verifyTransaction(txHash, baseHeight);
     txFoundOnChain = true;
-  } catch {
-    if (operatorAddress) {
+  } catch (err) {
+    // We only reach here after verifyTransaction exhausted its full retry budget
+    // (TX_EXPIRATION_BLOCKS ≈ 30 min), so a transient RPC blip would already have
+    // recovered. Whatever the failure reason, attempt the positive-only supplier
+    // fallback — a supplier on-chain conclusively confirms the stake regardless of
+    // why verify failed. If the fallback is inconclusive we mark Failure (bounded:
+    // we never rethrow into an indefinite Pending loop) but record *why* so a real
+    // verification error stays triageable instead of being mislabeled a clean
+    // "not found".
+    verifyErroredUnexpectedly = !isTxNotFoundFailure(err);
+
+    // Need both addresses to validate ownership — without the expected owner the
+    // supplier fallback can't prove the on-chain supplier is ours, so we skip it
+    // and let the tx stay marked Failure rather than risk a false positive.
+    if (operatorAddress && ownerAddress) {
       try {
-        const supplierExists = await checkSupplierOnChain(operatorAddress);
+        const supplierExists = await checkSupplierOnChain(operatorAddress, ownerAddress);
         if (supplierExists) {
           success = true;
           code = 0;
@@ -166,7 +210,8 @@ export async function ExecuteTransaction(args: TransactionArgs) {
           supplierFallbackHit = true;
         }
       } catch {
-        // supplier check also failed — tx stays marked as Failure (success stays false)
+        // supplier check also failed (e.g. RPC still down) — no positive evidence,
+        // tx stays marked as Failure (success stays false)
       }
     }
   }
@@ -181,6 +226,8 @@ export async function ExecuteTransaction(args: TransactionArgs) {
     }
   } else if (supplierFallbackHit) {
     verificationLog = 'verified via supplier state fallback (tx hash not found)';
+  } else if (verifyErroredUnexpectedly) {
+    verificationLog = `verification errored (not a clean not-found) after ${TX_EXPIRATION_BLOCKS} retries; marked failure for triage (baseHeight=${baseHeight})`;
   } else {
     verificationLog = `tx not found on-chain after ${TX_EXPIRATION_BLOCKS} retries (baseHeight=${baseHeight})`;
   }

--- a/apps/provider/src/actions/Keys.ts
+++ b/apps/provider/src/actions/Keys.ts
@@ -256,7 +256,12 @@ export async function MigrateKeysToAddressGroup(filters: KeyMigrationFilters, ta
       parsed.targetAddressGroupId,
     )
 
-    await TriggerAddressGroupMigrationSchedule()
+    const scheduleResult = await TriggerAddressGroupMigrationSchedule()
+    if (!scheduleResult.success) {
+      console.warn(
+        `[MigrateKeysToAddressGroup] keys migrated but schedule trigger failed; the recurring migration schedule will pick them up: ${scheduleResult.error.message}`,
+      )
+    }
 
     return migrated
   })

--- a/apps/provider/src/lib/dal/keys.ts
+++ b/apps/provider/src/lib/dal/keys.ts
@@ -644,6 +644,7 @@ export async function migrateKeysToAddressGroup(keyIds: number[], targetAddressG
         .select({ id: keysTable.id, state: keysTable.state, remediationHistory: keysTable.remediationHistory })
         .from(keysTable)
         .where(inArray(keysTable.id, chunkIds))
+        .for('update')
 
       const historyCase = buildRemediationHistoryCaseExpr(keys, migrationEntry)
       const stateResetIds = keys.filter((key) => STATES_REQUIRING_RESET.includes(key.state)).map((key) => key.id)
@@ -657,7 +658,12 @@ export async function migrateKeysToAddressGroup(keyIds: number[], targetAddressG
         await tx
           .update(keysTable)
           .set({ state: KeyState.Staked })
-          .where(inArray(keysTable.id, stateResetIds))
+          .where(
+            and(
+              inArray(keysTable.id, stateResetIds),
+              inArray(keysTable.state, STATES_REQUIRING_RESET),
+            ),
+          )
       }
     }
   })


### PR DESCRIPTION
## Summary

- Fixes a race condition where stake transactions that landed two or more blocks after broadcast were being marked as `failure` in the middleman DB even though the chain accepted them.
- Replaces the one-shot post-`waitForNextBlock` check with a Temporal activity-retry-driven poll across the full `TX_EXPIRATION_BLOCKS` window (~30 min at pocket's ~1-min block time)
- Makes unexpected errors (RPC outages, bugs) fail the workflow loudly so the tx stays `Pending` for human triage instead of being silently converted to `Failure`

## Root cause

`broadcastTxSync` confirms mempool acceptance, not block inclusion — a tx may land one, two, or more blocks later depending on backlog. The previous flow did:

1. `getBlockHeight()` → broadcast → `waitForNextBlock(height)` (waits for `height + 1`)
2. `verifyTransaction(hash, height)` — one shot across Tiers 1–4

When the tx landed at `height + 2` (or later), every tier failed at `height + 1`:
- Tier 1 (`tx_index`) hadn't caught up
- Tier 2 (REST) still returned 404
- Tier 3 (block scan) iterated 30 heights but every `comet.block(h)` past chain head threw and silently `continue`d
- Tier 4 (supplier state) didn't find the supplier on-chain yet (it landed at `height + 2` too)

Resulting DB write: `status=failure, code=∅, log=∅, consumedFee=0` — exactly what the user reported.

## What changed

**`apps/middleman-workflows/src/activities/index.ts`**
- `verifyTransaction` now throws `ApplicationFailure.retryable('Transaction not found on-chain', 'TX_NOT_FOUND', …)` when the hash is not on-chain, returning `[success, code, gasUsed]` only when found
- New `checkSupplierOnChain(operatorAddress)` activity for the Tier 4 positive-only fallback, extracted out of `verifyTransaction`

**`apps/middleman-workflows/src/workflows/ExecuteTransaction.ts`**
- `verifyTransaction` moved to its own `proxyActivities` group with `{ initialInterval: "60s", backoffCoefficient: 1, maximumAttempts: TX_EXPIRATION_BLOCKS }` — one attempt per ~block for the full expiration window
- `try/catch` around the activity; `isTxNotFoundFailure(err)` helper discriminates retries-exhausted (`ApplicationFailure.type === 'TX_NOT_FOUND'`) from any other failure, which is rethrown so the workflow fails and the tx stays `Pending`
- Tier 4 (`checkSupplierOnChain`) runs only after `TX_NOT_FOUND` retries are exhausted; a positive result short-circuits to success, a missing supplier stays `Failure`
- `code` is now persisted on every verification update, and `log` distinguishes: chain rejection (`verification failed with code N`), supplier-state fallback success, and true TX_NOT_FOUND after retries

**`apps/middleman-workflows/src/lib/blockchain/index.ts`**
- Tier 3 block scan capped at the current chain head (`Math.min(height + maxBlocks, latestHeight)`); future heights no longer consume the scan budget by throwing and `continue`-ing. The workflow-level retry policy handles waiting for new blocks.

## Behavior matrix

| Scenario | DB result |
|---|---|
| Tx found, chain code 0 | `Success` |
| Tx found, chain code ≠ 0 | `Failure`, `log = "verification failed with code N"` |
| Tx not found after 30 retries, supplier on-chain | `Success`, `log = "verified via supplier state fallback"` |
| Tx not found after 30 retries, supplier not on-chain | `Failure`, `log = "tx not found on-chain after 30 retries"` |
| RPC unreachable / unexpected error anywhere in verify | Workflow fails; tx marked as `Failure` |
