### PR TITLE
feat: UI revamp - sticky headers, tabs, failure reasons, notif filters

### DIFF
--- a/apps/middleman-workflows/src/activities/index.ts
+++ b/apps/middleman-workflows/src/activities/index.ts
@@ -1284,7 +1284,7 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
    * height (or its execution height on the first sweep). Maps the pocket tri-state
    * result down to the minimal shape the pure decision logic consumes.
    */
-  async verifyTxHash(transactionId: number): Promise<VerifyOutcome<{ success: boolean; code: number; gasUsed: string }>> {
+  async verifyTxHash(transactionId: number): Promise<VerifyOutcome<{ success: boolean; code: number; gasUsed: string; rawLog?: string }>> {
     const txn = await dal.transaction.getTransaction(transactionId)
     if (!txn?.hash) {
       throw new Error('verifyTxHash: tx missing hash')
@@ -1296,7 +1296,7 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
     // activity boundary (the default payload converter cannot encode BigInt).
     return {
       status: 'confirmed',
-      data: { success: out.data.success, code: out.data.code, gasUsed: out.data.gasUsed.toString() },
+      data: { success: out.data.success, code: out.data.code, gasUsed: out.data.gasUsed.toString(), rawLog: out.data.rawLog },
     }
   },
 
@@ -1399,11 +1399,16 @@ export const delegatorActivities = (dal: DAL, pocketRpcClient: PocketBlockchain,
 
     const status = decision.tx === 'success' ? TransactionStatus.Success : TransactionStatus.Failure
     const verificationHeight = await pocketRpcClient.getHeight().catch(() => undefined)
+    // Failure log: prefer the chain's own error text (rawLog, present when the tx
+    // was found on-chain and failed) so the UI can show the real reason; the
+    // hardcoded summaries remain for paths where no chain text exists (absent-tx
+    // failure) or as suffix context (sibling-met goal).
     const fields: { code?: number; consumedFee?: number; verificationHeight?: number; log?: string } = {
       verificationHeight,
       log: decision.tx === 'success' ? 'verified'
-        : decision.effects === 'apply-success' ? 'tx failed on-chain; goal met by sibling tx'
-        : 'verification negative (validity bound covered, no effect)',
+        : decision.effects === 'apply-success'
+          ? `tx failed on-chain; goal met by sibling tx${decision.rawLog ? ` (${decision.rawLog})` : ''}`
+          : decision.rawLog || 'verification negative (validity bound covered, no effect)',
     }
     if (decision.code !== undefined) fields.code = decision.code
     if (decision.gasUsed !== undefined) fields.consumedFee = Number(decision.gasUsed)

--- a/apps/middleman/src/actions/NotificationChannels.ts
+++ b/apps/middleman/src/actions/NotificationChannels.ts
@@ -176,8 +176,12 @@ export async function TestNotificationChannel(id: number) {
   })
 }
 
-export async function ListNotificationEvents(page = 0, pageSize = 25) {
-  return run(async () => dal.listNotificationEvents(await requireAuth(), page, pageSize))
+export async function ListNotificationEvents(
+  page = 0,
+  pageSize = 25,
+  filters?: dal.NotificationEventFilters,
+) {
+  return run(async () => dal.listNotificationEvents(await requireAuth(), page, pageSize, filters))
 }
 
 export async function GetNotificationEvent(uuid: string) {

--- a/apps/middleman/src/app/admin/setup/providersForm.tsx
+++ b/apps/middleman/src/app/admin/setup/providersForm.tsx
@@ -94,10 +94,10 @@ const ProvidersForm: React.FC<ProvidersFormProps> = ({
           name="providers"
           render={() => (
             <FormItem>
-              <div className="rounded-md border">
+              <div className="rounded-md border max-h-[60vh] overflow-y-auto">
                 <table className="w-full">
-                  <thead>
-                    <tr className="border-b text-left text-sm text-muted-foreground">
+                  <thead className="sticky top-0 z-10">
+                    <tr className="border-b text-left text-sm text-muted-foreground bg-background">
                       <th className="p-3 w-10"></th>
                       <th className="p-3">Name</th>
                       <th className="p-3">Identity</th>

--- a/apps/middleman/src/app/app/(lists)/suppliers/ActivitiesSection.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/ActivitiesSection.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { clsx } from 'clsx'
 import { GetPendingState } from '@/actions/Pending'
+import { Input } from '@igniter/ui/components/input'
 import Address from '@igniter/ui/components/Address'
 import TransactionHash from '@igniter/ui/components/TransactionHash'
 import Amount from '@igniter/ui/components/Amount'
@@ -21,11 +22,6 @@ import type { PendingStateSerialized, PendingOperationSerialized } from '@/lib/p
 function hasPendingOrLinger(state: PendingStateSerialized | undefined): boolean {
   if (!state) return false
   return (state.pendingOperations?.length ?? 0) > 0
-}
-
-function pendingCount(state: PendingStateSerialized | undefined): number {
-  if (!state) return 0
-  return Object.keys(state.byOperator).length
 }
 
 // Status-aware label and color per design spec:
@@ -63,33 +59,42 @@ export default function ActivitiesSection() {
     refetchInterval: (q) => (hasPendingOrLinger(q.state.data) ? 7000 : false),
   })
 
+  const [search, setSearch] = useState('')
+
   const rows = useMemo(() => {
     return pendingState?.pendingOperations ?? []
   }, [pendingState])
 
-  const count = pendingCount(pendingState)
-
-  // Render nothing when no pending and no recently-settled rows.
-  if (rows.length === 0) return null
+  // Client-side filter across supplier/owner addresses and provider name —
+  // mirrors the Suppliers tab search, scoped to the fields this strip shows.
+  const filteredRows = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return rows
+    return rows.filter((row) =>
+      [row.operatorAddress, row.ownerAddress, row.providerName]
+        .some((field) => field?.toLowerCase().includes(q)),
+    )
+  }, [rows, search])
 
   return (
     <div className="flex flex-col gap-3">
-      {/* Section heading — matches RecentChanges / Services Overview style.
-          Badge shows PENDING count only; settled-linger rows don't inflate it. */}
-      <h3 className="text-lg font-semibold">
-        In progress
-        {count > 0 && (
-          <span className="text-sm font-normal text-text-tertiary ml-2">· {count}</span>
-        )}
-      </h3>
-
       {/* Hand-built using the shared Table primitives (the same ones DataTable
           renders internally) + DataTable's exact header-cell classes. DataTable's
           own toolbar + pagination chrome would still render with no props, so we
           reuse the Table primitives directly for a compact, chrome-free strip that
           is visually identical to our tables. ~5 rows then internal scroll. */}
-      <Table containerClassName="max-h-[260px]">
-        <TableHeader>
+      {rows.length > 0 && (
+        <Input
+          placeholder="Search by supplier, owner, or provider…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="max-w-xs"
+        />
+      )}
+      <Table containerClassName="max-h-[420px]">
+        {/* Lock header to the top of the scroll box; opaque root bg so rows
+            don't bleed through, plus a bottom divider that stays put. */}
+        <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-(--bg-root) [&_th]:border-b [&_th]:border-border-primary">
           <TableRow className="bg-transparent">
             {/* Column order: Tx Hash · Submitted · Supplier · Owner · Provider · Amount · Op Funds · Status */}
             <TableHead className={clsx(HEAD_CLASS, TX_HASH_COL_CLASS)}>Tx Hash</TableHead>
@@ -103,7 +108,17 @@ export default function ActivitiesSection() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {rows.map((row) => {
+          {filteredRows.length === 0 && (
+            <TableRow>
+              <TableCell
+                colSpan={8}
+                className="h-24 text-center text-text-secondary"
+              >
+                {search.trim() ? 'No matches.' : 'No activity yet.'}
+              </TableCell>
+            </TableRow>
+          )}
+          {filteredRows.map((row) => {
             const statusLabel = getStatusLabel(row)
             const statusClass = getStatusClass(row)
             const submittedStr = row.createdAt

--- a/apps/middleman/src/app/app/(lists)/suppliers/ChainOverview.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/ChainOverview.tsx
@@ -151,8 +151,6 @@ export default function ChainOverview() {
 
   const handleExport = useCallback(() => exportChainOverviewCsv(sortedRows), [sortedRows])
 
-  if (!isLoading && !isError && !allRows.length) return null
-
   const cardClasses = 'rounded-lg border border-[color:--divider] bg-[color:--main-background] base-shadow p-4'
 
   if (isLoading) {

--- a/apps/middleman/src/app/app/(lists)/suppliers/SuppliersTabs.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/SuppliersTabs.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@igniter/ui/components/tabs'
+
+import NodesTable from '@/app/app/(lists)/suppliers/table'
+import ActivitiesSection from '@/app/app/(lists)/suppliers/ActivitiesSection'
+import ChainOverview from '@/app/app/(lists)/suppliers/ChainOverview'
+
+const TABS = ['suppliers', 'activity', 'overview'] as const
+type TabValue = (typeof TABS)[number]
+
+// The three data tables that used to stack on the Suppliers screen now live one
+// per tab. Selection is persisted in the URL (?tab=) so refreshes / deep-links
+// land on the same table — same pattern as WorkflowsTabs.
+export default function SuppliersTabs() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const param = searchParams.get('tab')
+  const tab: TabValue = (TABS as readonly string[]).includes(param ?? '')
+    ? (param as TabValue)
+    : 'suppliers'
+
+  const onTabChange = (next: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('tab', next)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+
+  return (
+    <Tabs value={tab} onValueChange={onTabChange}>
+      <TabsList>
+        <TabsTrigger value="suppliers">Suppliers</TabsTrigger>
+        <TabsTrigger value="activity">Activity</TabsTrigger>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+      </TabsList>
+      <TabsContent value="suppliers">
+        <NodesTable />
+      </TabsContent>
+      <TabsContent value="activity">
+        <ActivitiesSection />
+      </TabsContent>
+      <TabsContent value="overview">
+        <ChainOverview />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/apps/middleman/src/app/app/(lists)/suppliers/SuppliersTabs.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/SuppliersTabs.tsx
@@ -2,9 +2,11 @@
 
 import * as React from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@igniter/ui/components/tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger, TabsBadge } from '@igniter/ui/components/tabs'
 
+import { GetPendingState } from '@/actions/Pending'
 import NodesTable from '@/app/app/(lists)/suppliers/table'
 import ActivitiesSection from '@/app/app/(lists)/suppliers/ActivitiesSection'
 import ChainOverview from '@/app/app/(lists)/suppliers/ChainOverview'
@@ -25,6 +27,17 @@ export default function SuppliersTabs() {
     ? (param as TabValue)
     : 'suppliers'
 
+  // Lifted above the tab boundary so the pending count stays live regardless of
+  // the active tab — ActivitiesSection (its own consumer of this same queryKey)
+  // only mounts on the Activity tab, so the badge needs its own always-mounted
+  // read. Same queryKey → react-query dedups to a single poll + shared cache.
+  const { data: pendingState } = useQuery({
+    queryKey: ['pendingState'],
+    queryFn: GetPendingState,
+    refetchInterval: (q) => ((q.state.data?.pendingOperations?.length ?? 0) > 0 ? 7000 : false),
+  })
+  const pendingCount = Object.keys(pendingState?.byOperator ?? {}).length
+
   const onTabChange = (next: string) => {
     const params = new URLSearchParams(searchParams.toString())
     params.set('tab', next)
@@ -35,7 +48,10 @@ export default function SuppliersTabs() {
     <Tabs value={tab} onValueChange={onTabChange}>
       <TabsList>
         <TabsTrigger value="suppliers">Suppliers</TabsTrigger>
-        <TabsTrigger value="activity">Activity</TabsTrigger>
+        <TabsTrigger value="activity">
+          Activity
+          <TabsBadge count={pendingCount} variant="warning" />
+        </TabsTrigger>
         <TabsTrigger value="overview">Overview</TabsTrigger>
       </TabsList>
       <TabsContent value="suppliers">

--- a/apps/middleman/src/app/app/(lists)/suppliers/page.tsx
+++ b/apps/middleman/src/app/app/(lists)/suppliers/page.tsx
@@ -1,10 +1,8 @@
 import type { Metadata } from 'next'
 import React, { Suspense } from 'react'
-import NodesTable from '@/app/app/(lists)/suppliers/table'
 import ProviderStats from '@/app/app/(lists)/suppliers/ProviderStats'
-import ChainOverview from '@/app/app/(lists)/suppliers/ChainOverview'
 import RecentChanges from '@/app/app/(lists)/suppliers/RecentChanges'
-import ActivitiesSection from '@/app/app/(lists)/suppliers/ActivitiesSection'
+import SuppliersTabs from '@/app/app/(lists)/suppliers/SuppliersTabs'
 import { GetAppName } from '@/actions/ApplicationSettings'
 import Link from 'next/link'
 import { Button } from '@igniter/ui/components/button'
@@ -42,12 +40,12 @@ export default async function Page() {
       />
       <PageContent>
         <ProviderStats />
-        <ChainOverview />
         <Suspense>
           <RecentChanges />
         </Suspense>
-        <ActivitiesSection />
-        <NodesTable />
+        <Suspense>
+          <SuppliersTabs />
+        </Suspense>
       </PageContent>
     </>
   );

--- a/apps/middleman/src/app/app/(lists)/transactions/table/columns.tsx
+++ b/apps/middleman/src/app/app/(lists)/transactions/table/columns.tsx
@@ -7,6 +7,7 @@ import {ActivitySuccessIcon, ActivityWarningIcon, RightArrowIcon} from '@igniter
 import { Button } from '@igniter/ui/components/button'
 import { FilterGroup, SortOption } from '@igniter/ui/components/DataTable/index'
 import { amountToPokt } from '@igniter/ui/lib/utils'
+import { failureReasonDisplay } from '@igniter/commons/utils'
 import { useAddItemToDetail } from '@igniter/ui/components/QuickDetails/Provider'
 import Amount from '@igniter/ui/components/Amount'
 import TransactionHash from '@igniter/ui/components/TransactionHash'
@@ -27,6 +28,7 @@ export type Transaction = {
     provider: string,
     providerFee?: number | null,
     typeProviderFee?: ProviderFee | null,
+    log?: string | null,
 };
 
 export const columns: (ColumnDef<Transaction> & CsvColumnDef<Transaction>)[] = [
@@ -66,6 +68,24 @@ export const columns: (ColumnDef<Transaction> & CsvColumnDef<Transaction>)[] = [
             return <TransactionStatusBadge status={status} />;
         },
         csvFormatterFn: ({status}) => status.charAt(0).toUpperCase() + status.slice(1),
+    },
+    {
+        id: "failureReason",
+        header: "Failure Reason",
+        cell: ({ row }) => {
+            const { status, log } = row.original;
+            const text = failureReasonDisplay(status === TransactionStatus.Failure, log);
+            if (text === null) {
+                return <span className="text-muted-foreground">-</span>;
+            }
+            return (
+                <span className="block max-w-[16rem] truncate text-red-400" title={text}>
+                    {text}
+                </span>
+            );
+        },
+        csvFormatterFn: (item) =>
+            failureReasonDisplay(item.status === TransactionStatus.Failure, item.log) ?? '',
     },
     {
         accessorKey: "hash",

--- a/apps/middleman/src/app/app/(lists)/transactions/table/columns.tsx
+++ b/apps/middleman/src/app/app/(lists)/transactions/table/columns.tsx
@@ -8,6 +8,7 @@ import { Button } from '@igniter/ui/components/button'
 import { FilterGroup, SortOption } from '@igniter/ui/components/DataTable/index'
 import { amountToPokt } from '@igniter/ui/lib/utils'
 import { failureReasonDisplay } from '@igniter/commons/utils'
+import { FailureReasonPopover } from '@igniter/ui/components/FailureReasonPopover'
 import { useAddItemToDetail } from '@igniter/ui/components/QuickDetails/Provider'
 import Amount from '@igniter/ui/components/Amount'
 import TransactionHash from '@igniter/ui/components/TransactionHash'
@@ -29,6 +30,7 @@ export type Transaction = {
     providerFee?: number | null,
     typeProviderFee?: ProviderFee | null,
     log?: string | null,
+    code?: number | null,
 };
 
 export const columns: (ColumnDef<Transaction> & CsvColumnDef<Transaction>)[] = [
@@ -73,17 +75,16 @@ export const columns: (ColumnDef<Transaction> & CsvColumnDef<Transaction>)[] = [
         id: "failureReason",
         header: "Failure Reason",
         cell: ({ row }) => {
-            const { status, log } = row.original;
-            const text = failureReasonDisplay(status === TransactionStatus.Failure, log);
+            const { status, log, code } = row.original;
+            const text = failureReasonDisplay(status === TransactionStatus.Failure, log, code);
             if (text === null) {
                 return <span className="text-muted-foreground">-</span>;
             }
-            return (
-                <span className="block max-w-[16rem] truncate text-red-400" title={text}>
-                    {text}
-                </span>
-            );
+            // Friendly text in the cell; click to open the full raw log (copyable) inline.
+            return <FailureReasonPopover friendly={text} full={log?.trim() || ''} code={code} />;
         },
+        // CSV keeps the RAW chain log (more detail for debugging/support exports);
+        // the table cell shows the friendly mapped text. Intentionally no `code` arg.
         csvFormatterFn: (item) =>
             failureReasonDisplay(item.status === TransactionStatus.Failure, item.log) ?? '',
     },
@@ -160,6 +161,8 @@ export const columns: (ColumnDef<Transaction> & CsvColumnDef<Transaction>)[] = [
                                     provider: row.original.provider,
                                     providerFee: row.original.providerFee,
                                     typeProviderFee: row.original.typeProviderFee,
+                                    log: row.original.log,
+                                    code: row.original.code,
                                 }
                             })
                         }}

--- a/apps/middleman/src/app/app/(lists)/transactions/table/index.tsx
+++ b/apps/middleman/src/app/app/(lists)/transactions/table/index.tsx
@@ -64,7 +64,9 @@ export default function TransactionsTable() {
                             consumedFee: newTx.consumedFee,
                             provider: newTx.provider?.name || '',
                             providerFee: newTx.providerFee,
-                            typeProviderFee: newTx.typeProviderFee
+                            typeProviderFee: newTx.typeProviderFee,
+                            log: newTx.log,
+                            code: newTx.code,
                         }
                     }, index)
                 }
@@ -116,6 +118,7 @@ export default function TransactionsTable() {
                         providerFee: tx.providerFee,
                         typeProviderFee: tx.typeProviderFee,
                         log: tx.log,
+                        code: tx.code,
                     }
                 }) || []
             }

--- a/apps/middleman/src/app/app/(lists)/transactions/table/index.tsx
+++ b/apps/middleman/src/app/app/(lists)/transactions/table/index.tsx
@@ -115,6 +115,7 @@ export default function TransactionsTable() {
                         provider: tx.provider?.name || 'Height Pending',
                         providerFee: tx.providerFee,
                         typeProviderFee: tx.typeProviderFee,
+                        log: tx.log,
                     }
                 }) || []
             }

--- a/apps/middleman/src/app/app/notifications/NotificationHistorySection.tsx
+++ b/apps/middleman/src/app/app/notifications/NotificationHistorySection.tsx
@@ -10,6 +10,17 @@ import {
   MarkAllNotificationEventsViewed,
 } from '@/actions/NotificationChannels'
 import { EVENT_LABELS, describeEvent } from '@/lib/notificationEvents'
+import { NOTIFICATION_EVENT_TYPES, NotificationChannelType } from '@igniter/db/middleman/enums'
+
+// Event-type + channel dropdown options for the history filters.
+const EVENT_TYPE_OPTIONS = NOTIFICATION_EVENT_TYPES.map((t) => ({
+  value: t,
+  label: EVENT_LABELS[t] ?? t,
+}))
+const CHANNEL_OPTIONS = Object.values(NotificationChannelType).map((t) => ({
+  value: t,
+  label: t.charAt(0).toUpperCase() + t.slice(1),
+}))
 
 // Middleman wrapper around the shared history table: wallet-scoped actions +
 // middleman's event vocabulary. No detail drawer (provider-only), so a row click
@@ -27,13 +38,15 @@ export function NotificationHistorySection() {
 
   return (
     <NotificationHistory
+      eventTypeOptions={EVENT_TYPE_OPTIONS}
+      channelOptions={CHANNEL_OPTIONS}
       onOpenEvent={openEvent}
       labelFor={(type) => EVENT_LABELS[type] ?? 'Notification'}
       summaryFor={(type, metadata) =>
         describeEvent(type, (metadata ?? {}) as Record<string, unknown>)
       }
-      listEvents={async (page, pageSize) => {
-        const result = await ListNotificationEvents(page, pageSize)
+      listEvents={async (page, pageSize, filters) => {
+        const result = await ListNotificationEvents(page, pageSize, filters)
         if (!result.success) throw new Error(result.error.message)
         return result.data
       }}

--- a/apps/middleman/src/app/app/overview/ProviderBreakdown.tsx
+++ b/apps/middleman/src/app/app/overview/ProviderBreakdown.tsx
@@ -157,9 +157,12 @@ export default function ProviderBreakdown({ providerCount }: { providerCount: nu
       <div className="flex flex-col xl:flex-row gap-4">
         {/* Table card */}
         <div className={`${cardClasses} flex-1 min-w-0 overflow-x-auto`}>
+          {/* Bounded scroll box: invisible until the table outgrows it, then the
+              header below stays pinned. */}
+          <div className="max-h-[60vh] overflow-y-auto">
           <table className="w-full">
-            <thead>
-              <tr className="border-b border-[color:--divider] bg-muted/50">
+            <thead className="sticky top-0 z-10">
+              <tr className="border-b border-[color:--divider] bg-muted">
                 <th className={HEADER_CLASSES} onClick={() => handleSort('name')}>
                   Provider{sortIndicator('name')}
                 </th>
@@ -200,6 +203,7 @@ export default function ProviderBreakdown({ providerCount }: { providerCount: nu
               ))}
             </tbody>
           </table>
+          </div>
         </div>
 
         {/* Pie charts */}

--- a/apps/middleman/src/app/components/Sidebar.tsx
+++ b/apps/middleman/src/app/components/Sidebar.tsx
@@ -80,6 +80,13 @@ export const dynamic = "force-dynamic";
 export default function Sidebar({}: Readonly<AppSidebarProps>) {
   const pathname = usePathname();
 
+  // Sidebar chrome belongs only to the authenticated app/admin areas. On the
+  // portal (landing) and auth pages the whole rail is hidden — returning null
+  // drops both the fixed rail and its layout spacer so content is full width.
+  const isInternal =
+    pathname.startsWith("/app") || pathname.startsWith("/admin");
+  if (!isInternal) return null;
+
   const routes = pathname.startsWith("/admin") ? adminRoutes : mainRoutes;
 
   const MainRoutesMenu = routes.map((route) => (
@@ -91,7 +98,7 @@ export default function Sidebar({}: Readonly<AppSidebarProps>) {
           : "text-text-secondary"
       }
     >
-      <SidebarMenuButton asChild>
+      <SidebarMenuButton asChild tooltip={route.title}>
         <Link href={route.url}>
           <route.icon />
           <span>{route.title}</span>

--- a/apps/middleman/src/app/components/Sidebar.tsx
+++ b/apps/middleman/src/app/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from "@igniter/ui/components/sidebar";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { isInternalPath } from "@igniter/commons/utils";
 import OverviewDark from "@/app/assets/icons/dark/overview.svg";
 import ActivityDark from "@/app/assets/icons/dark/activity.svg";
 import NodesDark from "@/app/assets/icons/dark/nodes.svg";
@@ -83,9 +84,8 @@ export default function Sidebar({}: Readonly<AppSidebarProps>) {
   // Sidebar chrome belongs only to the authenticated app/admin areas. On the
   // portal (landing) and auth pages the whole rail is hidden — returning null
   // drops both the fixed rail and its layout spacer so content is full width.
-  const isInternal =
-    pathname.startsWith("/app") || pathname.startsWith("/admin");
-  if (!isInternal) return null;
+  // Same gate as SidebarTriggerGate via the shared isInternalPath helper.
+  if (!isInternalPath(pathname)) return null;
 
   const routes = pathname.startsWith("/admin") ? adminRoutes : mainRoutes;
 

--- a/apps/middleman/src/app/components/SidebarTriggerGate.tsx
+++ b/apps/middleman/src/app/components/SidebarTriggerGate.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { SidebarTrigger } from "@igniter/ui/components/sidebar";
+
+// The sidebar toggle only makes sense where the sidebar exists: the
+// authenticated app/admin areas. On the portal (landing) and auth pages there
+// is no rail, so the trigger is hidden — mirrors the gate in Sidebar.tsx.
+export default function SidebarTriggerGate() {
+  const pathname = usePathname();
+  const isInternal =
+    pathname.startsWith("/app") || pathname.startsWith("/admin");
+  if (!isInternal) return null;
+
+  return <SidebarTrigger />;
+}

--- a/apps/middleman/src/app/components/SidebarTriggerGate.tsx
+++ b/apps/middleman/src/app/components/SidebarTriggerGate.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { isInternalPath } from "@igniter/commons/utils";
 import { SidebarTrigger } from "@igniter/ui/components/sidebar";
 
 // The sidebar toggle only makes sense where the sidebar exists: the
 // authenticated app/admin areas. On the portal (landing) and auth pages there
-// is no rail, so the trigger is hidden — mirrors the gate in Sidebar.tsx.
+// is no rail, so the trigger is hidden — same gate as Sidebar.tsx via the
+// shared isInternalPath helper.
 export default function SidebarTriggerGate() {
   const pathname = usePathname();
-  const isInternal =
-    pathname.startsWith("/app") || pathname.startsWith("/admin");
-  if (!isInternal) return null;
+  if (!isInternalPath(pathname)) return null;
 
   return <SidebarTrigger />;
 }

--- a/apps/middleman/src/app/detail/TransactionDetail.tsx
+++ b/apps/middleman/src/app/detail/TransactionDetail.tsx
@@ -15,6 +15,7 @@ import { BaseQuickInfoTooltip } from '@igniter/ui/components/BaseQuickInfoToolti
 import Address from '@igniter/ui/components/Address'
 import { useAddItemToDetail } from '@igniter/ui/components/QuickDetails/Provider'
 import { MessageType } from '@igniter/commons/constants'
+import { failureReasonDisplay } from '@igniter/commons/utils'
 import { GetNode } from '@/actions/Nodes'
 import {
   TransactionsToNodesWithDetails,
@@ -83,6 +84,8 @@ export interface TransactionDetailBody {
   provider: string
   providerFee?: number | null
   typeProviderFee?: ProviderFee | null
+  log?: string | null
+  code?: number | null
 }
 
 export interface TransactionDetail {
@@ -301,9 +304,14 @@ export default function TransactionDetail({
   provider,
   providerFee,
   typeProviderFee,
+  log,
+  code,
 }: TransactionDetailBody) {
   const addItemToDetail = useAddItemToDetail()
   const [isShowingTransactionDetails, setIsShowingTransactionDetails] = useState(false);
+
+  const isFailure = status === TransactionStatus.Failure
+  const failureReason = failureReasonDisplay(isFailure, log, code)
 
   let onClickAddress: ((address: string) => void) | undefined = undefined
 
@@ -333,6 +341,8 @@ export default function TransactionDetail({
                   providerFee: tx.providerFee,
                   typeProviderFee: tx.typeProviderFee,
                   operations: JSON.parse(tx.unsignedPayload).body.messages,
+                  log: tx.log,
+                  code: tx.code,
                 }
               }),
               provider: node.provider || null,
@@ -354,11 +364,10 @@ export default function TransactionDetail({
       label: 'Status',
       value: (
         <div className={'flex items-center gap-2'}>
-          {status === TransactionStatus.Failure && (
+          {isFailure && failureReason && (
             <BaseQuickInfoTooltip
-              title={'Not Enough Coins'}
-              description={'Validator does not have enough coins in their account.'}
-              actionText={'View In Explorer'}
+              title={'Transaction Failed'}
+              description={failureReason}
             >
               <Button variant={'icon'} className={'h-4 w-4 mr-[-6px] mb-[-5px]'}>
                 <WarningIcon />

--- a/apps/middleman/src/app/layout.tsx
+++ b/apps/middleman/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/app/theme";
 import WalletConnectionProvider from "@/app/context/WalletConnection/Provider";
 import { ApplicationSettingsProvider } from "@/app/context/ApplicationSettings";
 import { SidebarInset, SidebarProvider } from "@igniter/ui/components/sidebar";
+import SidebarTriggerGate from "@/app/components/SidebarTriggerGate";
 import { AppTopBar } from "@igniter/ui/components/AppTopBar/index";
 
 import CurrentUser from "@/app/components/CurrentUser";
@@ -59,7 +60,7 @@ export default function RootLayout({
                     <SidebarProvider className="flex flex-col h-dvh overflow-hidden">
                       <QuickDetailProvider>
                         <NotificationsProvider>
-                          <AppTopBar>
+                          <AppTopBar leading={<SidebarTriggerGate />}>
                             <CurrentUser />
                             <ThemeToggle />
                           </AppTopBar>

--- a/apps/middleman/src/lib/dal/notificationChannels.filters.test.ts
+++ b/apps/middleman/src/lib/dal/notificationChannels.filters.test.ts
@@ -1,0 +1,50 @@
+jest.mock('server-only', () => ({}))
+jest.mock('@/db', () => ({ getDb: () => ({}) }))
+
+import { buildNotificationEventFilterConditions } from './notificationChannels'
+
+// The helper turns the optional filter set into AND-able SQL conditions. These
+// tests lock the branching (each active filter contributes exactly one
+// condition; absent/empty filters contribute none) so a future refactor can't
+// silently drop a filter dimension.
+describe('buildNotificationEventFilterConditions (middleman)', () => {
+  it('produces no conditions when nothing is filtered', () => {
+    expect(buildNotificationEventFilterConditions(undefined)).toHaveLength(0)
+    expect(buildNotificationEventFilterConditions({})).toHaveLength(0)
+  })
+
+  it('adds exactly one condition per active filter dimension', () => {
+    expect(buildNotificationEventFilterConditions({ type: 'stake' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ read: 'unread' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ read: 'read' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ channel: 'discord' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ search: 'abc' })).toHaveLength(1)
+  })
+
+  it('ignores an empty/unknown read value', () => {
+    expect(
+      buildNotificationEventFilterConditions({ read: '' as unknown as 'read' }),
+    ).toHaveLength(0)
+  })
+
+  it('ignores empty-string filter values (treated as unconstrained)', () => {
+    expect(
+      buildNotificationEventFilterConditions({ type: '', channel: '', search: '' }),
+    ).toHaveLength(0)
+  })
+
+  it('ignores an unknown event type instead of shipping it to the enum column', () => {
+    expect(buildNotificationEventFilterConditions({ type: 'not_a_real_type' })).toHaveLength(0)
+  })
+
+  it('combines every active filter into four ANDable conditions', () => {
+    expect(
+      buildNotificationEventFilterConditions({
+        type: 'stake',
+        read: 'unread',
+        channel: 'discord',
+        search: 'x',
+      }),
+    ).toHaveLength(4)
+  })
+})

--- a/apps/middleman/src/lib/dal/notificationChannels.ts
+++ b/apps/middleman/src/lib/dal/notificationChannels.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 import { getDb } from '@/db'
-import { and, count, desc, eq, inArray, isNull } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
+import { NOTIFICATION_EVENT_TYPES } from '@igniter/db/middleman/enums'
 import {
   notificationChannelsTable,
   notificationEventsTable,
@@ -9,8 +10,46 @@ import {
   type InsertNotificationEvent,
   type NotificationChannel,
   type NotificationEvent,
+  type NotificationEventType,
   type NotificationPreferences,
 } from '@igniter/db/middleman/schema'
+
+// Server-side filters for the notification history table. All optional; an
+// absent field means "no constraint on that dimension".
+export type NotificationEventFilters = {
+  /** Partial, case-insensitive match on the event UUID. */
+  search?: string
+  /** Exact event type (e.g. 'stake', 'service_change'). */
+  type?: string
+  /** Read/unread by viewedAt presence. */
+  read?: 'read' | 'unread'
+  /** Delivering channel type (e.g. 'discord') — matched against the channels JSON. */
+  channel?: string
+}
+
+// Translates the optional filter set into a list of AND-able SQL conditions.
+// Exported for unit testing of the filter branching.
+export function buildNotificationEventFilterConditions(filters?: NotificationEventFilters) {
+  const conds = []
+  // Only push a type condition for a KNOWN enum member — an arbitrary string
+  // (e.g. a hand-crafted request bypassing the UI) would otherwise reach the
+  // enum column and make Postgres throw "invalid input value for enum".
+  if (filters?.type && (NOTIFICATION_EVENT_TYPES as readonly string[]).includes(filters.type)) {
+    conds.push(eq(notificationEventsTable.type, filters.type as NotificationEventType))
+  }
+  if (filters?.read === 'unread') conds.push(isNull(notificationEventsTable.viewedAt))
+  if (filters?.read === 'read') conds.push(isNotNull(notificationEventsTable.viewedAt))
+  if (filters?.search) {
+    conds.push(sql`${notificationEventsTable.uuid}::text ILIKE ${'%' + filters.search + '%'}`)
+  }
+  if (filters?.channel) {
+    // channels is a JSON array of { type, ... }; match any element's type.
+    conds.push(
+      sql`EXISTS (SELECT 1 FROM json_array_elements(${notificationEventsTable.channels}) elem WHERE elem->>'type' = ${filters.channel})`,
+    )
+  }
+  return conds
+}
 
 // The list/table view never receives the encrypted config — secrets stay on the
 // server. Only these non-secret columns are selected.
@@ -126,12 +165,21 @@ export async function listNotificationEvents(
   userIdentity: string,
   page = 0,
   pageSize = 25,
+  filters?: NotificationEventFilters,
 ): Promise<{ data: NotificationEvent[]; total: number; unviewedTotal: number }> {
   const db = getDb()
   // Scoped to the owning wallet on BOTH the rows query and the counts, so the
-  // paginated total never leaks other wallets' events.
-  const where = eq(notificationEventsTable.createdBy, userIdentity)
-  const unviewedWhere = and(where, isNull(notificationEventsTable.viewedAt))
+  // paginated total never leaks other wallets' events. Filters are ANDed on top.
+  const where = and(
+    eq(notificationEventsTable.createdBy, userIdentity),
+    ...buildNotificationEventFilterConditions(filters),
+  )
+  // Unread count stays scoped-but-unfiltered so the badge/mark-all reflect the
+  // true unread total regardless of the active filters.
+  const unviewedWhere = and(
+    eq(notificationEventsTable.createdBy, userIdentity),
+    isNull(notificationEventsTable.viewedAt),
+  )
   const [rows, [countRow], [unviewedRow]] = await Promise.all([
     db
       .select()

--- a/apps/middleman/src/lib/dal/notificationChannels.ts
+++ b/apps/middleman/src/lib/dal/notificationChannels.ts
@@ -1,7 +1,11 @@
 import 'server-only'
 import { getDb } from '@/db'
-import { and, count, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNull } from 'drizzle-orm'
 import { NOTIFICATION_EVENT_TYPES } from '@igniter/db/middleman/enums'
+import {
+  buildNotificationEventFilterConditions as buildConditions,
+  type NotificationEventFilters,
+} from '@igniter/db/notifications'
 import {
   notificationChannelsTable,
   notificationEventsTable,
@@ -10,45 +14,16 @@ import {
   type InsertNotificationEvent,
   type NotificationChannel,
   type NotificationEvent,
-  type NotificationEventType,
   type NotificationPreferences,
 } from '@igniter/db/middleman/schema'
 
-// Server-side filters for the notification history table. All optional; an
-// absent field means "no constraint on that dimension".
-export type NotificationEventFilters = {
-  /** Partial, case-insensitive match on the event UUID. */
-  search?: string
-  /** Exact event type (e.g. 'stake', 'service_change'). */
-  type?: string
-  /** Read/unread by viewedAt presence. */
-  read?: 'read' | 'unread'
-  /** Delivering channel type (e.g. 'discord') — matched against the channels JSON. */
-  channel?: string
-}
+export type { NotificationEventFilters }
 
-// Translates the optional filter set into a list of AND-able SQL conditions.
-// Exported for unit testing of the filter branching.
+// Binds the middleman events table + enum to the shared filter builder in
+// @igniter/db/notifications. Kept as a same-signature wrapper so call sites and
+// the unit tests (notificationChannels.filters.test.ts) stay unchanged.
 export function buildNotificationEventFilterConditions(filters?: NotificationEventFilters) {
-  const conds = []
-  // Only push a type condition for a KNOWN enum member — an arbitrary string
-  // (e.g. a hand-crafted request bypassing the UI) would otherwise reach the
-  // enum column and make Postgres throw "invalid input value for enum".
-  if (filters?.type && (NOTIFICATION_EVENT_TYPES as readonly string[]).includes(filters.type)) {
-    conds.push(eq(notificationEventsTable.type, filters.type as NotificationEventType))
-  }
-  if (filters?.read === 'unread') conds.push(isNull(notificationEventsTable.viewedAt))
-  if (filters?.read === 'read') conds.push(isNotNull(notificationEventsTable.viewedAt))
-  if (filters?.search) {
-    conds.push(sql`${notificationEventsTable.uuid}::text ILIKE ${'%' + filters.search + '%'}`)
-  }
-  if (filters?.channel) {
-    // channels is a JSON array of { type, ... }; match any element's type.
-    conds.push(
-      sql`EXISTS (SELECT 1 FROM json_array_elements(${notificationEventsTable.channels}) elem WHERE elem->>'type' = ${filters.channel})`,
-    )
-  }
-  return conds
+  return buildConditions(notificationEventsTable, NOTIFICATION_EVENT_TYPES, filters)
 }
 
 // The list/table view never receives the encrypted config — secrets stay on the

--- a/apps/provider-workflows/src/activities/index.ts
+++ b/apps/provider-workflows/src/activities/index.ts
@@ -1001,7 +1001,7 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
    * now carries coveredBlockTime (chain block time at coveredUpToHeight) so callers
    * can supply chainTimeAtCoverage to decideVerification without a wall-clock.
    */
-  async verifyTxHash(transactionId: number): Promise<VerifyOutcome<{ success: boolean; code: number; gasUsed: string }> & { chainTimeAtCoverage?: Date | null }> {
+  async verifyTxHash(transactionId: number): Promise<VerifyOutcome<{ success: boolean; code: number; gasUsed: string; rawLog?: string }> & { chainTimeAtCoverage?: Date | null }> {
     const txn = await dal.transactions.getTransaction(transactionId)
     if (!txn?.hash) {
       throw new Error('verifyTxHash: tx missing hash')
@@ -1016,7 +1016,7 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
     // boundary (default payload converter cannot encode BigInt).
     return {
       status: 'confirmed',
-      data: { success: out.data.success, code: out.data.code, gasUsed: out.data.gasUsed.toString() },
+      data: { success: out.data.success, code: out.data.code, gasUsed: out.data.gasUsed.toString(), rawLog: out.data.rawLog },
     }
   },
 
@@ -1131,11 +1131,16 @@ export const providerActivities = (dal: DAL, pocketRpcClient: PocketBlockchain) 
     }
 
     const status = decision.tx === 'success' ? TransactionStatus.Success : TransactionStatus.Failure
+    // Failure message: prefer the chain's own error text (rawLog, present when the tx
+    // was found on-chain and failed) so the UI can show the real reason; the hardcoded
+    // summaries remain for paths with no chain text (absent-tx failure) or as suffix
+    // context (sibling-met goal).
     const claimed = await dal.transactions.claimTerminalTransition(transactionId, status, {
       code: decision.code,
       message: decision.tx === 'success' ? 'verified'
-        : decision.effects === 'apply-success' ? 'tx failed on-chain; goal met by sibling tx'
-        : 'verification negative (validity bound covered, no effect)',
+        : decision.effects === 'apply-success'
+          ? `tx failed on-chain; goal met by sibling tx${decision.rawLog ? ` (${decision.rawLog})` : ''}`
+          : decision.rawLog || 'verification negative (validity bound covered, no effect)',
     })
 
     // Provider-UI drain path: an Unstake verified success kicks off the drain using the

--- a/apps/provider/src/actions/NotificationChannels.ts
+++ b/apps/provider/src/actions/NotificationChannels.ts
@@ -13,6 +13,7 @@ import {
   listUnviewedNotificationEvents,
   markNotificationEventsViewed,
   markAllNotificationEventsViewed,
+  type NotificationEventFilters,
 } from '@/lib/dal/notificationChannels'
 import { withRequireOwner } from '@/lib/utils/actionUtils'
 import { NotificationChannelType } from '@igniter/db/provider/enums'
@@ -267,8 +268,12 @@ export async function TestNotificationChannel(id: number) {
   })
 }
 
-export async function ListNotificationEvents(page = 0, pageSize = 25, search?: string) {
-  return withRequireOwner(async () => listNotificationEvents(page, pageSize, search))
+export async function ListNotificationEvents(
+  page = 0,
+  pageSize = 25,
+  filters?: NotificationEventFilters,
+) {
+  return withRequireOwner(async () => listNotificationEvents(page, pageSize, filters))
 }
 
 export async function GetNotificationEvent(uuid: string) {

--- a/apps/provider/src/app/admin/(internal)/keys/ActivitiesSection.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/ActivitiesSection.tsx
@@ -15,16 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '@igniter/ui/components/table'
-import type {
-  PendingStateSerialized,
-  PendingOperationSerialized,
-} from '@/lib/pending/derivePendingState'
-
-// PENDING-only count — recently-settled linger rows don't inflate the badge.
-function pendingCount(state: PendingStateSerialized | undefined): number {
-  if (!state) return 0
-  return Object.keys(state.byKey).length
-}
+import type { PendingOperationSerialized } from '@/lib/pending/derivePendingState'
 
 const TYPE_LABELS: Record<PendingOperationSerialized['kind'], string> = {
   stake: 'Stake',
@@ -86,26 +77,14 @@ export default function ActivitiesSection() {
     return pendingState?.pendingOperations ?? []
   }, [pendingState])
 
-  const count = pendingCount(pendingState)
-
-  // Render nothing when no pending and no recently-settled rows — section only
-  // appears during activity.
-  if (rows.length === 0) return null
-
   return (
     <div className="flex flex-col gap-3">
-      {/* Badge shows PENDING count only; settled-linger rows don't inflate it. */}
-      <h3 className="text-lg font-semibold">
-        In progress
-        {count > 0 && (
-          <span className="text-sm font-normal text-text-tertiary ml-2">· {count}</span>
-        )}
-      </h3>
-
       {/* Compact, chrome-free strip built from the shared Table primitives (no
           DataTable toolbar/pagination). ~5 rows then internal scroll. */}
       <Table containerClassName="max-h-[260px]">
-        <TableHeader>
+        {/* Lock header to the top of the scroll box; opaque root bg so rows
+            don't bleed through, plus a bottom divider that stays put. */}
+        <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-(--bg-root) [&_th]:border-b [&_th]:border-border-primary">
           <TableRow className="bg-transparent">
             {/* Column order: Tx Hash · Submitted · Supplier · Type · Status */}
             <TableHead className={clsx(HEAD_CLASS, TX_HASH_COL_CLASS)}>Tx Hash</TableHead>
@@ -116,6 +95,16 @@ export default function ActivitiesSection() {
           </TableRow>
         </TableHeader>
         <TableBody>
+          {rows.length === 0 && (
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                className="h-24 text-center text-text-secondary"
+              >
+                No activity yet.
+              </TableCell>
+            </TableRow>
+          )}
           {rows.map((row) => {
             const statusLabel = getStatusLabel(row)
             const statusClass = getStatusClass(row)

--- a/apps/provider/src/app/admin/(internal)/keys/KeysTabs.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/KeysTabs.tsx
@@ -2,9 +2,11 @@
 
 import * as React from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useQuery } from '@tanstack/react-query'
 
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@igniter/ui/components/tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger, TabsBadge } from '@igniter/ui/components/tabs'
 
+import { GetKeysPendingState } from '@/actions/Transactions'
 import KeysTable from '@/app/admin/(internal)/keys/table'
 import ActivitiesSection from '@/app/admin/(internal)/keys/ActivitiesSection'
 
@@ -24,6 +26,20 @@ export default function KeysTabs() {
     ? (param as TabValue)
     : 'keys'
 
+  // Lifted above the tab boundary so the pending count stays live regardless of
+  // the active tab — ActivitiesSection (its own consumer of this same queryKey)
+  // only mounts on the Activity tab, so the badge needs its own always-mounted
+  // read. Same queryKey → react-query dedups to a single poll + shared cache.
+  const { data: pendingState } = useQuery({
+    queryKey: ['keys-pending-state'],
+    queryFn: async () => {
+      const res = await GetKeysPendingState()
+      return res.success ? res.data : { byKey: {}, pendingOperations: [] }
+    },
+    refetchInterval: 4000,
+  })
+  const pendingCount = Object.keys(pendingState?.byKey ?? {}).length
+
   const onTabChange = (next: string) => {
     const params = new URLSearchParams(searchParams.toString())
     params.set('tab', next)
@@ -34,7 +50,10 @@ export default function KeysTabs() {
     <Tabs value={tab} onValueChange={onTabChange}>
       <TabsList>
         <TabsTrigger value="keys">Keys</TabsTrigger>
-        <TabsTrigger value="activity">Activity</TabsTrigger>
+        <TabsTrigger value="activity">
+          Activity
+          <TabsBadge count={pendingCount} variant="warning" />
+        </TabsTrigger>
       </TabsList>
       <TabsContent value="keys">
         <KeysTable />

--- a/apps/provider/src/app/admin/(internal)/keys/KeysTabs.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/KeysTabs.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import * as React from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@igniter/ui/components/tabs'
+
+import KeysTable from '@/app/admin/(internal)/keys/table'
+import ActivitiesSection from '@/app/admin/(internal)/keys/ActivitiesSection'
+
+const TABS = ['keys', 'activity'] as const
+type TabValue = (typeof TABS)[number]
+
+// The two data tables that used to stack on the Keys screen now live one per
+// tab. Selection is persisted in the URL (?tab=) so refreshes / deep-links land
+// on the same table — same pattern as the middleman Suppliers screen.
+export default function KeysTabs() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const param = searchParams.get('tab')
+  const tab: TabValue = (TABS as readonly string[]).includes(param ?? '')
+    ? (param as TabValue)
+    : 'keys'
+
+  const onTabChange = (next: string) => {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('tab', next)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
+
+  return (
+    <Tabs value={tab} onValueChange={onTabChange}>
+      <TabsList>
+        <TabsTrigger value="keys">Keys</TabsTrigger>
+        <TabsTrigger value="activity">Activity</TabsTrigger>
+      </TabsList>
+      <TabsContent value="keys">
+        <KeysTable />
+      </TabsContent>
+      <TabsContent value="activity">
+        <ActivitiesSection />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/apps/provider/src/app/admin/(internal)/keys/KeysTabs.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/KeysTabs.tsx
@@ -36,7 +36,7 @@ export default function KeysTabs() {
       const res = await GetKeysPendingState()
       return res.success ? res.data : { byKey: {}, pendingOperations: [] }
     },
-    refetchInterval: 4000,
+    refetchInterval: (q) => (Object.keys(q.state.data?.byKey ?? {}).length > 0 ? 4000 : false),
   })
   const pendingCount = Object.keys(pendingState?.byKey ?? {}).length
 

--- a/apps/provider/src/app/admin/(internal)/keys/page.tsx
+++ b/apps/provider/src/app/admin/(internal)/keys/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import React from 'react'
-import KeysTable from '@/app/admin/(internal)/keys/table'
-import ActivitiesSection from '@/app/admin/(internal)/keys/ActivitiesSection'
+import KeysTabs from '@/app/admin/(internal)/keys/KeysTabs'
 import { GetAppName, GetApplicationSettings } from '@/actions/ApplicationSettings'
 import ClearRemediationButton from '@/app/admin/(internal)/keys/ClearRemediationButton'
 import AutoStakeToggle from '@/app/admin/(internal)/keys/AutoStakeToggle'
@@ -41,9 +40,8 @@ export default async function AddressesPage() {
         }
       />
       <PageContent>
-        <ActivitiesSection />
         <React.Suspense>
-          <KeysTable />
+          <KeysTabs />
         </React.Suspense>
       </PageContent>
     </KeysSelectionProvider>

--- a/apps/provider/src/app/admin/(internal)/layout.tsx
+++ b/apps/provider/src/app/admin/(internal)/layout.tsx
@@ -3,7 +3,7 @@ import "@/app/globals.css";
 import { ThemeProvider } from "@/app/theme";
 import WalletConnectionProvider from "@/app/context/WalletConnection/Provider";
 import { ApplicationSettingsProvider } from "@/app/context/ApplicationSettings";
-import { SidebarInset, SidebarProvider } from "@igniter/ui/components/sidebar";
+import { SidebarInset, SidebarProvider, SidebarTrigger } from "@igniter/ui/components/sidebar";
 import { AppTopBar } from "@igniter/ui/components/AppTopBar/index";
 import CurrentUser from "@/components/CurrentUser";
 import Sidebar from "@/components/Sidebar";
@@ -33,7 +33,7 @@ export default function RootLayout({
               <SidebarProvider className="flex flex-col h-dvh overflow-hidden">
                 <QuickDetailProvider>
                   <NotificationsProvider>
-                    <AppTopBar>
+                    <AppTopBar leading={<SidebarTrigger />}>
                       <CurrentUser />
                       <ThemeToggle />
                     </AppTopBar>
@@ -41,7 +41,7 @@ export default function RootLayout({
                         <Sidebar />
                         <SidebarInset className="!min-h-0">
                           <div className={"w-full h-full flex overflow-x-hidden"}>
-                            <div className="flex flex-col gap-6 flex-1 overflow-y-auto scrollbar-hidden w-[calc(100dvw)] md:w-[calc(100dvw-255px)]">
+                            <div className="flex flex-col gap-6 flex-1 overflow-y-auto scrollbar-hidden w-full min-w-0">
                               <RegisterPlugins />
                               <NotificationEventsBridge />
                               {children}

--- a/apps/provider/src/app/admin/(internal)/notifications/NotificationEventsSection.tsx
+++ b/apps/provider/src/app/admin/(internal)/notifications/NotificationEventsSection.tsx
@@ -15,7 +15,18 @@ import {
 } from '@/actions/NotificationChannels'
 import type { ProviderQuickDetailItem } from '@/app/admin/details/types'
 import type { NotificationEvent, NotificationEventMetadata } from '@igniter/db/provider/schema'
+import { NOTIFICATION_EVENT_TYPES, NotificationChannelType } from '@igniter/db/provider/enums'
 import { NOTIFICATION_EVENT_LABELS, REMEDIATION_REASON_LABELS } from '@/lib/constants'
+
+// Event-type + channel dropdown options for the history filters.
+const EVENT_TYPE_OPTIONS = NOTIFICATION_EVENT_TYPES.map((t) => ({
+  value: t,
+  label: NOTIFICATION_EVENT_LABELS[t as keyof typeof NOTIFICATION_EVENT_LABELS] ?? t,
+}))
+const CHANNEL_OPTIONS = Object.values(NotificationChannelType).map((t) => ({
+  value: t,
+  label: t.charAt(0).toUpperCase() + t.slice(1),
+}))
 
 function metadataSummary(type: string, metadata: NotificationEventMetadata | null | undefined): string {
   if (!metadata) return '—'
@@ -96,7 +107,8 @@ export function NotificationEventsSection({ onMarkAllViewed }: NotificationEvent
 
   return (
     <NotificationHistory
-      enableSearch
+      eventTypeOptions={EVENT_TYPE_OPTIONS}
+      channelOptions={CHANNEL_OPTIONS}
       onMarkAllViewed={onMarkAllViewed}
       onOpenEvent={openEvent}
       renderChannelIcon={(type) => <NotificationChannelIcon type={type} className="h-3 w-3 shrink-0" />}
@@ -104,8 +116,8 @@ export function NotificationEventsSection({ onMarkAllViewed }: NotificationEvent
         NOTIFICATION_EVENT_LABELS[type as keyof typeof NOTIFICATION_EVENT_LABELS] ?? type
       }
       summaryFor={(type, metadata) => metadataSummary(type, metadata as NotificationEventMetadata)}
-      listEvents={async (page, pageSize, search) => {
-        const result = await ListNotificationEvents(page, pageSize, search)
+      listEvents={async (page, pageSize, filters) => {
+        const result = await ListNotificationEvents(page, pageSize, filters)
         if (!result.success) throw new Error(result.error.message)
         return result.data
       }}

--- a/apps/provider/src/app/admin/(internal)/notifications/NotificationEventsSection.tsx
+++ b/apps/provider/src/app/admin/(internal)/notifications/NotificationEventsSection.tsx
@@ -107,6 +107,7 @@ export function NotificationEventsSection({ onMarkAllViewed }: NotificationEvent
 
   return (
     <NotificationHistory
+      enableSearch
       eventTypeOptions={EVENT_TYPE_OPTIONS}
       channelOptions={CHANNEL_OPTIONS}
       onMarkAllViewed={onMarkAllViewed}

--- a/apps/provider/src/app/admin/(internal)/transactions/table/columns.tsx
+++ b/apps/provider/src/app/admin/(internal)/transactions/table/columns.tsx
@@ -6,6 +6,7 @@ import Address from '@igniter/ui/components/Address'
 import type { Transaction } from '@igniter/db/provider/schema'
 import { TransactionStatus, TransactionType, TransactionTrigger, RemediationHistoryEntryReason } from '@igniter/db/provider/enums'
 import { failureReasonDisplay } from '@igniter/commons/utils'
+import { FailureReasonPopover } from '@igniter/ui/components/FailureReasonPopover'
 import { Button } from '@igniter/ui/components/button'
 import { RightArrowIcon } from '@igniter/ui/assets'
 import { useAddItemToDetail } from '@igniter/ui/components/QuickDetails/Provider'
@@ -90,7 +91,7 @@ export const columns: Array<ColumnDef<Transaction>> = [
   },
   {
     accessorKey: "reason",
-    header: "Reason",
+    header: "Remediation",
     cell: ({ row }) => {
       const reason = row.getValue("reason") as string | null
       return (
@@ -105,15 +106,12 @@ export const columns: Array<ColumnDef<Transaction>> = [
     header: "Failure Reason",
     cell: ({ row }) => {
       const status = row.getValue("status") as string
-      const text = failureReasonDisplay(status === TransactionStatus.Failure, row.original.message)
+      const text = failureReasonDisplay(status === TransactionStatus.Failure, row.original.message, row.original.code)
       if (text === null) {
         return <span className="text-slightly-muted-foreground">-</span>
       }
-      return (
-        <span className="block max-w-[16rem] truncate text-red-400" title={text}>
-          {text}
-        </span>
-      )
+      // Friendly text in the cell; click to open the full raw message (copyable) inline.
+      return <FailureReasonPopover friendly={text} full={row.original.message?.trim() || ''} code={row.original.code} />
     },
   },
   {

--- a/apps/provider/src/app/admin/(internal)/transactions/table/columns.tsx
+++ b/apps/provider/src/app/admin/(internal)/transactions/table/columns.tsx
@@ -5,6 +5,7 @@ import { FilterGroup, SortOption } from '@igniter/ui/components/DataTable/index'
 import Address from '@igniter/ui/components/Address'
 import type { Transaction } from '@igniter/db/provider/schema'
 import { TransactionStatus, TransactionType, TransactionTrigger, RemediationHistoryEntryReason } from '@igniter/db/provider/enums'
+import { failureReasonDisplay } from '@igniter/commons/utils'
 import { Button } from '@igniter/ui/components/button'
 import { RightArrowIcon } from '@igniter/ui/assets'
 import { useAddItemToDetail } from '@igniter/ui/components/QuickDetails/Provider'
@@ -95,6 +96,22 @@ export const columns: Array<ColumnDef<Transaction>> = [
       return (
         <span className="text-slightly-muted-foreground">
           {reason ? (ReasonLabels[reason] || reason) : '-'}
+        </span>
+      )
+    },
+  },
+  {
+    accessorKey: "message",
+    header: "Failure Reason",
+    cell: ({ row }) => {
+      const status = row.getValue("status") as string
+      const text = failureReasonDisplay(status === TransactionStatus.Failure, row.original.message)
+      if (text === null) {
+        return <span className="text-slightly-muted-foreground">-</span>
+      }
+      return (
+        <span className="block max-w-[16rem] truncate text-red-400" title={text}>
+          {text}
         </span>
       )
     },

--- a/apps/provider/src/app/admin/details/TransactionDetail/index.tsx
+++ b/apps/provider/src/app/admin/details/TransactionDetail/index.tsx
@@ -119,8 +119,6 @@ export default function TransactionDetail({ tx }: TransactionDetailProps) {
     lastCoveredHeight,
     timeoutHeight,
     timeoutTimestamp,
-    code,
-    message,
     unavailableChecks,
     lastVerificationAt,
     createdAt,
@@ -150,7 +148,7 @@ export default function TransactionDetail({ tx }: TransactionDetailProps) {
       value: <Badge variant={variant}>{StatusLabels[status] || status}</Badge>,
     },
     {
-      label: 'Reason',
+      label: 'Remediation',
       value: <span>{reason ? (ReasonLabels[reason] || reason) : '—'}</span>,
     },
     {
@@ -172,14 +170,6 @@ export default function TransactionDetail({ tx }: TransactionDetailProps) {
     {
       label: 'Timeout Timestamp',
       value: <span className="font-mono">{formatDate(timeoutTimestamp)}</span>,
-    },
-    {
-      label: 'Code',
-      value: <span className="font-mono">{code ?? '—'}</span>,
-    },
-    {
-      label: 'Message',
-      value: <span className="text-xs break-all">{message || '—'}</span>,
     },
     {
       label: 'Unavailable Checks',

--- a/apps/provider/src/components/Sidebar.tsx
+++ b/apps/provider/src/components/Sidebar.tsx
@@ -104,7 +104,7 @@ export default function Sidebar({}: Readonly<AppSidebarProps>) {
           : "text-text-secondary"
       }
     >
-      <SidebarMenuButton asChild>
+      <SidebarMenuButton asChild tooltip={route.title}>
         <Link href={route.url}>
           <route.icon />
           <span>{route.title}</span>

--- a/apps/provider/src/lib/dal/notificationChannels.filters.test.ts
+++ b/apps/provider/src/lib/dal/notificationChannels.filters.test.ts
@@ -1,0 +1,49 @@
+jest.mock('@/db', () => ({ getDb: () => ({}) }))
+
+import { buildNotificationEventFilterConditions } from './notificationChannels'
+
+// The helper turns the optional filter set into AND-able SQL conditions. These
+// tests lock the branching (each active filter contributes exactly one
+// condition; absent/empty filters contribute none) so a future refactor can't
+// silently drop a filter dimension.
+describe('buildNotificationEventFilterConditions (provider)', () => {
+  it('produces no conditions when nothing is filtered', () => {
+    expect(buildNotificationEventFilterConditions(undefined)).toHaveLength(0)
+    expect(buildNotificationEventFilterConditions({})).toHaveLength(0)
+  })
+
+  it('adds exactly one condition per active filter dimension', () => {
+    expect(buildNotificationEventFilterConditions({ type: 'keys_staked' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ read: 'unread' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ read: 'read' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ channel: 'telegram' })).toHaveLength(1)
+    expect(buildNotificationEventFilterConditions({ search: 'abc' })).toHaveLength(1)
+  })
+
+  it('ignores an empty/unknown read value', () => {
+    expect(
+      buildNotificationEventFilterConditions({ read: '' as unknown as 'read' }),
+    ).toHaveLength(0)
+  })
+
+  it('ignores empty-string filter values (treated as unconstrained)', () => {
+    expect(
+      buildNotificationEventFilterConditions({ type: '', channel: '', search: '' }),
+    ).toHaveLength(0)
+  })
+
+  it('ignores an unknown event type instead of shipping it to the enum column', () => {
+    expect(buildNotificationEventFilterConditions({ type: 'not_a_real_type' })).toHaveLength(0)
+  })
+
+  it('combines every active filter into four ANDable conditions', () => {
+    expect(
+      buildNotificationEventFilterConditions({
+        type: 'keys_staked',
+        read: 'unread',
+        channel: 'telegram',
+        search: 'x',
+      }),
+    ).toHaveLength(4)
+  })
+})

--- a/apps/provider/src/lib/dal/notificationChannels.ts
+++ b/apps/provider/src/lib/dal/notificationChannels.ts
@@ -1,4 +1,5 @@
-import { count, desc, eq, inArray, isNull } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
+import { NOTIFICATION_EVENT_TYPES } from '@igniter/db/provider/enums'
 import {
   notificationChannelsTable,
   notificationEventsTable,
@@ -6,10 +7,48 @@ import {
   type NotificationChannel,
   type InsertNotificationChannel,
   type NotificationEvent,
+  type NotificationEventType,
   type SmtpConfiguration,
   type InsertSmtpConfiguration,
 } from '@igniter/db/provider/schema'
 import { getDb } from '@/db'
+
+// Server-side filters for the notification history table. All optional; an
+// absent field means "no constraint on that dimension".
+export type NotificationEventFilters = {
+  /** Partial, case-insensitive match on the event UUID. */
+  search?: string
+  /** Exact event type (e.g. 'stake', 'service_change'). */
+  type?: string
+  /** Read/unread by viewedAt presence. */
+  read?: 'read' | 'unread'
+  /** Delivering channel type (e.g. 'discord') — matched against the channels JSON. */
+  channel?: string
+}
+
+// Translates the optional filter set into a list of AND-able SQL conditions.
+// Exported for unit testing of the filter branching.
+export function buildNotificationEventFilterConditions(filters?: NotificationEventFilters) {
+  const conds = []
+  // Only push a type condition for a KNOWN enum member — an arbitrary string
+  // (e.g. a hand-crafted request bypassing the UI) would otherwise reach the
+  // enum column and make Postgres throw "invalid input value for enum".
+  if (filters?.type && (NOTIFICATION_EVENT_TYPES as readonly string[]).includes(filters.type)) {
+    conds.push(eq(notificationEventsTable.type, filters.type as NotificationEventType))
+  }
+  if (filters?.read === 'unread') conds.push(isNull(notificationEventsTable.viewedAt))
+  if (filters?.read === 'read') conds.push(isNotNull(notificationEventsTable.viewedAt))
+  if (filters?.search) {
+    conds.push(sql`${notificationEventsTable.uuid}::text ILIKE ${'%' + filters.search + '%'}`)
+  }
+  if (filters?.channel) {
+    // channels is a JSON array of { type, ... }; match any element's type.
+    conds.push(
+      sql`EXISTS (SELECT 1 FROM json_array_elements(${notificationEventsTable.channels}) elem WHERE elem->>'type' = ${filters.channel})`,
+    )
+  }
+  return conds
+}
 
 // Deliberately excludes `config`: it holds channel secrets (webhook URL, bot
 // token) and must not be shipped to the client with the list view. Use
@@ -117,10 +156,11 @@ export async function deleteSmtpConfig(): Promise<void> {
 export async function listNotificationEvents(
   page: number,
   pageSize: number,
-  search?: string,
+  filters?: NotificationEventFilters,
 ): Promise<{ data: NotificationEvent[]; total: number; unviewedTotal: number }> {
   const db = getDb()
-  const where = search ? eq(notificationEventsTable.uuid, search) : undefined
+  const conds = buildNotificationEventFilterConditions(filters)
+  const where = conds.length ? and(...conds) : undefined
   const [rows, [countRow], [unviewedRow]] = await Promise.all([
     db
       .select()

--- a/apps/provider/src/lib/dal/notificationChannels.ts
+++ b/apps/provider/src/lib/dal/notificationChannels.ts
@@ -1,5 +1,9 @@
-import { and, count, desc, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNull } from 'drizzle-orm'
 import { NOTIFICATION_EVENT_TYPES } from '@igniter/db/provider/enums'
+import {
+  buildNotificationEventFilterConditions as buildConditions,
+  type NotificationEventFilters,
+} from '@igniter/db/notifications'
 import {
   notificationChannelsTable,
   notificationEventsTable,
@@ -7,47 +11,18 @@ import {
   type NotificationChannel,
   type InsertNotificationChannel,
   type NotificationEvent,
-  type NotificationEventType,
   type SmtpConfiguration,
   type InsertSmtpConfiguration,
 } from '@igniter/db/provider/schema'
 import { getDb } from '@/db'
 
-// Server-side filters for the notification history table. All optional; an
-// absent field means "no constraint on that dimension".
-export type NotificationEventFilters = {
-  /** Partial, case-insensitive match on the event UUID. */
-  search?: string
-  /** Exact event type (e.g. 'stake', 'service_change'). */
-  type?: string
-  /** Read/unread by viewedAt presence. */
-  read?: 'read' | 'unread'
-  /** Delivering channel type (e.g. 'discord') — matched against the channels JSON. */
-  channel?: string
-}
+export type { NotificationEventFilters }
 
-// Translates the optional filter set into a list of AND-able SQL conditions.
-// Exported for unit testing of the filter branching.
+// Binds the provider events table + enum to the shared filter builder in
+// @igniter/db/notifications. Kept as a same-signature wrapper so call sites and
+// the unit tests (notificationChannels.filters.test.ts) stay unchanged.
 export function buildNotificationEventFilterConditions(filters?: NotificationEventFilters) {
-  const conds = []
-  // Only push a type condition for a KNOWN enum member — an arbitrary string
-  // (e.g. a hand-crafted request bypassing the UI) would otherwise reach the
-  // enum column and make Postgres throw "invalid input value for enum".
-  if (filters?.type && (NOTIFICATION_EVENT_TYPES as readonly string[]).includes(filters.type)) {
-    conds.push(eq(notificationEventsTable.type, filters.type as NotificationEventType))
-  }
-  if (filters?.read === 'unread') conds.push(isNull(notificationEventsTable.viewedAt))
-  if (filters?.read === 'read') conds.push(isNotNull(notificationEventsTable.viewedAt))
-  if (filters?.search) {
-    conds.push(sql`${notificationEventsTable.uuid}::text ILIKE ${'%' + filters.search + '%'}`)
-  }
-  if (filters?.channel) {
-    // channels is a JSON array of { type, ... }; match any element's type.
-    conds.push(
-      sql`EXISTS (SELECT 1 FROM json_array_elements(${notificationEventsTable.channels}) elem WHERE elem->>'type' = ${filters.channel})`,
-    )
-  }
-  return conds
+  return buildConditions(notificationEventsTable, NOTIFICATION_EVENT_TYPES, filters)
 }
 
 // Deliberately excludes `config`: it holds channel secrets (webhook URL, bot

--- a/packages/commons/src/utils.test.ts
+++ b/packages/commons/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { parseEnvInt, checkEnvVariables, failureReasonDisplay } from './utils';
+import { parseEnvInt, checkEnvVariables, failureReasonDisplay, cosmosSdkErrorMessage } from './utils';
 
 describe('parseEnvInt', () => {
   it('parses a valid integer string', () => {
@@ -83,5 +83,46 @@ describe('failureReasonDisplay', () => {
     expect(failureReasonDisplay(true, undefined)).toBe('Unknown error');
     expect(failureReasonDisplay(true, '')).toBe('Unknown error');
     expect(failureReasonDisplay(true, '   ')).toBe('Unknown error');
+  });
+
+  it('maps a corroborated sdk code to its friendly message', () => {
+    expect(
+      failureReasonDisplay(true, 'spendable balance 0upokt is smaller than 60000000000upokt: insufficient funds', 5),
+    ).toBe('Insufficient funds to cover the transaction');
+    expect(
+      failureReasonDisplay(true, 'out of gas in location: WritePerByte; gasWanted: 200000, gasUsed: 213417: out of gas', 11),
+    ).toBe('Transaction ran out of gas');
+  });
+
+  it('shows the raw reason when the code is not corroborated by the log (module codespace collision)', () => {
+    // poktroll "supplier" codespace code 5 is NOT sdk insufficient-funds
+    expect(failureReasonDisplay(true, 'supplier stake below minimum', 5)).toBe('supplier stake below minimum');
+  });
+
+  it('shows the raw reason when the code is unknown or absent', () => {
+    expect(failureReasonDisplay(true, 'some module error', 999)).toBe('some module error');
+    expect(failureReasonDisplay(true, 'some module error', null)).toBe('some module error');
+    expect(failureReasonDisplay(true, 'some module error')).toBe('some module error');
+  });
+});
+
+describe('cosmosSdkErrorMessage', () => {
+  it('returns the friendly message when code and log agree', () => {
+    expect(cosmosSdkErrorMessage(32, 'account sequence mismatch, expected 5, got 3: incorrect account sequence'))
+      .toBe('Wrong account sequence — transaction sent out of order');
+    expect(cosmosSdkErrorMessage(13, 'insufficient fees; got: 1upokt required: 10upokt: insufficient fee'))
+      .toBe('Fee too low for this transaction');
+  });
+
+  it('matches case-insensitively', () => {
+    expect(cosmosSdkErrorMessage(11, 'OUT OF GAS: gasWanted 1, gasUsed 2')).toBe('Transaction ran out of gas');
+  });
+
+  it('returns null without corroboration, unknown code, or missing input', () => {
+    expect(cosmosSdkErrorMessage(5, 'supplier stake below minimum')).toBeNull();
+    expect(cosmosSdkErrorMessage(999, 'insufficient funds')).toBeNull();
+    expect(cosmosSdkErrorMessage(null, 'insufficient funds')).toBeNull();
+    expect(cosmosSdkErrorMessage(5, null)).toBeNull();
+    expect(cosmosSdkErrorMessage(5, '')).toBeNull();
   });
 });

--- a/packages/commons/src/utils.test.ts
+++ b/packages/commons/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { parseEnvInt, checkEnvVariables } from './utils';
+import { parseEnvInt, checkEnvVariables, failureReasonDisplay } from './utils';
 
 describe('parseEnvInt', () => {
   it('parses a valid integer string', () => {
@@ -63,5 +63,25 @@ describe('checkEnvVariables', () => {
 
   it('does not throw for an empty list', () => {
     expect(() => checkEnvVariables([])).not.toThrow();
+  });
+});
+
+describe('failureReasonDisplay', () => {
+  it('returns null when the transaction is not a failure (caller shows a dash)', () => {
+    expect(failureReasonDisplay(false, 'insufficient funds')).toBeNull();
+    expect(failureReasonDisplay(false, null)).toBeNull();
+    expect(failureReasonDisplay(false, undefined)).toBeNull();
+  });
+
+  it('returns the trimmed reason for a failure', () => {
+    expect(failureReasonDisplay(true, 'insufficient funds')).toBe('insufficient funds');
+    expect(failureReasonDisplay(true, '  sequence mismatch  ')).toBe('sequence mismatch');
+  });
+
+  it('falls back to "Unknown error" when a failure has no usable reason', () => {
+    expect(failureReasonDisplay(true, null)).toBe('Unknown error');
+    expect(failureReasonDisplay(true, undefined)).toBe('Unknown error');
+    expect(failureReasonDisplay(true, '')).toBe('Unknown error');
+    expect(failureReasonDisplay(true, '   ')).toBe('Unknown error');
   });
 });

--- a/packages/commons/src/utils.ts
+++ b/packages/commons/src/utils.ts
@@ -10,3 +10,17 @@ export const checkEnvVariables = (vars: string[]) => {
     }
   }
 }
+
+/**
+ * Display text for a transaction's failure reason, shared by both apps'
+ * transaction tables. Returns `null` when the row is not a failure (the caller
+ * renders a placeholder such as "-"); otherwise the trimmed reason, or
+ * "Unknown error" when the reason is absent, empty, or whitespace-only.
+ */
+export const failureReasonDisplay = (
+  isFailure: boolean,
+  reason: string | null | undefined,
+): string | null => {
+  if (!isFailure) return null
+  return reason?.trim() || 'Unknown error'
+}

--- a/packages/commons/src/utils.ts
+++ b/packages/commons/src/utils.ts
@@ -24,3 +24,12 @@ export const failureReasonDisplay = (
   if (!isFailure) return null
   return reason?.trim() || 'Unknown error'
 }
+
+/**
+ * Whether a pathname belongs to the authenticated internal areas (app/admin),
+ * as opposed to the portal (landing) and auth pages. Single source of truth for
+ * the sidebar gate: both the rail (Sidebar) and its toggle (SidebarTriggerGate)
+ * must agree, so the prefix set lives here rather than being duplicated.
+ */
+export const isInternalPath = (pathname: string): boolean =>
+  pathname.startsWith('/app') || pathname.startsWith('/admin')

--- a/packages/commons/src/utils.ts
+++ b/packages/commons/src/utils.ts
@@ -12,17 +12,92 @@ export const checkEnvVariables = (vars: string[]) => {
 }
 
 /**
+ * Cosmos SDK registered errors (codespace "sdk"), keyed by ABCI code.
+ * Source: cosmos-sdk types/errors/errors.go (codes 2-42).
+ *
+ * `match` is the exact message string registered for that code (lowercased);
+ * `friendly` is the short human-readable text shown in the transaction tables.
+ *
+ * The friendly text is only used when the raw log actually contains `match`.
+ * ABCI codes are only unique within a codespace, and we don't persist the
+ * codespace, so a poktroll module error that reuses the same numeric code
+ * (e.g. code 5 in the "supplier" codespace) must never be relabeled as the
+ * sdk meaning — the log-content check makes that mislabeling impossible.
+ */
+const COSMOS_SDK_ERRORS: Record<number, { match: string; friendly: string }> = {
+  2: { match: 'tx parse error', friendly: 'Transaction could not be decoded' },
+  3: { match: 'invalid sequence', friendly: 'Invalid account sequence' },
+  4: { match: 'unauthorized', friendly: 'Unauthorized signer or signature' },
+  5: { match: 'insufficient funds', friendly: 'Insufficient funds to cover the transaction' },
+  6: { match: 'unknown request', friendly: 'Unknown request' },
+  7: { match: 'invalid address', friendly: 'Invalid address' },
+  8: { match: 'invalid pubkey', friendly: 'Invalid public key' },
+  9: { match: 'unknown address', friendly: 'Unknown address' },
+  10: { match: 'invalid coins', friendly: 'Invalid coin amount or denomination' },
+  11: { match: 'out of gas', friendly: 'Transaction ran out of gas' },
+  12: { match: 'memo too large', friendly: 'Transaction memo is too large' },
+  13: { match: 'insufficient fee', friendly: 'Fee too low for this transaction' },
+  14: { match: 'maximum number of signatures exceeded', friendly: 'Too many signatures' },
+  15: { match: 'no signatures supplied', friendly: 'No signatures supplied' },
+  16: { match: 'failed to marshal json bytes', friendly: 'Internal encoding error (JSON)' },
+  17: { match: 'failed to unmarshal json bytes', friendly: 'Internal decoding error (JSON)' },
+  18: { match: 'invalid request', friendly: 'Invalid request' },
+  19: { match: 'tx already in mempool', friendly: 'Transaction already pending in the mempool' },
+  20: { match: 'mempool is full', friendly: 'Network mempool is full — try again later' },
+  21: { match: 'tx too large', friendly: 'Transaction too large' },
+  22: { match: 'key not found', friendly: 'Key not found' },
+  23: { match: 'invalid account password', friendly: 'Invalid account password' },
+  24: { match: 'tx intended signer does not match the given signer', friendly: 'Signer does not match the intended signer' },
+  25: { match: 'invalid gas adjustment', friendly: 'Invalid gas adjustment' },
+  26: { match: 'invalid height', friendly: 'Invalid block height' },
+  27: { match: 'invalid version', friendly: 'Invalid version' },
+  28: { match: 'invalid chain-id', friendly: 'Wrong chain ID' },
+  29: { match: 'invalid type', friendly: 'Invalid type' },
+  30: { match: 'tx timeout height', friendly: 'Transaction expired (timeout height exceeded)' },
+  31: { match: 'unknown extension options', friendly: 'Unknown extension options' },
+  32: { match: 'incorrect account sequence', friendly: 'Wrong account sequence — transaction sent out of order' },
+  33: { match: 'failed packing protobuf message to any', friendly: 'Internal encoding error (protobuf)' },
+  34: { match: 'failed unpacking protobuf message from any', friendly: 'Internal decoding error (protobuf)' },
+  35: { match: 'internal logic error', friendly: 'Internal logic error' },
+  36: { match: 'conflict', friendly: 'Conflict — state changed concurrently' },
+  37: { match: 'feature not supported', friendly: 'Feature not supported' },
+  38: { match: 'not found', friendly: 'Not found' },
+  39: { match: 'internal io error', friendly: 'Internal I/O error' },
+  40: { match: 'error in app.toml', friendly: 'Node configuration error' },
+  41: { match: 'invalid gas limit', friendly: 'Invalid gas limit' },
+  42: { match: 'tx timeout', friendly: 'Transaction timed out before being included in a block' },
+}
+
+/**
+ * Friendly message for a Cosmos SDK ABCI error, or `null` when the code is
+ * unknown or the raw log doesn't corroborate the sdk meaning (see
+ * COSMOS_SDK_ERRORS for why corroboration is required).
+ */
+export const cosmosSdkErrorMessage = (
+  code: number | null | undefined,
+  rawLog: string | null | undefined,
+): string | null => {
+  if (code == null || !rawLog) return null
+  const entry = COSMOS_SDK_ERRORS[code]
+  if (!entry) return null
+  return rawLog.toLowerCase().includes(entry.match) ? entry.friendly : null
+}
+
+/**
  * Display text for a transaction's failure reason, shared by both apps'
  * transaction tables. Returns `null` when the row is not a failure (the caller
- * renders a placeholder such as "-"); otherwise the trimmed reason, or
- * "Unknown error" when the reason is absent, empty, or whitespace-only.
+ * renders a placeholder such as "-"). For failures, prefers the friendly
+ * Cosmos SDK message when `code` maps to one corroborated by the raw reason;
+ * otherwise the trimmed reason, or "Unknown error" when the reason is absent,
+ * empty, or whitespace-only.
  */
 export const failureReasonDisplay = (
   isFailure: boolean,
   reason: string | null | undefined,
+  code?: number | null,
 ): string | null => {
   if (!isFailure) return null
-  return reason?.trim() || 'Unknown error'
+  return cosmosSdkErrorMessage(code, reason) ?? (reason?.trim() || 'Unknown error')
 }
 
 /**

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/src/watchdogStore.js",
       "require": "./dist/src/watchdogStore.js",
       "types": "./dist/src/watchdogStore.d.ts"
+    },
+    "./notifications": {
+      "import": "./dist/src/notifications.js",
+      "require": "./dist/src/notifications.js",
+      "types": "./dist/src/notifications.d.ts"
     }
   },
   "scripts": {

--- a/packages/db/src/notifications.ts
+++ b/packages/db/src/notifications.ts
@@ -1,0 +1,53 @@
+import { eq, isNotNull, isNull, sql, type Column, type SQL } from 'drizzle-orm'
+
+// Server-side filters for the notification history table. All optional; an
+// absent field means "no constraint on that dimension". App-agnostic — provider
+// and middleman share the identical shape.
+export type NotificationEventFilters = {
+  /** Partial, case-insensitive match on the event UUID. */
+  search?: string
+  /** Exact event type (e.g. 'stake', 'service_change'). */
+  type?: string
+  /** Read/unread by viewedAt presence. */
+  read?: 'read' | 'unread'
+  /** Delivering channel type (e.g. 'discord') — matched against the channels JSON. */
+  channel?: string
+}
+
+// The subset of a notificationEventsTable's columns that filtering touches.
+// Provider and middleman each own their own table, but both expose these
+// identically, so the builder is app-agnostic — each app binds its own table.
+export type NotificationEventFilterColumns = {
+  type: Column
+  viewedAt: Column
+  uuid: Column
+  channels: Column
+}
+
+// Translates the optional filter set into a list of AND-able SQL conditions.
+// `eventTypes` is the app's NOTIFICATION_EVENT_TYPES: only a KNOWN enum member
+// yields a type condition — an arbitrary string (e.g. a hand-crafted request
+// bypassing the UI) would otherwise reach the enum column and make Postgres
+// throw "invalid input value for enum".
+export function buildNotificationEventFilterConditions(
+  columns: NotificationEventFilterColumns,
+  eventTypes: readonly string[],
+  filters?: NotificationEventFilters,
+): SQL[] {
+  const conds: SQL[] = []
+  if (filters?.type && eventTypes.includes(filters.type)) {
+    conds.push(eq(columns.type, filters.type))
+  }
+  if (filters?.read === 'unread') conds.push(isNull(columns.viewedAt))
+  if (filters?.read === 'read') conds.push(isNotNull(columns.viewedAt))
+  if (filters?.search) {
+    conds.push(sql`${columns.uuid}::text ILIKE ${'%' + filters.search + '%'}`)
+  }
+  if (filters?.channel) {
+    // channels is a JSON array of { type, ... }; match any element's type.
+    conds.push(
+      sql`EXISTS (SELECT 1 FROM json_array_elements(${columns.channels}) elem WHERE elem->>'type' = ${filters.channel})`,
+    )
+  }
+  return conds
+}

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -339,12 +339,13 @@ export class PocketBlockchain {
       const transactionHash = await client.broadcastTxSync(txBytes)
       return { transactionHash, success: true }
     } catch (error) {
-      const { code, message } = error as { code: number; message: string }
+
+      const err = error as { code?: number; message?: string; log?: string }
       return {
         transactionHash: '',
         success: false,
-        code,
-        message,
+        code: err.code,
+        message: err.log ?? err.message,
       }
     }
   }
@@ -403,6 +404,7 @@ export class PocketBlockchain {
         gasWanted: tx.gasWanted,
         success: tx.code === 0,
         code: tx.code,
+        rawLog: tx.rawLog,
       }
     }
 
@@ -516,7 +518,7 @@ export class PocketBlockchain {
         const results = await comet.blockResults(height)
         const txData = results.results[i]
         if (!txData) return 'result-missing'
-        return { hash: txHash, height, index: i, gasUsed: txData.gasUsed, gasWanted: txData.gasWanted, success: txData.code === 0, code: txData.code }
+        return { hash: txHash, height, index: i, gasUsed: txData.gasUsed, gasWanted: txData.gasWanted, success: txData.code === 0, code: txData.code, rawLog: txData.log }
       }
     }
     return 'no-match'
@@ -539,6 +541,7 @@ export class PocketBlockchain {
         gasWanted: BigInt(txResponse.gas_wanted || '0'),
         success: txResponse.code === 0,
         code: txResponse.code,
+        rawLog: txResponse.raw_log ?? undefined,
       }
     } catch (error) {
       this.logger.warn('API tx lookup failed', { txHash, error })
@@ -946,7 +949,8 @@ export class PocketBlockchain {
           success: false,
           rejected: true,
           code: e.code,
-          message: e.message ?? 'broadcast rejected',
+          // `.log` is the clean ABCI error; `.message` is the verbose cosmjs wrapper.
+          message: e.log ?? e.message ?? 'broadcast rejected',
         }
       }
 
@@ -970,7 +974,8 @@ export class PocketBlockchain {
         success: false,
         rejected: false,
         code: e.code,
-        message: e.message ?? 'broadcast failed',
+        // Prefer the clean ABCI `.log` when present (undefined on non-cosmjs errors).
+        message: e.log ?? e.message ?? 'broadcast failed',
       }
     }
   }

--- a/packages/pocket/src/types.ts
+++ b/packages/pocket/src/types.ts
@@ -80,6 +80,8 @@ export interface TransactionResult {
   gasWanted?: bigint;
   success: boolean;
   code: number;
+  /** Chain error text (ABCI log) for failed txs; empty/undefined on success. */
+  rawLog?: string;
 }
 
 /**

--- a/packages/tx-verify/src/decide.ts
+++ b/packages/tx-verify/src/decide.ts
@@ -8,7 +8,7 @@ import type { VerifyOutcome, SupplierPathOutcome } from './verifyOutcome'
 export const TX_EXPIRATION_BLOCKS = 30
 
 export interface DecideInput {
-  hash: VerifyOutcome<{ success: boolean; code: number; gasUsed: string }>
+  hash: VerifyOutcome<{ success: boolean; code: number; gasUsed: string; rawLog?: string }>
   /** null when the tx type has no supplier path (e.g. send / OperationalFunds) */
   supplier: SupplierPathOutcome | null
   /** advisory only, not read — kept so existing callers compile without changes */
@@ -50,6 +50,8 @@ export interface VerificationDecision {
   failedOperators?: string[]
   code?: number
   gasUsed?: string
+  /** Chain error text (ABCI log) when the tx was found on-chain and failed. */
+  rawLog?: string
   newLastCoveredHeight?: number
   /** any applicable path was unavailable */
   incUnavailable: boolean
@@ -85,14 +87,14 @@ export function decideVerification(input: DecideInput): VerificationDecision {
   //    but destructive effects require knowing the goal-state.
   if (hash.status === 'confirmed' && !hash.data.success) {
     if (!supplierApplicable) {
-      return { tx: 'failure', effects: 'none', code: hash.data.code, gasUsed: hash.data.gasUsed, incUnavailable: false }
+      return { tx: 'failure', effects: 'none', code: hash.data.code, gasUsed: hash.data.gasUsed, rawLog: hash.data.rawLog, incUnavailable: false }
     }
     if (supplier!.status === 'confirmed') {
       // Goal met by a sibling tx — do NOT release/penalize staked state.
-      return { tx: 'failure', effects: 'apply-success', code: hash.data.code, gasUsed: hash.data.gasUsed, incUnavailable: false }
+      return { tx: 'failure', effects: 'apply-success', code: hash.data.code, gasUsed: hash.data.gasUsed, rawLog: hash.data.rawLog, incUnavailable: false }
     }
     if (supplier!.status === 'absent') {
-      return { tx: 'failure', effects: 'apply-failure', failedOperators: supplier!.absentOperators, code: hash.data.code, gasUsed: hash.data.gasUsed, incUnavailable: false }
+      return { tx: 'failure', effects: 'apply-failure', failedOperators: supplier!.absentOperators, code: hash.data.code, gasUsed: hash.data.gasUsed, rawLog: hash.data.rawLog, incUnavailable: false }
     }
     // supplier unavailable: wait — never run destructive effects on an unknown goal-state.
     return { tx: 'pending', effects: 'none', incUnavailable: true }

--- a/packages/ui/src/components/AppSidebar.tsx
+++ b/packages/ui/src/components/AppSidebar.tsx
@@ -6,6 +6,7 @@ import {
   SidebarGroupContent,
   SidebarHeader,
   SidebarMenu,
+  SidebarRail,
 } from "./sidebar";
 
 import { ComponentType } from "react";
@@ -28,6 +29,7 @@ export default function AppSidebar({
 }: Readonly<AppSidebarProps>) {
   return (
     <Sidebar
+      collapsible="icon"
       className="top-[calc(var(--header-height)+var(--notification-height,0px))] !h-[calc(100svh-var(--header-height)-var(--notification-height,0px))]"
       {...sidebarProps}
     >
@@ -46,6 +48,7 @@ export default function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarFooter>
+      <SidebarRail />
     </Sidebar>
   );
 }

--- a/packages/ui/src/components/AppTopBar/index.tsx
+++ b/packages/ui/src/components/AppTopBar/index.tsx
@@ -5,10 +5,11 @@ import { PocketBrandLogo } from "../PocketBrandLogo";
 
 export interface AppTopBarProps {
   logoIcon?: ComponentType;
+  leading?: React.ReactNode;
   children?: React.ReactNode;
 }
 
-export async function AppTopBar({ logoIcon: LogoIcon, children } : Readonly<AppTopBarProps>) {
+export async function AppTopBar({ logoIcon: LogoIcon, leading, children } : Readonly<AppTopBarProps>) {
 
   return (
     <header
@@ -21,7 +22,8 @@ export async function AppTopBar({ logoIcon: LogoIcon, children } : Readonly<AppT
           "h-(--header-height) w-full flex items-center justify-between"
         }
       >
-        <div>
+        <div className="flex items-center gap-2">
+          { leading }
           { LogoIcon ? <LogoIcon /> : <PocketBrandLogo /> }
         </div>
         <div className="w-full md:w-auto flex flex-row items-center gap-3 justify-end">

--- a/packages/ui/src/components/DataTable/index.tsx
+++ b/packages/ui/src/components/DataTable/index.tsx
@@ -115,6 +115,8 @@ export interface DataTableProps<TData extends object, TValue> {
   enableRowSelection?: boolean
   /** Derive a stable string key from a row; passed to tanstack getRowId. */
   getRowId?: (row: TData) => string
+  /** Lock the header row so it stays visible while the table body scrolls. On by default. */
+  stickyHeader?: boolean
   /** Called whenever the selection changes; receives the selected row originals. */
   onSelectionChange?: (selectedRows: TData[]) => void
 }
@@ -143,6 +145,7 @@ export default function DataTable<TData extends object, TValue>({
   enableRowSelection,
   getRowId,
   onSelectionChange,
+  stickyHeader = true,
 }: DataTableProps<TData, TValue>) {
   const isServerPaginated = !!manualPagination
   const defaultSort = sorts.flat().find((sort) => sort.isDefault);
@@ -427,6 +430,12 @@ export default function DataTable<TData extends object, TValue>({
                           "text-text-tertiary uppercase text-xs font-semibold tracking-wide px-4",
                           align === 'center' && 'text-center',
                           align === 'right' && 'text-right',
+                          // Locks the header to the top of the (already scrollable)
+                          // table container. Needs an opaque bg (the page/table
+                          // root color) so scrolled rows don't bleed through, plus
+                          // a bottom border since the header row's own divider
+                          // scrolls away with the body.
+                          stickyHeader && 'sticky top-0 z-10 bg-(--bg-root) border-b border-border-primary',
                         )
                       }
                     >
@@ -434,7 +443,7 @@ export default function DataTable<TData extends object, TValue>({
                     </TableHead>
                   )
                 })}
-                {itemActions && <TableHead />}
+                {itemActions && <TableHead className={clsx(stickyHeader && 'sticky top-0 z-10 bg-(--bg-root) border-b border-border-primary')} />}
               </TableRow>
             ))}
           </TableHeader>

--- a/packages/ui/src/components/FailureReasonPopover.tsx
+++ b/packages/ui/src/components/FailureReasonPopover.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import * as React from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from '@igniter/ui/components/popover'
+import { PayloadBlock } from '@igniter/ui/components/PayloadBlock'
+import { cn } from '@igniter/ui/lib/utils'
+
+export type FailureReasonPopoverProps = {
+  /** Short, human-readable reason shown in the cell (already computed by the caller). */
+  friendly: string
+  /** Full raw chain error, shown expanded + copyable in the popover. '' when none. */
+  full: string
+  /** On-chain error code, shown in the popover footer. */
+  code?: number | null
+  /** Extra classes for the trigger (e.g. truncate width). */
+  className?: string
+}
+
+/**
+ * Failure-reason table cell: shows the short friendly reason and, when there is
+ * more to show (a full raw log and/or a code), an expand affordance that opens a
+ * popover with the full copyable error — no navigation to the detail panel needed.
+ * Generic on purpose (no @igniter/commons dependency): the caller maps the reason.
+ */
+export function FailureReasonPopover({ friendly, full, code, className }: FailureReasonPopoverProps) {
+  const expandable = Boolean(full) || code != null
+
+  // Nothing beyond the friendly text to reveal — render plain, no popover.
+  if (!expandable) {
+    return (
+      <span className={cn('block max-w-[16rem] truncate text-red-400', className)} title={friendly}>
+        {friendly}
+      </span>
+    )
+  }
+
+  // Show the friendly headline in the popover only when it adds detail beyond the raw text.
+  const showHeadline = Boolean(full) && friendly !== full
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          // Keep the click on the cell (don't trigger any row-level open).
+          onClick={(e) => e.stopPropagation()}
+          title="Click to view the full error"
+          className={cn(
+            'flex max-w-[16rem] items-center gap-1 text-left text-red-400 hover:underline',
+            className,
+          )}
+        >
+          <span className="truncate">{friendly}</span>
+          <svg viewBox="0 0 16 16" aria-hidden="true" className="h-3 w-3 shrink-0 opacity-70">
+            <path
+              fill="currentColor"
+              d="M9 2h5v5h-1.5V4.56L8.56 8.5 7.5 7.44 11.44 3.5H9V2zM2 9h1.5v2.44L7.44 7.5 8.5 8.56 4.56 12.5H7V14H2V9z"
+            />
+          </svg>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="flex w-[380px] max-w-[90vw] flex-col gap-2 p-3">
+        {showHeadline && <p className="text-sm text-red-400">{friendly}</p>}
+        {full ? (
+          <PayloadBlock label="Full message" text={full} variant="error" defaultExpanded />
+        ) : (
+          !showHeadline && <p className="text-sm text-red-400">{friendly}</p>
+        )}
+        {code != null && <p className="font-mono text-xs text-text-tertiary">Code: {code}</p>}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/ui/src/components/NotificationChannels/NotificationHistory.tsx
+++ b/packages/ui/src/components/NotificationChannels/NotificationHistory.tsx
@@ -5,6 +5,13 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import DataTable from '../DataTable/index'
 import { Button } from '../button'
 import { Input } from '../input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../select'
 import { RightArrowIcon } from '../../assets'
 import type { ColumnDef } from '../table'
 import type { CsvColumnDef } from '../../lib/csv'
@@ -33,18 +40,37 @@ export interface NotificationHistoryEvent {
   viewedAt: Date | string | null
 }
 
+/** A selectable value for one of the filter dropdowns. */
+export interface NotificationFilterOption {
+  value: string
+  label: string
+}
+
+/** Server-side filter selection sent to `listEvents`. Absent field = unconstrained. */
+export interface NotificationHistoryFilters {
+  search?: string
+  type?: string
+  read?: 'read' | 'unread'
+  channel?: string
+}
+
 export interface NotificationHistoryProps {
   /**
    * App-specific, wallet/owner-scoped fetch returning a page + total count.
    * `unviewedTotal` is the server-side count of ALL unread events (not just this
    * page) so the badge and the mark-all control reflect the true unread total
    * rather than however many unread rows happen to land on the current page.
+   * `filters` carries the active dropdown/search selection (all optional).
    */
   listEvents: (
     page: number,
     pageSize: number,
-    search?: string,
+    filters?: NotificationHistoryFilters,
   ) => Promise<{ data: NotificationHistoryEvent[]; total: number; unviewedTotal?: number }>
+  /** When set, renders an event-type filter dropdown (each app's own vocabulary). */
+  eventTypeOptions?: NotificationFilterOption[]
+  /** When set, renders a channel filter dropdown (e.g. Discord/Telegram/Email). */
+  channelOptions?: NotificationFilterOption[]
   /** Marks every unread event viewed (app-scoped). */
   markAllViewed: () => Promise<void>
   /** Human label for an event type (vocabularies differ per app). */
@@ -83,6 +109,8 @@ function formatDate(date: Date | string) {
  */
 export function NotificationHistory({
   listEvents,
+  eventTypeOptions,
+  channelOptions,
   markAllViewed,
   labelFor,
   summaryFor,
@@ -97,11 +125,27 @@ export function NotificationHistory({
   const [pageIndex, setPageIndex] = useState(0)
   const [pageSize, setPageSize] = useState(initialPageSize)
   const [search, setSearch] = useState('')
+  const [typeFilter, setTypeFilter] = useState('')
+  const [readFilter, setReadFilter] = useState<'' | 'read' | 'unread'>('')
+  const [channelFilter, setChannelFilter] = useState('')
   const [isMarkingAll, setIsMarkingAll] = useState(false)
 
+  // Any filter change resets to page 0 so the user isn't stranded on a page
+  // that no longer exists under the narrower result set.
+  const onFilterChange = (apply: () => void) => {
+    apply()
+    setPageIndex(0)
+  }
+
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: [queryKey, pageIndex, pageSize, search],
-    queryFn: () => listEvents(pageIndex, pageSize, search || undefined),
+    queryKey: [queryKey, pageIndex, pageSize, search, typeFilter, readFilter, channelFilter],
+    queryFn: () =>
+      listEvents(pageIndex, pageSize, {
+        search: search || undefined,
+        type: typeFilter || undefined,
+        read: readFilter || undefined,
+        channel: channelFilter || undefined,
+      }),
   })
 
   const handleMarkAll = async () => {
@@ -180,35 +224,81 @@ export function NotificationHistory({
 
   return (
     <div className="flex flex-col gap-3">
-      {(enableSearch || unviewedCount > 0) && (
-        <div className="flex items-center gap-3">
-          {enableSearch && (
-            <Input
-              placeholder="Search by UUID…"
-              value={search}
-              onChange={(e) => {
-                setSearch(e.target.value)
-                setPageIndex(0)
-              }}
-              className="max-w-xs"
-            />
-          )}
-          {unviewedCount > 0 && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="text-xs shrink-0"
-              disabled={isMarkingAll}
-              onClick={handleMarkAll}
-            >
-              Mark all as read
-              <span className="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full bg-yellow-400 text-black text-[10px] font-bold">
-                {unviewedCount}
-              </span>
-            </Button>
-          )}
-        </div>
-      )}
+      <div className="flex flex-wrap items-center gap-2">
+        {enableSearch && (
+          <Input
+            placeholder="Search by UUID…"
+            value={search}
+            onChange={(e) => onFilterChange(() => setSearch(e.target.value))}
+            className="max-w-xs"
+          />
+        )}
+        {eventTypeOptions && eventTypeOptions.length > 0 && (
+          <Select
+            value={typeFilter || 'all'}
+            onValueChange={(v) => onFilterChange(() => setTypeFilter(v === 'all' ? '' : v))}
+          >
+            <SelectTrigger className="w-[170px]">
+              <SelectValue placeholder="All events" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All events</SelectItem>
+              {eventTypeOptions.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        <Select
+          value={readFilter || 'all'}
+          onValueChange={(v) =>
+            onFilterChange(() => setReadFilter(v === 'all' ? '' : (v as 'read' | 'unread')))
+          }
+        >
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="unread">Unread</SelectItem>
+            <SelectItem value="read">Read</SelectItem>
+          </SelectContent>
+        </Select>
+        {channelOptions && channelOptions.length > 0 && (
+          <Select
+            value={channelFilter || 'all'}
+            onValueChange={(v) => onFilterChange(() => setChannelFilter(v === 'all' ? '' : v))}
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue placeholder="All channels" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All channels</SelectItem>
+              {channelOptions.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {unviewedCount > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-xs shrink-0 ml-auto"
+            disabled={isMarkingAll}
+            onClick={handleMarkAll}
+          >
+            Mark all as read
+            <span className="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full bg-yellow-400 text-black text-[10px] font-bold">
+              {unviewedCount}
+            </span>
+          </Button>
+        )}
+      </div>
 
       <DataTable
         isLoading={isLoading}

--- a/packages/ui/src/components/workflows/SchedulesTab.tsx
+++ b/packages/ui/src/components/workflows/SchedulesTab.tsx
@@ -105,8 +105,8 @@ export function SchedulesTab({
           Resume failed for <span className="font-mono">{resumeError.scheduleId}</span>: {resumeError.message}
         </p>
       )}
-      <Table>
-        <TableHeader>
+      <Table containerClassName="max-h-[60vh]">
+        <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-(--bg-root) [&_th]:border-b [&_th]:border-border-primary">
           <TableRow>
             <TableHead />
             <TableHead>Schedule</TableHead>

--- a/packages/ui/src/components/workflows/WorkflowDetailClient.tsx
+++ b/packages/ui/src/components/workflows/WorkflowDetailClient.tsx
@@ -276,8 +276,8 @@ export function WorkflowDetailClient({
               <h2 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
                 Child workflows ({detail.children.length})
               </h2>
-              <Table>
-                <TableHeader>
+              <Table containerClassName="max-h-[60vh]">
+                <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-(--bg-root) [&_th]:border-b [&_th]:border-border-primary">
                   <TableRow>
                     <TableHead>Workflow ID</TableHead>
                     <TableHead>Type</TableHead>
@@ -456,8 +456,8 @@ function ActivitiesTable({
     return <p className="text-xs text-text-tertiary">No activities recorded.</p>
   }
   return (
-    <Table>
-      <TableHeader>
+    <Table containerClassName="max-h-[60vh]">
+      <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-(--bg-root) [&_th]:border-b [&_th]:border-border-primary">
         <TableRow>
           <TableHead className="w-8" />
           <TableHead>#</TableHead>


### PR DESCRIPTION
Lock table headers while scrolling in both apps: DataTable opts in by default, and the hand-rolled tables (activity, chain overview, provider breakdown, workflows) get bounded scroll boxes. #317

Consolidate multi-table screens into tabs: middleman Suppliers (Suppliers/Activity/Overview) and provider Keys (Keys/Activity), with the active tab persisted in the URL. #317

Surface the failure reason on failed transactions in both apps’ tables, reading the log/message columns through a shared failureReasonDisplay helper. #317

Add server-side filtering to notification history (event type, read/unread, channel) in both apps; the unread badge count stays unfiltered. #317

Make the left sidebar collapsible to an icon rail with a header toggle, hidden on the landing/auth pages. #317

Add unit tests for the notification filter conditions (both apps) and the shared failure-reason helper. #317