### PR TITLE
fix(UI): keep wallet reconnect working across app releases

### DIFF
--- a/apps/middleman/src/app/context/WalletConnection/Provider.tsx
+++ b/apps/middleman/src/app/context/WalletConnection/Provider.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cookies } from 'next/headers'
-import { PROVIDER_COOKIE_KEY, WALLET_COOKIE_KEY } from '@igniter/ui/context/WalletConnection/constants'
+import { PROVIDER_COOKIE_KEY } from '@igniter/ui/context/WalletConnection/constants'
 import { getApplicationSettings } from '@/actions/ApplicationSettings'
 import ClientWalletConnectionProvider from './client'
 import { auth } from '@/auth'
@@ -21,7 +21,6 @@ export default async function WalletConnectionProvider({children}: React.PropsWi
       expectedConnection={{
         identity: session?.user?.identity,
         provider: cookiesAwaited.get(PROVIDER_COOKIE_KEY)?.value,
-        wallet: cookiesAwaited.get(WALLET_COOKIE_KEY)?.value
       }}
       settings={{
         apiUrl: '/api/rpc',

--- a/apps/provider/src/app/context/WalletConnection/Provider.tsx
+++ b/apps/provider/src/app/context/WalletConnection/Provider.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { cookies } from 'next/headers'
-import { PROVIDER_COOKIE_KEY, WALLET_COOKIE_KEY } from '@igniter/ui/context/WalletConnection/constants'
+import { PROVIDER_COOKIE_KEY } from '@igniter/ui/context/WalletConnection/constants'
 import { GetApplicationSettings } from '@/actions/ApplicationSettings'
 import ClientWalletConnectionProvider from './client'
 import { auth } from '@/auth'
@@ -21,7 +21,6 @@ export default async function WalletConnectionProvider({children}: React.PropsWi
       expectedConnection={{
         identity: session?.user?.identity,
         provider: cookiesAwaited.get(PROVIDER_COOKIE_KEY)?.value,
-        wallet: cookiesAwaited.get(WALLET_COOKIE_KEY)?.value
       }}
       settings={{
         apiUrl: '/api/rpc',

--- a/packages/ui/src/context/WalletConnection/constants.tsx
+++ b/packages/ui/src/context/WalletConnection/constants.tsx
@@ -1,2 +1,1 @@
-export const WALLET_COOKIE_KEY = 'latest_wallet_connected'
 export const PROVIDER_COOKIE_KEY = 'latest_provider_connected'

--- a/packages/ui/src/context/WalletConnection/index.tsx
+++ b/packages/ui/src/context/WalletConnection/index.tsx
@@ -189,7 +189,11 @@ export const WalletConnectionProvider = ({
       } as const;
 
       setCookie(WALLET_COOKIE_KEY, providerInfo.connection.name, cookieOptions)
-      setCookie(PROVIDER_COOKIE_KEY, providerInfo.name, cookieOptions)
+      // Persist the wallet provider's stable EIP-6963 rdns (permanent, globally
+      // unique) rather than its display name, so reconnect survives a wallet
+      // renaming itself across versions. Falls back to the name for providers
+      // that don't expose an rdns. Reconnect matches rdns-first (see #309).
+      setCookie(PROVIDER_COOKIE_KEY, providerInfo.rdns ?? providerInfo.name, cookieOptions)
 
       setAccountListener(providerInfo.provider)
 
@@ -216,7 +220,15 @@ export const WalletConnectionProvider = ({
     const providers = await getAvailableProviders()
 
     for (const providerInfo of providers) {
-      if (providerInfo.name === provider && providerInfo.connection.name === wallet) {
+      // Match on the wallet provider's stable identity (EIP-6963 rdns, falling
+      // back to display name) instead of the connection *class name*: that is
+      // a minified identifier that changes between production builds, so a cookie
+      // written by an earlier release never matches the current build (#309 —
+      // providers page stuck loading after an app update until the user
+      // disconnects/reconnects the wallet).
+      const matchesProvider =
+        providerInfo.rdns === provider || providerInfo.name === provider
+      if (matchesProvider) {
         connection = new providerInfo.connection(providerInfo.provider, settings)
 
         break;
@@ -272,7 +284,14 @@ export const WalletConnectionProvider = ({
       const { identity, provider, wallet } = expectedConnection;
       if (identity && provider && wallet) {
         (async () => {
-          await reconnect(identity, wallet, provider);
+          try {
+            await reconnect(identity, wallet, provider);
+          } catch {
+            // Auto-reconnect is best-effort: a failure here must not become an
+            // unhandled rejection that silently leaves the app in a connecting
+            // state forever. Stay disconnected so the UI can prompt to connect.
+            setIsConnected(false);
+          }
         })();
       }
     }

--- a/packages/ui/src/context/WalletConnection/index.tsx
+++ b/packages/ui/src/context/WalletConnection/index.tsx
@@ -3,7 +3,7 @@
 import type { WalletConnection, WalletSettings } from './WalletConnection';
 import { createContext, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import {SignedMemo, SignedTransaction, TransactionMessage} from "../../lib/models/Transactions";
-import { PROVIDER_COOKIE_KEY, WALLET_COOKIE_KEY } from './constants';
+import { PROVIDER_COOKIE_KEY } from './constants';
 import { KeplrWalletConnection } from './KeplrWalletConnection';
 import {PocketWalletConnection} from "./PocketWalletConnection";
 import { setCookie } from '../../lib/cookies'
@@ -58,7 +58,6 @@ export interface WalletConnectionContext {
   signTransaction(messages: TransactionMessage[], signer?: string, memo?: SignedMemo): Promise<SignedTransaction>;
   reconnect(
     address: string,
-    wallet: string,
     provider: string
   ): Promise<boolean>;
 }
@@ -101,7 +100,6 @@ export const WalletConnectionContext = createContext<WalletConnectionContext>({
   },
   reconnect: async (
     address: string,
-    wallet: string,
     provider: string
   )=> {
     console.warn('Method not implemented: reconnect. Something is wrong with the wallet connection provider.');
@@ -123,7 +121,6 @@ export interface WalletConnectionProviderProps {
   expectedConnection?: {
     identity: string
     provider: string
-    wallet: string
   },
   settings: WalletSettings
   children: ReactNode
@@ -188,7 +185,6 @@ export const WalletConnectionProvider = ({
         sameSite: 'Lax'
       } as const;
 
-      setCookie(WALLET_COOKIE_KEY, providerInfo.connection.name, cookieOptions)
       // Persist the wallet provider's stable EIP-6963 rdns (permanent, globally
       // unique) rather than its display name, so reconnect survives a wallet
       // renaming itself across versions. Falls back to the name for providers
@@ -212,7 +208,6 @@ export const WalletConnectionProvider = ({
 
   const reconnect = useCallback(async (
     address: string,
-    wallet: string,
     provider: string
   ) => {
     let connection: WalletConnection | undefined
@@ -281,11 +276,11 @@ export const WalletConnectionProvider = ({
 
   useEffect(() => {
     if (expectedConnection) {
-      const { identity, provider, wallet } = expectedConnection;
-      if (identity && provider && wallet) {
+      const { identity, provider } = expectedConnection;
+      if (identity && provider) {
         (async () => {
           try {
-            await reconnect(identity, wallet, provider);
+            await reconnect(identity, provider);
           } catch {
             // Auto-reconnect is best-effort: a failure here must not become an
             // unhandled rejection that silently leaves the app in a connecting
@@ -295,7 +290,7 @@ export const WalletConnectionProvider = ({
         })();
       }
     }
-  }, [expectedConnection?.wallet, expectedConnection?.provider, expectedConnection?.identity]);
+  }, [expectedConnection?.provider, expectedConnection?.identity]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
- Reconnect matched the wallet on its connection class name, which gets minified and changes on production build — so a cookie from an older release didnt match the new build and the providers page hung on loading until the user manually disconnected/reconnected (#309)

- Now match on the stable EIP-6963 rdns (falling back to display name) instead, and guard auto-reconnect so any failure ends disconnected, not stuck loading.