### PR TITLE
chore(release): promote staging to main (CI fixes + v0.15.0 code)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,4 +112,4 @@ jobs:
           file: ./apps/${{ matrix.app }}/Dockerfile
           push: false
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,6 +5,12 @@ on:
     types: [closed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Version bump for manual runs (PR-merge runs use the release:* label instead)'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
 
 concurrency:
   group: deploy-production
@@ -62,9 +68,9 @@ jobs:
           if [ -z "$LATEST_TAG" ]; then LATEST_TAG="v0.0.0"; fi
           VERSION=${LATEST_TAG#v}
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          if ${{ contains(github.event.pull_request.labels.*.name, 'release:major') }}; then
+          if ${{ contains(github.event.pull_request.labels.*.name, 'release:major') }} || [ "${{ github.event.inputs.release_type }}" = "major" ]; then
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
-          elif ${{ contains(github.event.pull_request.labels.*.name, 'release:minor') }}; then
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'release:minor') }} || [ "${{ github.event.inputs.release_type }}" = "minor" ]; then
             MINOR=$((MINOR + 1)); PATCH=0
           else
             PATCH=$((PATCH + 1))
@@ -87,7 +93,7 @@ jobs:
             ghcr.io/pokt-network/${{ matrix.app }}:${{ env.NEW_VERSION }}
             ghcr.io/pokt-network/${{ matrix.app }}:latest
           cache-from: type=gha,scope=${{ matrix.app }}
-          cache-to: type=gha,scope=${{ matrix.app }},mode=max
+          cache-to: type=gha,scope=${{ matrix.app }},mode=max,ignore-error=true
 
   release:
     needs: build-push

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,7 @@ jobs:
           push: true
           tags: ghcr.io/pokt-network/${{ matrix.app }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha,scope=${{ matrix.app }}
-          cache-to: type=gha,scope=${{ matrix.app }},mode=max
+          cache-to: type=gha,scope=${{ matrix.app }},mode=max,ignore-error=true
 
   post-deploy:
     needs: build-push

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -57,7 +57,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
-            --title "Release v${NEW_VERSION}" \
+            --title "chore(release): v${NEW_VERSION}" \
             --body "$(cat <<EOF
           ## Release v${NEW_VERSION}
 


### PR DESCRIPTION
Direct staging → main promotion (admin). Brings the CI robustness fixes (gha cache ignore-error, conventional release title, deploy-production release_type input) and the already-merged watchdog + notifications code to main. No release label -> no automatic deploy; version/release handled separately via manual dispatch.