### PR TITLE
feat(provider): add CometBFT RPC type for service endpoints (#328)

### DIFF
--- a/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
+++ b/apps/provider/src/components/AddOrUpdateServiceDialog.tsx
@@ -54,6 +54,7 @@ const validRpcTypes = [
   validRpcTypesEnums[1].toString(),
   validRpcTypesEnums[2].toString(),
   validRpcTypesEnums[3].toString(),
+  validRpcTypesEnums[4].toString(),
 ] as const;
 
 const RPCTypeSchema = z.enum(validRpcTypes).default(PROTOCOL_DEFAULT_TYPE).transform(v => Number(v));

--- a/apps/provider/src/lib/constants.ts
+++ b/apps/provider/src/lib/constants.ts
@@ -42,6 +42,7 @@ export const labelByRpcType: Record<string, string> = {
   [RPCType.GRPC]: "GRPC",
   [RPCType.WEBSOCKET]: "WEBSOCKET",
   [RPCType.REST]: "REST",
+  [RPCType.COMET_BFT]: "COMET_BFT",
 }
 
 export const validRpcTypes = [
@@ -49,4 +50,5 @@ export const validRpcTypes = [
   RPCType.GRPC,
   RPCType.WEBSOCKET,
   RPCType.REST,
+  RPCType.COMET_BFT,
 ] as const;

--- a/packages/domain/src/provider/utils/suppliers.test.ts
+++ b/packages/domain/src/provider/utils/suppliers.test.ts
@@ -37,6 +37,10 @@ describe('getSchemeForRpcType', () => {
     expect(getSchemeForRpcType(RPCType.WEBSOCKET)).toBe('wss');
   });
 
+  it('returns https for COMET_BFT', () => {
+    expect(getSchemeForRpcType(RPCType.COMET_BFT)).toBe('https');
+  });
+
   it('falls back to https for unknown RPC types', () => {
     expect(getSchemeForRpcType(RPCType.UNKNOWN_RPC)).toBe('https');
     expect(getSchemeForRpcType(RPCType.UNRECOGNIZED)).toBe('https');
@@ -59,6 +63,10 @@ describe('getUrlTokenFromRpcType', () => {
 
   it('returns ws for WEBSOCKET', () => {
     expect(getUrlTokenFromRpcType(RPCType.WEBSOCKET)).toBe('ws');
+  });
+
+  it('returns cometbft for COMET_BFT', () => {
+    expect(getUrlTokenFromRpcType(RPCType.COMET_BFT)).toBe('cometbft');
   });
 
   it('falls back to json for unknown RPC types', () => {

--- a/packages/domain/src/provider/utils/suppliers.ts
+++ b/packages/domain/src/provider/utils/suppliers.ts
@@ -10,6 +10,7 @@ export function getSchemeForRpcType(rpcType: RPCType) {
     switch (rpcType) {
         case RPCType.JSON_RPC:
         case RPCType.REST:
+        case RPCType.COMET_BFT:
             return 'https';
         case RPCType.GRPC:
             return 'grpcs';
@@ -30,6 +31,8 @@ export function getUrlTokenFromRpcType(rpcType: RPCType) {
             return 'grpc';
         case RPCType.WEBSOCKET:
             return 'ws';
+        case RPCType.COMET_BFT:
+            return 'cometbft';
         default:
             return 'json';
     }


### PR DESCRIPTION
The chain already defines RPCType.COMET_BFT = 5 but the app layer whitelisted only the four original types, so operators could not configure CometBFT endpoints for their services.

- add COMET_BFT to labelByRpcType and validRpcTypes (cascades to server-side validation, dialogs, and table chips)

- extend the endpoint zod enum in AddOrUpdateServiceDialog to the fifth type; the Add Protocol cap follows validRpcTypes.length

- map COMET_BFT to scheme "https" and URL token "cometbft" so the default endpoint hostname no longer collides with JSON_RPC

- unit tests for both switch functions