### PR TITLE
fix(docker): make /app writable for runtime user and pin pnpm/turbo

### DIFF
--- a/apps/middleman/Dockerfile
+++ b/apps/middleman/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     git \
     openssh-client \
     curl \
-    && npm install -g pnpm@latest turbo@^2.4.4 \
+    && npm install -g pnpm@10.15.0 turbo@2.4.4 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -47,6 +47,11 @@ RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 --gid 100
 
 RUN mkdir -p /app/apps/middleman/.next/cache/fetch-cache && \
     chown -R nextjs:nodejs /app/apps/middleman/.next/cache/fetch-cache
+
+# The migration initContainer runs `pnpm run middleman:migration:migrate`
+# with workingDir /app as the nextjs user. pnpm writes temp files in the
+# CWD, so /app itself must be writable by that user.
+RUN chown nextjs:nodejs /app
 
 USER nextjs
 

--- a/apps/provider/Dockerfile
+++ b/apps/provider/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     git \
     openssh-client \
     curl \
-    && npm install -g pnpm@latest turbo@^2.4.4 \
+    && npm install -g pnpm@10.15.0 turbo@2.4.4 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -47,6 +47,11 @@ RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 --gid 100
 
 RUN mkdir -p /app/apps/provider/.next/cache/fetch-cache && \
     chown -R nextjs:nodejs /app/apps/provider/.next/cache/fetch-cache
+
+# The migration initContainer runs `pnpm run provider:migration:migrate`
+# with workingDir /app as the nextjs user. pnpm writes temp files in the
+# CWD, so /app itself must be writable by that user.
+RUN chown nextjs:nodejs /app
 
 USER nextjs
 


### PR DESCRIPTION
## Problem

The CVE-2026-44578 `next` bump forced the first middleman/provider image rebuild in ~7 weeks. Two coupled issues surfaced:

1. **Deployment stuck (EACCES).** The migration initContainer runs `pnpm run *:migration:migrate` with `workingDir: /app` as the `nextjs` user (uid 1001). Current pnpm writes a `_tmp_*` file in the CWD; `/app` was root-owned → `EACCES` → migration crashed → rollout never progressed. `middleman-workflows` already `chown`s /app for its runtime user; this brings middleman/provider in line.

2. **Root cause of the build breaking from a "simple" dep bump.** The Dockerfiles installed `pnpm@latest` + `turbo@^2.4.4` (floating). Between the last good build (2026-03-24) and now, `pnpm@latest` changed behavior twice (PNPM_HOME/bin PATH enforcement, then temp files in CWD). Pinned both to the versions already declared in `package.json` `packageManager` (`pnpm@10.15.0`) and known-good `turbo@2.4.4` so builds are reproducible.

## Validation

Built a production image from `apps/middleman/Dockerfile` (multi-stage, runs as `nextjs` — the real prod artifact, **not** the dev/root Tilt Dockerfile), `kind load`ed it, pointed the deployment at it:

- `create-db` ✅
- `db-migrations` ✅ — `[✓] migrations applied successfully!` (as nextjs, thanks to chown /app)
- `middleman` container ✅ ready, restarts=0, `▲ Next.js 15.5.16`, DB connected

## Notes

The first Tilt run was a false positive — Tilt uses `k8s/apps/middleman/Dockerfile` (single-stage, runs as **root**), where the EACCES can't reproduce. Validation above used the actual production Dockerfile.