### PR TITLE
feat(middleman): surface rev share split and warn on 0% client share

### DIFF
--- a/apps/middleman/src/app/app/stake/components/PlanDetailsSection.tsx
+++ b/apps/middleman/src/app/app/stake/components/PlanDetailsSection.tsx
@@ -41,6 +41,24 @@ export function PlanDetailsSection({
   return (
     <>
       <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
+        <span className="text-[14px] text-[var(--text-tertiary)]">Provider Share</span>
+        <span className="text-[14px] font-mono text-[var(--text-primary)] mt-[4px]">
+          {shares.providerShare.toFixed(1)}%
+        </span>
+      </span>
+      <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
+        <span className="text-[14px] text-[var(--text-tertiary)]">Supplier Share</span>
+        <span className="text-[14px] font-mono text-[var(--text-primary)] mt-[4px]">
+          {shares.supplierShare.toFixed(1)}%
+        </span>
+      </span>
+      <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
+        <span className="text-[14px] text-[var(--text-tertiary)]">Delegator Fee</span>
+        <span className="text-[14px] font-mono text-[var(--text-primary)] mt-[4px]">
+          {shares.delegatorShare.toFixed(1)}%
+        </span>
+      </span>
+      <span className="flex flex-row items-center justify-between px-4 py-3 border-b border-[var(--border-primary)]">
         <span className="text-[14px] text-[var(--text-tertiary)]">Client Share</span>
         <span className="text-[14px] font-mono text-[var(--text-primary)] mt-[4px]">
           {shares.clientShare.toFixed(1)}%

--- a/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
+++ b/apps/middleman/src/app/app/stake/components/ReviewStep/index.tsx
@@ -11,7 +11,7 @@ import { requestSuppliers } from '@/lib/services/provider'
 import { StakeDistributionOffer } from '@/lib/models/StakeDistributionOffer'
 import { getShortAddress, toCurrencyFormat } from '@igniter/ui/lib/utils'
 import { QuickInfoPopOverIcon } from '@igniter/ui/components/QuickInfoPopOverIcon'
-import { CaretSmallIcon, CornerIcon } from '@igniter/ui/assets'
+import { CaretSmallIcon, CornerIcon, WarningIcon } from '@igniter/ui/assets'
 import React, { useMemo, useState } from 'react'
 import { useApplicationSettings } from '@/app/context/ApplicationSettings'
 import { StakingProcess, StakingProcessStatus } from '@/app/app/stake/components/ReviewStep/StakingProcess'
@@ -19,6 +19,8 @@ import { Transaction } from '@igniter/db/middleman/schema'
 import AvatarByString from '@igniter/ui/components/AvatarByString'
 import { calculateShares } from '@/lib/utils/shareCalculations'
 import { PlanDetailsSection } from '@/app/app/stake/components/PlanDetailsSection'
+
+const CLIENT_SHARE_WARNING_THRESHOLD = 0;
 
 function useSimulateFee(
   selectedOffer: StakeDistributionOffer,
@@ -500,6 +502,19 @@ export function ReviewStep({onStakeCompleted, amount, selectedOffer, selectedAdd
                     </React.Fragment>
                 ))}
             </div>
+
+            {shares && shares.clientShare <= CLIENT_SHARE_WARNING_THRESHOLD && (
+              <div className="flex flex-row items-start gap-3 bg-warning-bg p-[11px_16px] rounded-[8px]">
+                <WarningIcon className="mt-[2px] shrink-0" />
+                <span className="text-[14px] text-[var(--text-primary)]">
+                    <span className="font-medium text-warning">
+                        This plan's client rev share is {shares.clientShare.toFixed(1)}%.
+                    </span>
+                    <br />
+                    You will receive 0% of rewards from this provider.
+                </span>
+              </div>
+            )}
 
             <StakingProcess
               disabled={isLoadingFee || errorFee || isLoadingBalance || errorBalance || !balanceCoversTotal}


### PR DESCRIPTION
Stake Review only showed the resulting Client Share %, leaving where the rest of the rewards go implicit. Add explicit Provider, Supplier and Delegator rows alongside Client Share in PlanDetailsSection, and warn in ReviewStep when the client share is 0% or below so a delegator can't unknowingly stake for no rewards.