### PR TITLE
fix: keep expected supplier endpoints aligned with overrides

### DIFF
--- a/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.test.ts
+++ b/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.test.ts
@@ -70,7 +70,6 @@ describe('BuildSupplierServiceConfigHandler', () => {
         mockedGetRevShare.mockReturnValue([
             { address: operatorAddress, revSharePercentage: 30 },
         ]);
-
         mockedGetEpUrl.mockReturnValue('https://interpolated');
     });
 
@@ -111,6 +110,34 @@ describe('BuildSupplierServiceConfigHandler', () => {
             input.services[0]?.endpoints[0],
             interpolationParams,
         );
+    });
+
+    it.each([
+        ['4', 'https://numeric-override.example.com'],
+        ['REST', 'https://legacy-override.example.com'],
+    ])('applies endpoint override key %s for string rpc types', (overrideKey, overrideUrl) => {
+        const overrideInput = {
+            ...input,
+            addressGroup: {
+                ...input.addressGroup,
+                addressGroupServices: [
+                    {
+                        ...addressGroupServiceConfig,
+                        endpointOverrides: {
+                            [overrideKey]: overrideUrl,
+                        },
+                    },
+                ],
+            },
+        } as BuildSupplierServiceConfigInput;
+
+        const result = handler.execute(overrideInput);
+
+        expect(result[0]?.endpoints[0]).toMatchObject({
+            url: overrideUrl,
+            rpcType: 4,
+            configs: [],
+        });
     });
 
     it('leaves the client (owner) with 0% when supplier share + rev shares total 100% (kleomedes/Marco case)', () => {

--- a/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.ts
+++ b/packages/domain/src/provider/operations/suppliers/BuildSupplierServiceConfig/BuildSupplierServiceConfigHandler.ts
@@ -1,8 +1,13 @@
 import {BuildSupplierServiceConfigInput} from '@igniter/domain/provider/operations';
-import {getRevShare, getEndpointInterpolatedUrl, deduplicateRevShare} from "@igniter/domain/provider/utils";
+import {
+    getRevShare,
+    getEndpointInterpolatedUrl,
+    deduplicateRevShare,
+    getEndpointOverride,
+    normalizeRpcType,
+} from "@igniter/domain/provider/utils";
 import {SupplierServiceConfig} from "@igniter/pocket/proto/pocket/shared/service";
 import {RevenueShareOverflowError} from "@igniter/domain/provider/errors";
-import {RPCTypeMap} from '@igniter/pocket';
 
 export class BuildSupplierServiceConfigHandler {
     execute(input: BuildSupplierServiceConfigInput) : SupplierServiceConfig[] {
@@ -41,8 +46,8 @@ export class BuildSupplierServiceConfigHandler {
                 serviceId: cfg.serviceId,
                 revShare: deduplicatedRevShare,
                 endpoints: svc.endpoints.map((ep) => {
-                    const rpcKey = String(ep.rpcType);
-                    const overrideUrl = overrides[rpcKey];
+                    const rpcType = normalizeRpcType(ep.rpcType);
+                    const overrideUrl = getEndpointOverride(overrides, ep.rpcType);
 
                     return {
                         url: overrideUrl || getEndpointInterpolatedUrl(ep, {
@@ -51,7 +56,7 @@ export class BuildSupplierServiceConfigHandler {
                             region: addressGroup.relayMiner.region.urlValue,
                             domain: addressGroup.relayMiner.domain,
                         }),
-                        rpcType: RPCTypeMap[ep.rpcType] ?? -1,
+                        rpcType,
                         configs: [],
                     };
                 }),

--- a/packages/domain/src/provider/utils/endpointOverrides.test.ts
+++ b/packages/domain/src/provider/utils/endpointOverrides.test.ts
@@ -1,0 +1,92 @@
+import {RPCType} from '@igniter/pocket/proto/pocket/shared/service';
+import {
+  getEndpointOverride,
+  getExpectedServicesFromKey,
+  normalizeRpcType,
+} from './suppliers';
+
+describe('endpoint override compatibility', () => {
+  it.each([
+    [RPCType.REST, RPCType.REST],
+    ['4', RPCType.REST],
+    ['REST', RPCType.REST],
+    ['JSON_RPC', RPCType.JSON_RPC],
+  ])('normalizes rpc type %s', (input, expected) => {
+    expect(normalizeRpcType(input)).toBe(expected);
+  });
+
+  it('prefers the raw legacy key when both formats exist', () => {
+    expect(
+      getEndpointOverride(
+        {
+          REST: 'https://legacy.example.com',
+          '4': 'https://numeric.example.com',
+        },
+        'REST',
+      ),
+    ).toBe('https://legacy.example.com');
+  });
+
+  it('falls back to the normalized numeric key', () => {
+    expect(
+      getEndpointOverride(
+        {'4': 'https://numeric.example.com'},
+        'REST',
+      ),
+    ).toBe('https://numeric.example.com');
+  });
+
+  const makeKey = (endpointOverrides?: Record<string, string>) => ({
+    address: 'pokt1supplier',
+    ownerAddress: 'pokt1owner',
+    delegatorRewardsAddress: null,
+    delegatorRevSharePercentage: null,
+    addressGroup: {
+      relayMiner: {
+        identity: 'rm1',
+        domain: 'example.com',
+        region: {urlValue: 'us'},
+      },
+      addressGroupServices: [
+        {
+          serviceId: 'svc1',
+          addSupplierShare: false,
+          supplierShare: 0,
+          revShare: [],
+          endpointOverrides,
+          service: {
+            endpoints: [
+              {
+                rpcType: 'REST',
+                url: 'https://{protocol}.example.com',
+              },
+            ],
+          },
+        },
+      ],
+    },
+  }) as any;
+
+  it.each([
+    [{'4': 'https://numeric.example.com'}, 'https://numeric.example.com'],
+    [{REST: 'https://legacy.example.com'}, 'https://legacy.example.com'],
+  ])('applies endpoint overrides from either key format', (overrides, expectedUrl) => {
+    const [service] = getExpectedServicesFromKey(makeKey(overrides));
+
+    expect(service?.endpoints[0]).toEqual({
+      url: expectedUrl,
+      rpcType: RPCType.REST,
+      configs: [],
+    });
+  });
+
+  it('keeps existing protocol interpolation while normalizing emitted rpcType', () => {
+    const [service] = getExpectedServicesFromKey(makeKey());
+
+    expect(service?.endpoints[0]).toEqual({
+      url: 'https://json.example.com',
+      rpcType: RPCType.REST,
+      configs: [],
+    });
+  });
+});

--- a/packages/domain/src/provider/utils/endpointOverrides.test.ts
+++ b/packages/domain/src/provider/utils/endpointOverrides.test.ts
@@ -36,6 +36,10 @@ describe('endpoint override compatibility', () => {
     ).toBe('https://numeric.example.com');
   });
 
+  it('returns undefined when no override key matches', () => {
+    expect(getEndpointOverride({'3': 'https://json.example.com'}, 'REST')).toBeUndefined();
+  });
+
   const makeKey = (endpointOverrides?: Record<string, string>) => ({
     address: 'pokt1supplier',
     ownerAddress: 'pokt1owner',

--- a/packages/domain/src/provider/utils/suppliers.ts
+++ b/packages/domain/src/provider/utils/suppliers.ts
@@ -6,6 +6,28 @@ import {KeyWithGroup} from "@igniter/db/provider/schema";
 import {RPCTypeMap} from '@igniter/pocket/constants';
 import {deduplicateRevShare} from "./services";
 
+export function normalizeRpcType(rpcType: RPCType | string | undefined): RPCType {
+  if (typeof rpcType === 'string') {
+    return RPCTypeMap[rpcType as keyof typeof RPCTypeMap] ?? RPCType.UNRECOGNIZED;
+  }
+
+  return rpcType ?? RPCType.UNRECOGNIZED;
+}
+
+export function getEndpointOverride(
+  endpointOverrides: Record<string, string> | null | undefined,
+  rpcType: RPCType | string | undefined,
+): string | undefined {
+  if (!endpointOverrides) {
+    return undefined;
+  }
+
+  const rawKey = String(rpcType);
+  const normalizedKey = String(normalizeRpcType(rpcType));
+
+  return endpointOverrides[rawKey] ?? endpointOverrides[normalizedKey];
+}
+
 export function getSchemeForRpcType(rpcType: RPCType) {
     switch (rpcType) {
         case RPCType.JSON_RPC:
@@ -166,19 +188,24 @@ export function getExpectedServicesFromKey(key: KeyWithGroup): Array<SupplierSer
     const newExpectedService: SupplierServiceConfig = {
       serviceId: addressGroupService.serviceId,
       revShare: deduplicateRevShare(filteredRevShare),
-      endpoints: addressGroupService.service.endpoints?.map((endpoint) => ({
-        url: getEndpointInterpolatedUrl(endpoint, {
-          sid: addressGroupService.serviceId,
-          rm: key.addressGroup?.relayMiner?.identity || '',
-          region: key.addressGroup?.relayMiner?.region?.urlValue || '',
-          domain: key.addressGroup?.relayMiner?.domain || '',
-        }),
-        // Normalize rpcType to numeric to match BuildSupplierServiceConfigHandler
-        rpcType: typeof endpoint.rpcType === 'string'
-          ? (RPCTypeMap[endpoint.rpcType as keyof typeof RPCTypeMap] ?? -1)
-          : endpoint.rpcType,
-        configs: []
-      })),
+      endpoints: addressGroupService.service.endpoints?.map((endpoint) => {
+        const rpcType = normalizeRpcType(endpoint.rpcType);
+        const overrideUrl = getEndpointOverride(
+          addressGroupService.endpointOverrides,
+          endpoint.rpcType,
+        );
+
+        return {
+          url: overrideUrl || getEndpointInterpolatedUrl(endpoint, {
+            sid: addressGroupService.serviceId,
+            rm: key.addressGroup?.relayMiner?.identity || '',
+            region: key.addressGroup?.relayMiner?.region?.urlValue || '',
+            domain: key.addressGroup?.relayMiner?.domain || '',
+          }),
+          rpcType,
+          configs: [],
+        };
+      }),
     }
 
     expectedServices.push(newExpectedService)


### PR DESCRIPTION
## Summary

The provider can repeatedly trigger ServiceMismatch remediation even when the supplier is correctly configured on-chain. The expected-service calculator ignored address-group endpointOverrides, while BuildSupplierServiceConfigHandler applied them when constructing the remediation stake transaction.

This change:

- Applies endpointOverrides when calculating expected supplier services.
- Adds shared RPC type normalization for numeric values, numeric strings, and enum names such as REST and JSON_RPC.
- Supports both legacy override keys such as `"REST"` and normalized numeric keys such as `"4"` in both validation and stake construction.
- Preserves the original endpoint value during `{protocol}` interpolation, avoiding unintended hostname changes and automatic restakes.
- Adds regression tests for both override-key formats and for the existing string-RPC interpolation behavior.

This keeps validation and remediation aligned without migrating existing endpoint hostnames or stored overrides.

## Validation

GitHub Actions CI run #151 passed:

- Branch gate
- PR title validation
- Format check
- Lint
- Build
- Type check
- Tests
- No-console guard
- Docker builds for provider, provider-workflows, middleman, and middleman-workflows