### PR TITLE
fix: stop transient RPC errors from wedging the tx verifier

### DIFF
--- a/apps/middleman-workflows/src/workflows/ExecutePendingTransactions.ts
+++ b/apps/middleman-workflows/src/workflows/ExecutePendingTransactions.ts
@@ -1,6 +1,6 @@
 import {proxyActivities, WorkflowIdReusePolicy, ParentClosePolicy} from "@temporalio/workflow";
 import { delegatorActivities } from '@/activities';
-import {executeChild, log, WorkflowError} from "@temporalio/workflow";
+import {executeChild, log, ApplicationFailure} from "@temporalio/workflow";
 
 // @ts-expect-error p-limit is ESM-only; its default export has no CJS types under this build's module resolution
 import pLimit from 'p-limit'
@@ -65,6 +65,6 @@ export async function ExecutePendingTransactions(args: ExecutePendingTransaction
   const allFailed =
     results.length > 0 && results.every((r) => r.status === "rejected");
   if (allFailed) {
-    throw new WorkflowError("ExecutePendingTransactions: all child workflows failed");
+    throw new ApplicationFailure("ExecutePendingTransactions: all child workflows failed", "fatal_error", true);
   }
 }

--- a/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
+++ b/apps/middleman-workflows/src/workflows/ExecuteTransaction.ts
@@ -1,7 +1,7 @@
 import {
   log,
   proxyActivities,
-  WorkflowError,
+  ApplicationFailure,
 } from '@temporalio/workflow'
 import { delegatorActivities } from "@/activities";
 import { TransactionStatus, TransactionType } from '@igniter/db/middleman/enums'
@@ -66,7 +66,7 @@ export async function ExecuteTransaction(args: TransactionArgs) {
 
   const result = await executeTransaction(transaction.id);
   if (!result) {
-    throw new WorkflowError("Transaction execution failed");
+    throw new ApplicationFailure("Transaction execution failed", "fatal_error", true);
   }
 
   if (!result.transactionHash) {

--- a/apps/middleman-workflows/src/workflows/SupplierStatus.ts
+++ b/apps/middleman-workflows/src/workflows/SupplierStatus.ts
@@ -2,7 +2,7 @@ import * as wf from '@temporalio/workflow'
 import {
   log,
   proxyActivities,
-  WorkflowError,
+  ApplicationFailure,
 } from '@temporalio/workflow'
 import {
   delegatorActivities,
@@ -101,7 +101,7 @@ export async function SupplierStatus(): Promise<{ height: number, minId: number,
   const r = await Promise.allSettled(childPromises)
   const allFailed = r.every(r => r.status === 'rejected')
   if (allFailed) {
-    throw new WorkflowError('All activities failed')
+    throw new ApplicationFailure('SupplierStatus: all child ranges failed', 'fatal_error', true)
   }
 
   log.debug('Completed SupplierStatus', { height, minId, maxId })

--- a/apps/middleman-workflows/src/workflows/SupplierStatusRange.ts
+++ b/apps/middleman-workflows/src/workflows/SupplierStatusRange.ts
@@ -1,7 +1,7 @@
 import {
   log,
   proxyActivities,
-  WorkflowError,
+  ApplicationFailure,
 } from '@temporalio/workflow'
 import {
   delegatorActivities,
@@ -70,7 +70,7 @@ export async function SupplierStatusByRange(input: SupplierStatusByRange): Promi
     return r.status === 'rejected'
   });
   if (allFailed) {
-    throw new WorkflowError('All activities failed');
+    throw new ApplicationFailure('SupplierStatusByRange: all activities failed', 'fatal_error', true);
   }
 
   const upserted = r.filter(r => r.status === 'fulfilled').length

--- a/apps/middleman-workflows/src/workflows/VerifyPendingTransactions.ts
+++ b/apps/middleman-workflows/src/workflows/VerifyPendingTransactions.ts
@@ -1,4 +1,4 @@
-import { proxyActivities, log, WorkflowError } from '@temporalio/workflow'
+import { proxyActivities, log, ApplicationFailure } from '@temporalio/workflow'
 import { delegatorActivities } from '@/activities'
 import { decideVerification, TX_EXPIRATION_BLOCKS } from '@igniter/tx-verify'
 
@@ -23,7 +23,17 @@ export async function VerifyPendingTransactions() {
     applyVerificationDecision,
   } = proxyActivities<ReturnType<typeof delegatorActivities>>({
     startToCloseTimeout: '120s',
-    retry: { maximumAttempts: 3 },
+    // The default 3 attempts at a 1s base exhaust in ~4s — shorter than a single
+    // block (~60s on mainnet), so any RPC hiccup tied to the chain's own cadence
+    // (a node at a commit boundary, a backend a block behind) burns every attempt
+    // inside one block and reports a permanent failure for a transient condition.
+    // Span more than one block instead.
+    retry: {
+      initialInterval: '5s',
+      backoffCoefficient: 2,
+      maximumInterval: '30s',
+      maximumAttempts: 5,
+    },
   })
 
   const txs = await listPendingWithHash()
@@ -59,15 +69,26 @@ export async function VerifyPendingTransactions() {
     ),
   )
 
-  for (const r of results) {
-    if (r.status === 'rejected') {
-      log.warn('VerifyPendingTransactions: tx verification failed', { reason: String(r.reason) })
-    }
+  const failedReasons = results
+    .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+    .map((r) => String(r.reason))
+  for (const reason of failedReasons) {
+    log.warn('VerifyPendingTransactions: tx verification failed', { reason })
   }
 
   // Match the SupplierStatus pattern: tolerate partial failure, but surface a
-  // systemic one (all failed → RPC/DB down) instead of completing green.
-  if (results.length > 0 && results.every((r) => r.status === 'rejected')) {
-    throw new WorkflowError('VerifyPendingTransactions: all transactions failed')
+  // systemic one (all failed → RPC/DB down) instead of completing green. It MUST
+  // be an ApplicationFailure: `WorkflowError` is a plain Error subclass (not a
+  // TemporalFailure), so throwing it fails the workflow TASK instead of the
+  // workflow, and the task then retries forever — under ScheduleOverlapPolicy.SKIP
+  // that wedges the whole schedule (mainnet, 2026-08-10: 3 days without a sweep).
+  // A failed execution lets the next scheduled sweep run fresh.
+  if (results.length > 0 && failedReasons.length === results.length) {
+    throw new ApplicationFailure(
+      'VerifyPendingTransactions: all transactions failed',
+      'fatal_error',
+      true,
+      [failedReasons],
+    )
   }
 }

--- a/apps/middleman-workflows/src/workflows/VerifyPendingTransactions.ts
+++ b/apps/middleman-workflows/src/workflows/VerifyPendingTransactions.ts
@@ -88,7 +88,10 @@ export async function VerifyPendingTransactions() {
       'VerifyPendingTransactions: all transactions failed',
       'fatal_error',
       true,
-      [failedReasons],
+      // Capped: the realistic trigger for a big backlog is the aftermath of a
+      // stall, and an oversized details payload would fail the workflow task that
+      // reports the failure — the exact wedge this file exists to prevent.
+      [failedReasons.slice(0, 20)],
     )
   }
 }

--- a/apps/middleman-workflows/src/workflows/noWorkflowError.test.ts
+++ b/apps/middleman-workflows/src/workflows/noWorkflowError.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Structural guard, not a behavioural test.
+ *
+ * `WorkflowError` is exported by @temporalio/workflow and constructs fine, which
+ * is what makes it a trap: it extends plain `Error`, NOT `TemporalFailure`. The
+ * SDK fails the whole workflow only for TemporalFailure subclasses; anything else
+ * fails the workflow TASK, which then retries forever. A scheduled workflow stuck
+ * that way keeps `runningActions` non-empty, so ScheduleOverlapPolicy.SKIP skips
+ * every later fire and the schedule silently stops doing its job — mainnet went
+ * 3 days without verifying a transaction this way on 2026-08-10.
+ *
+ * There is no workflow test harness in this repo (@temporalio/testing is not a
+ * dependency), so this greps the source instead of exercising the runtime. Throw
+ * `ApplicationFailure` to fail a workflow.
+ */
+describe('workflows never throw WorkflowError', () => {
+  const dirs = [
+    join(__dirname),
+    join(__dirname, '..', '..', '..', 'provider-workflows', 'src', 'workflows'),
+  ]
+
+  const files = dirs.flatMap((dir) => {
+    let entries: string[]
+    try {
+      entries = readdirSync(dir)
+    } catch {
+      return [] // sibling app not checked out in this context
+    }
+    return entries
+      .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+      .map((f) => join(dir, f))
+  })
+
+  it('finds workflow files to check', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it.each(files)('%s does not construct WorkflowError', (file) => {
+    const source = readFileSync(file, 'utf8')
+    expect(source).not.toMatch(/new\s+WorkflowError\s*\(/)
+  })
+})

--- a/apps/provider-workflows/src/workflows/ExecutePendingTransactions.ts
+++ b/apps/provider-workflows/src/workflows/ExecutePendingTransactions.ts
@@ -48,10 +48,11 @@ export async function ExecutePendingTransactions() {
     log.warn('ExecutePendingTransactions: child workflow failed', { reason })
   }
 
-  // Non-retryable ApplicationFailure (NOT WorkflowError — not exported by
-  // @temporalio/workflow; `new WorkflowError()` throws TypeError and wedges the
-  // workflow task forever under ScheduleOverlapPolicy.SKIP). A failed execution lets
-  // the next scheduled dispatch run fresh.
+  // Non-retryable ApplicationFailure (NOT WorkflowError — it IS exported and does
+  // construct, but it extends plain Error rather than TemporalFailure, so throwing
+  // it fails the workflow TASK instead of the workflow; the task then retries
+  // forever, wedging the schedule under ScheduleOverlapPolicy.SKIP). A failed
+  // execution lets the next scheduled dispatch run fresh.
   if (results.length > 0 && failedReasons.length === results.length) {
     throw new ApplicationFailure(
       'ExecutePendingTransactions: all child workflows failed',

--- a/apps/provider-workflows/src/workflows/SupplierStatus.ts
+++ b/apps/provider-workflows/src/workflows/SupplierStatus.ts
@@ -2,7 +2,6 @@ import * as wf from '@temporalio/workflow'
 import {
   log,
   proxyActivities,
-  WorkflowError,
 } from '@temporalio/workflow'
 import {
   providerActivities,

--- a/apps/provider-workflows/src/workflows/VerifyPendingTransactions.ts
+++ b/apps/provider-workflows/src/workflows/VerifyPendingTransactions.ts
@@ -22,7 +22,15 @@ export async function VerifyPendingTransactions() {
     applyVerificationDecision,
   } = proxyActivities<ReturnType<typeof providerActivities>>({
     startToCloseTimeout: '120s',
-    retry: { maximumAttempts: 3 },
+    // The default 3 attempts at a 1s base exhaust in ~4s — shorter than a single
+    // block (~60s on mainnet), so an RPC hiccup tied to the chain's own cadence
+    // burns every attempt inside one block. Span more than one block instead.
+    retry: {
+      initialInterval: '5s',
+      backoffCoefficient: 2,
+      maximumInterval: '30s',
+      maximumAttempts: 5,
+    },
   })
 
   const txs = await listPendingWithHash()
@@ -71,10 +79,12 @@ export async function VerifyPendingTransactions() {
 
   // Match the SupplierStatus pattern: tolerate partial failure, but surface a
   // systemic one (all failed → RPC/DB down) instead of completing green. Use a
-  // non-retryable ApplicationFailure (NOT WorkflowError — which is not exported by
-  // @temporalio/workflow; `new WorkflowError()` throws TypeError, wedging the
-  // workflow task forever under ScheduleOverlapPolicy.SKIP). A failed execution lets
-  // the next scheduled sweep run fresh.
+  // non-retryable ApplicationFailure (NOT WorkflowError — it IS exported and does
+  // construct, but it extends plain Error rather than TemporalFailure, so throwing
+  // it fails the workflow TASK instead of the workflow; the task then retries
+  // forever, wedging the schedule under ScheduleOverlapPolicy.SKIP — exactly what
+  // hit middleman on mainnet on 2026-08-10). A failed execution lets the next
+  // scheduled sweep run fresh.
   if (results.length > 0 && failedReasons.length === results.length) {
     throw new ApplicationFailure(
       'VerifyPendingTransactions: all transactions failed',

--- a/apps/provider-workflows/src/workflows/VerifyPendingTransactions.ts
+++ b/apps/provider-workflows/src/workflows/VerifyPendingTransactions.ts
@@ -90,7 +90,9 @@ export async function VerifyPendingTransactions() {
       'VerifyPendingTransactions: all transactions failed',
       'fatal_error',
       true,
-      [failedReasons],
+      // Capped: an oversized details payload would fail the workflow task that
+      // reports the failure — the exact wedge this guard exists to prevent.
+      [failedReasons.slice(0, 20)],
     )
   }
 }

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -501,7 +501,8 @@ export class PocketBlockchain {
    * Scans the already-fetched `block` at `height` for the tx whose SHA256 equals
    * `normalizedHash`. Returns the built TransactionResult on a hit, 'no-match' if
    * the hash is not in this block, or 'result-missing' if the hash matched but
-   * blockResults had no entry at the matched index.
+   * its result row could not be read — either blockResults had no entry at the
+   * matched index, or the blockResults call itself failed.
    */
   private async matchTxInBlock(
     comet: Awaited<ReturnType<typeof this.getCometClient>>,
@@ -515,7 +516,20 @@ export class PocketBlockchain {
       const bytes = txs[i]
       if (!bytes) continue
       if (toHex(sha256(bytes)).toUpperCase() === normalizedHash) {
-        const results = await comet.blockResults(height)
+        // The hash matched, so the block store already holds this height. Its ABCI
+        // responses may still be unreadable — a node that has just saved the block
+        // but not yet persisted its results answers "could not find results for
+        // height #N" (observed on mainnet at the commit boundary of a block). That
+        // is a transient read failure over a tx we KNOW is on-chain, so it must
+        // degrade to 'result-missing' -> unavailable, never escape as a throw and
+        // fail the caller's activity.
+        let results
+        try {
+          results = await comet.blockResults(height)
+        } catch (error) {
+          this.logger.warn('matchTxInBlock: blockResults failed for a matched tx', { txHash, height, error })
+          return 'result-missing'
+        }
         const txData = results.results[i]
         if (!txData) return 'result-missing'
         return { hash: txHash, height, index: i, gasUsed: txData.gasUsed, gasWanted: txData.gasWanted, success: txData.code === 0, code: txData.code, rawLog: txData.log }

--- a/packages/pocket/src/index.ts
+++ b/packages/pocket/src/index.ts
@@ -472,8 +472,13 @@ export class PocketBlockchain {
       // Hash matched in this block but its result row is missing — the tx IS
       // on-chain, we just can't read its outcome. That is NOT negative evidence;
       // treat as unavailable so the verifier keeps retrying instead of failing.
-      if (match === 'result-missing') {
-        this.logger.warn('verifyTransaction: matched tx has no block result entry', { txHash, height: h })
+      if (match === 'result-missing' || match === 'result-unreadable') {
+        this.logger.warn(
+          match === 'result-missing'
+            ? 'verifyTransaction: matched tx has no block result entry'
+            : 'verifyTransaction: matched tx result row could not be read',
+          { txHash, height: h },
+        )
         return { status: 'unavailable' }
       }
       return { status: 'confirmed', data: match }
@@ -500,9 +505,11 @@ export class PocketBlockchain {
   /**
    * Scans the already-fetched `block` at `height` for the tx whose SHA256 equals
    * `normalizedHash`. Returns the built TransactionResult on a hit, 'no-match' if
-   * the hash is not in this block, or 'result-missing' if the hash matched but
-   * its result row could not be read — either blockResults had no entry at the
-   * matched index, or the blockResults call itself failed.
+   * the hash is not in this block, 'result-missing' if blockResults had no entry
+   * at the matched index, or 'result-unreadable' if the blockResults call itself
+   * failed. The last two are kept apart so the logs say which one happened; both
+   * mean the same thing to the caller (the tx is on-chain, its outcome is not
+   * readable yet) and both map to `unavailable`.
    */
   private async matchTxInBlock(
     comet: Awaited<ReturnType<typeof this.getCometClient>>,
@@ -510,7 +517,7 @@ export class PocketBlockchain {
     height: number,
     normalizedHash: string,
     txHash: string,
-  ): Promise<TransactionResult | 'no-match' | 'result-missing'> {
+  ): Promise<TransactionResult | 'no-match' | 'result-missing' | 'result-unreadable'> {
     const txs = block.block.txs
     for (let i = 0; i < txs.length; i++) {
       const bytes = txs[i]
@@ -528,7 +535,7 @@ export class PocketBlockchain {
           results = await comet.blockResults(height)
         } catch (error) {
           this.logger.warn('matchTxInBlock: blockResults failed for a matched tx', { txHash, height, error })
-          return 'result-missing'
+          return 'result-unreadable'
         }
         const txData = results.results[i]
         if (!txData) return 'result-missing'
@@ -601,8 +608,13 @@ export class PocketBlockchain {
       if (!block) continue
       const match = await this.matchTxInBlock(comet, block, h, normalizedHash, txHash)
       if (match === 'no-match') continue
-      if (match === 'result-missing') {
-        this.logger.warn('Block results missing entry for matched TX', { txHash, height: h })
+      if (match === 'result-missing' || match === 'result-unreadable') {
+        this.logger.warn(
+          match === 'result-missing'
+            ? 'Block results missing entry for matched TX'
+            : 'Block results unreadable for matched TX',
+          { txHash, height: h },
+        )
         return null
       }
       return match

--- a/packages/pocket/src/verifyTransaction.test.ts
+++ b/packages/pocket/src/verifyTransaction.test.ts
@@ -180,7 +180,10 @@ describe('PocketBlockchain.verifyTransaction', () => {
     mockBlock.mockImplementation((h: number) =>
       Promise.resolve({ block: { txs: h === 1000 ? [txContent] : [] } }),
     )
-    mockBlockResults.mockRejectedValue(
+    // Once, not persistently: clearAllMocks() resets calls but NOT implementations,
+    // and this config sets neither resetMocks nor restoreMocks — a persistent
+    // rejection here would silently poison any confirmed-path test added below.
+    mockBlockResults.mockRejectedValueOnce(
       new Error('{"code":-32603,"message":"Internal error","data":"could not find results for height #1000"}'),
     )
 

--- a/packages/pocket/src/verifyTransaction.test.ts
+++ b/packages/pocket/src/verifyTransaction.test.ts
@@ -167,6 +167,29 @@ describe('PocketBlockchain.verifyTransaction', () => {
     expect(r.status).toBe('confirmed')
   })
 
+  // Commit-boundary race (mainnet, 2026-08-10): the hash matched inside the block
+  // — so the block store had the height — but blockResults for that SAME height
+  // threw "could not find results for height #N" because the node had not yet
+  // persisted its ABCI responses. The tx IS on-chain; we just cannot read its
+  // outcome yet, which is exactly `unavailable`. Before the fix this error escaped
+  // verifyTransaction, failed the activity, and wedged the sweep workflow.
+  it('unavailable when blockResults throws for a matched tx (commit-boundary race)', async () => {
+    mockGetTx.mockResolvedValue(null)
+    mockFetch.mockResolvedValue({ ok: false })
+    mockGetHeight.mockResolvedValue(1005)
+    mockBlock.mockImplementation((h: number) =>
+      Promise.resolve({ block: { txs: h === 1000 ? [txContent] : [] } }),
+    )
+    mockBlockResults.mockRejectedValue(
+      new Error('{"code":-32603,"message":"Internal error","data":"could not find results for height #1000"}'),
+    )
+
+    const bc = await createInstance('http://api.example.com')
+    const r = await bc.verifyTransaction(txHash, 1000, 30)
+
+    expect(r.status).toBe('unavailable')
+  })
+
   it('returns absent with coveredUpToHeight = startHeight - 1 when caught up to head', async () => {
     // getTx returns null (no direct hit)
     mockGetTx.mockResolvedValue(null)


### PR DESCRIPTION
# fix: stop transient RPC errors from wedging the tx verifier

## What happened on mainnet

On 2026-08-10 at 13:34:30 UTC the scheduled `VerifyPendingTransactions` run stopped making progress and stayed `Running` for three days. With `ScheduleOverlapPolicy: Skip`, every subsequent fire (one every 30s) was skipped — `SkippedOverlap` climbed to 9533 — so **no pending transaction was verified for three days**. Five stake transactions sat at `status = pending`, and the suppliers behind them never got their `nodes` row, so users saw their supplier as "pending" in the UI while it was staked and healthy on chain.

The chain of causation, taken from the workflow history:

```
5   ACTIVITY_TASK_SCHEDULED  listPendingWithHash  args=[]
7   ACTIVITY_TASK_COMPLETED  result=[{"id":387,"executionHeight":872892}]
11  ACTIVITY_TASK_SCHEDULED  verifyTxHash  args=['387']
13  ACTIVITY_TASK_FAILED     msg={"code":-32603,"message":"Internal error",
                                  "data":"could not find results for height #872893"}
16+ WORKFLOW_TASK_FAILED     "VerifyPendingTransactions: all transactions failed"  (forever)
```

1. Transaction 387 landed on chain in block 872893 (index 1772, `code 0` — successful).
2. The block scan matched the hash inside block 872893, then called `blockResults(872893)` on the same height. That call hit a node which had the block but had not yet persisted its ABCI responses, which CometBFT reports as `could not find results for height #N`. Per-node `cometbft_consensus_height` from Prometheus confirms all three backends were sitting exactly at 872893 at that moment — the failure landed on the block's commit boundary.
3. `blockResults` sat outside `verifyTransaction`'s `try/catch` (only `comet.block(h)` was wrapped), so the error escaped instead of degrading to the `unavailable` state the tri-state contract already defines for "the tx is on chain but we cannot read its outcome yet".
4. The activity's retry policy — 3 attempts at the default 1s base — exhausted in about 4 seconds, well inside a single ~60s block, so a condition tied to the chain's own cadence was reported as a permanent failure.
5. It was the only pending transaction, so `results.every(rejected)` held and the workflow threw `WorkflowError`.
6. **`WorkflowError` extends plain `Error`, not `TemporalFailure`.** The SDK fails the workflow only for `TemporalFailure` subclasses; anything else fails the workflow *task*, which then retries forever. The run stayed `Running`, and `Skip` did the rest.

Note that `WorkflowError` *is* exported from `@temporalio/workflow` and *does* construct — verified at runtime, `instanceof Error` true, `instanceof TemporalFailure` false. Two comments in `provider-workflows` claimed it was unexported and threw a `TypeError`; the conclusion they drew was right but the stated mechanism was wrong, and they are corrected here.

## What this PR changes

**`packages/pocket`** — `blockResults` is wrapped so a failed read of a matched tx's result row degrades to `result-missing` → `unavailable`, which makes the verifier retry rather than fail. Covered by a new regression test that reproduces the exact production error string.

**`middleman-workflows`** — all five `throw new WorkflowError(...)` sites become non-retryable `ApplicationFailure`, matching the pattern `provider-workflows` already used. A failed execution now ends the run, so the schedule's next fire proceeds normally.

**Retry policy for the verification sweep** (both apps) — from 3 attempts in ~4s to 5 attempts with a 5s base, 2x backoff, capped at 30s. That spans more than one block, so a commit-boundary hiccup resolves itself without any human involvement.

**`noWorkflowError.test.ts`** — a structural guard over both apps' workflow directories that fails if `new WorkflowError(` reappears. It greps source rather than exercising the runtime, because `@temporalio/testing` is not a dependency of this repo and adding it was out of scope here. Verified to go red by injecting the pattern.

## Verification

- `packages/pocket`: 7/7 (new commit-boundary test red before the fix, green after)
- `middleman-workflows`: 91/91 · `provider-workflows`: 33/33
- `turbo lint`, `turbo build`, `no-console-guard.sh`: pass

## Review follow-ups already folded in

- `blockResults` failing is now `result-unreadable`, kept apart from `result-missing`, because the old shared path logged "matched tx has no block result entry" for a read that never happened. Both still map to `unavailable`.
- The `ApplicationFailure` details payload is capped at 20 reasons in both apps. An oversized payload would fail the workflow task that reports the failure — the same wedge this PR removes.
- The new test's `blockResults` rejection is one-shot. `clearAllMocks()` resets calls but not implementations, and this jest config sets neither `resetMocks` nor `restoreMocks`, so a persistent rejection would have silently poisoned any confirmed-path test appended after it.

## Known gaps, deliberately not addressed here

- **The watchdog cannot see this failure mode.** `evaluateLiveness` returns `healthy` whenever `runningActions.length > 0` (`packages/temporal/src/scheduleWatchdog.ts:166`), so a schedule blocked by a wedged run reads green in the Workflows UI. This PR removes one cause, not the blind spot: a nondeterminism error after a workflow-code deploy, an unregistered activity name, or an oversized payload all reproduce the same silent stall, and the new grep-based guard catches none of them. The concrete proposal for a follow-up is to have `evaluateLiveness` treat a running action older than K × the schedule interval as `stale` instead of trusting its mere presence.
- **The sweep's worst-case wall clock roughly doubles and nothing bounds it.** Per activity it goes from ~363s (3 × 120s `startToCloseTimeout` + ~3s backoff) to ~665s (5 × 120s + 65s backoff), and `createOptions` sets no `workflowRunTimeout`. This is accepted here because the run now *ends* — under the old behaviour it never did — so starvation is bounded by the failure rather than unbounded. Two follow-ups worth doing: a run timeout on the sweep, and `nonRetryableErrorTypes` for the deterministic activity throws (`tx missing hash`, `tx not found`), which today burn all 5 attempts plus 65s of backoff on permanent conditions.
- **`ExecuteTransaction` has a false-failure path on the broadcast leg.** The `if (!result)` guard is unreachable — `sendTransaction` always returns an object, returning `{ transactionHash: '', success: false }` from its own catch — so a socket timeout on `broadcastTxSync` *after* the node accepted the tx into mempool takes the `!result.transactionHash` branch, marks the tx `Failure` and emails the user. Pre-existing and untouched here, but it is the same false-negative class this PR removes from the verification leg, and it is worth its own fix.
- `provider-workflows/src/activities/index.ts` has three pre-existing `rawLog` type errors (`TS2339`), present on `staging` before this branch and confirmed by re-running the check with this branch's provider changes stashed. `check-types` is `continue-on-error: true` in CI.
- `apps/middleman-workflows/src/lib/blockchain/index.ts` is dead code — nothing imports it — and carries its own copy of the same `blockResults` call. Left untouched; it should probably be deleted.
